### PR TITLE
Add POST /v1/chains/:chainId/transactions/:safeAddress/propose

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -19,6 +19,7 @@ import { Safe } from '../../domain/safe/entities/safe.entity';
 import { Transaction } from '../../domain/safe/entities/transaction.entity';
 import { Transfer } from '../../domain/safe/entities/transfer.entity';
 import { Token } from '../../domain/tokens/entities/token.entity';
+import { ProposeTransactionDto } from '../../domain/transactions/entities/propose-transaction.dto.entity';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { CacheRouter } from '../cache/cache.router';
 import { ICacheService } from '../cache/cache.service.interface';
@@ -577,6 +578,32 @@ export class TransactionApi implements ITransactionApi {
           limit: limit,
           offset: offset,
         },
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async postMultisigTransaction(
+    address: string,
+    proposeTransactionDto: ProposeTransactionDto,
+  ): Promise<unknown> {
+    try {
+      const url = `${this.baseUrl}/api/v1/safes/${address}/multisig-transactions/`;
+      return await this.networkService.post(url, {
+        to: proposeTransactionDto.to,
+        value: proposeTransactionDto.value,
+        data: proposeTransactionDto.data,
+        operation: proposeTransactionDto.operation,
+        baseGas: proposeTransactionDto.baseGas,
+        gasPrice: proposeTransactionDto.gasPrice,
+        gasToken: proposeTransactionDto.gasToken,
+        refundReceiver: proposeTransactionDto.refundReceiver,
+        nonce: proposeTransactionDto.nonce,
+        safeTxGas: proposeTransactionDto.safeTxGas,
+        contractTransactionHash: proposeTransactionDto.safeTxHash,
+        sender: proposeTransactionDto.sender,
+        signature: proposeTransactionDto.signature,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -18,6 +18,7 @@ import { Device } from '../notifications/entities/device.entity';
 import { GetEstimationDto } from '../estimations/entities/get-estimation.dto.entity';
 import { Estimation } from '../estimations/entities/estimation.entity';
 import { Message } from '../messages/entities/message.entity';
+import { ProposeTransactionDto } from '../transactions/entities/propose-transaction.dto.entity';
 
 export interface ITransactionApi {
   getBalances(
@@ -157,6 +158,11 @@ export interface ITransactionApi {
     limit?: number,
     offset?: number,
   ): Promise<Page<Message>>;
+
+  postMultisigTransaction(
+    address: string,
+    data: ProposeTransactionDto,
+  ): Promise<unknown>;
 
   postMessage(
     safeAddress: string,

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -6,6 +6,7 @@ import { Transaction } from './entities/transaction.entity';
 import { ModuleTransaction } from './entities/module-transaction.entity';
 import { SafeList } from './entities/safe-list.entity';
 import { CreationTransaction } from './entities/creation-transaction.entity';
+import { ProposeTransactionDto } from '../transactions/entities/propose-transaction.dto.entity';
 
 export const ISafeRepository = Symbol('ISafeRepository');
 
@@ -97,4 +98,10 @@ export interface ISafeRepository {
     chainId: string,
     safeAddress: string,
   ): Promise<MultisigTransaction | null>;
+
+  proposeTransaction(
+    chainId: string,
+    safeAddress: string,
+    proposeTransactionDto: ProposeTransactionDto,
+  ): Promise<unknown>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -357,6 +357,10 @@ export class SafeRepository implements ISafeRepository {
       CacheRouter.getModuleTransactionsCacheDir(chainId, safeAddress),
       CacheRouter.getTransfersCacheDir(chainId, safeAddress, false, false),
       CacheRouter.getIncomingTransfersCacheDir(chainId, safeAddress),
+      CacheRouter.getBalanceCacheDir(chainId, safeAddress),
+      CacheRouter.getSafeCacheDir(chainId, safeAddress),
+      CacheRouter.getCollectiblesCacheDir(chainId, safeAddress),
+      CacheRouter.getAllTransactionsCacheDir(chainId, safeAddress),
     ];
 
     for (const cacheDir of cacheDirs) {

--- a/src/domain/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/domain/transactions/entities/propose-transaction.dto.entity.ts
@@ -1,0 +1,18 @@
+import { Operation } from '../../safe/entities/operation.entity';
+
+export class ProposeTransactionDto {
+  to: string;
+  value: string;
+  data: string | null;
+  nonce: string;
+  operation: Operation;
+  safeTxGas: string;
+  baseGas: string;
+  gasPrice: string;
+  gasToken: string | null;
+  refundReceiver: string | null;
+  safeTxHash: string;
+  sender: string;
+  signature: string | null;
+  origin: string | null;
+}

--- a/src/domain/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/domain/transactions/entities/propose-transaction.dto.entity.ts
@@ -9,7 +9,7 @@ export class ProposeTransactionDto {
   safeTxGas: string;
   baseGas: string;
   gasPrice: string;
-  gasToken: string | null;
+  gasToken: string;
   refundReceiver: string | null;
   safeTxHash: string;
   sender: string;

--- a/src/routes/transactions/entities/__tests__/propose-transaction.dto.builder.ts
+++ b/src/routes/transactions/entities/__tests__/propose-transaction.dto.builder.ts
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker';
+import { Operation } from '../../../../domain/safe/entities/operation.entity';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { ProposeTransactionDto } from '../propose-transaction.dto.entity';
+
+export function proposeTransactionDtoBuilder(): IBuilder<ProposeTransactionDto> {
+  return Builder.new<ProposeTransactionDto>()
+    .with('to', faker.finance.ethereumAddress())
+    .with('value', faker.random.numeric())
+    .with('data', faker.datatype.hexadecimal(32))
+    .with('nonce', faker.random.numeric())
+    .with('operation', faker.helpers.arrayElement([0, 1]) as Operation)
+    .with('safeTxGas', faker.random.numeric())
+    .with('baseGas', faker.random.numeric())
+    .with('gasPrice', faker.random.numeric())
+    .with('gasToken', faker.datatype.hexadecimal(32))
+    .with('refundReceiver', faker.finance.ethereumAddress())
+    .with('safeTxHash', faker.datatype.hexadecimal(32))
+    .with('sender', faker.finance.ethereumAddress())
+    .with('signature', faker.datatype.hexadecimal(32))
+    .with('origin', faker.random.word());
+}

--- a/src/routes/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/propose-transaction.dto.entity.ts
@@ -1,0 +1,34 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Operation } from '../../../domain/safe/entities/operation.entity';
+import { ProposeTransactionDto as DomainProposeTransactionDto } from '../../../domain/transactions/entities/propose-transaction.dto.entity';
+
+export class ProposeTransactionDto implements DomainProposeTransactionDto {
+  @ApiProperty()
+  to: string;
+  @ApiProperty()
+  value: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  data: string | null;
+  @ApiProperty()
+  nonce: string;
+  @ApiProperty()
+  operation: Operation;
+  @ApiProperty()
+  safeTxGas: string;
+  @ApiProperty()
+  baseGas: string;
+  @ApiProperty()
+  gasPrice: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  gasToken: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  refundReceiver: string | null;
+  @ApiProperty()
+  safeTxHash: string;
+  @ApiProperty()
+  sender: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  signature: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  origin: string | null;
+}

--- a/src/routes/transactions/entities/propose-transaction.dto.entity.ts
+++ b/src/routes/transactions/entities/propose-transaction.dto.entity.ts
@@ -19,8 +19,8 @@ export class ProposeTransactionDto implements DomainProposeTransactionDto {
   baseGas: string;
   @ApiProperty()
   gasPrice: string;
-  @ApiPropertyOptional({ type: String, nullable: true })
-  gasToken: string | null;
+  @ApiProperty()
+  gasToken: string;
   @ApiPropertyOptional({ type: String, nullable: true })
   refundReceiver: string | null;
   @ApiProperty()

--- a/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
@@ -29,6 +29,7 @@ export const proposeTransactionDtoSchema: JSONSchemaType<ProposeTransactionDto> 
       'safeTxGas',
       'baseGas',
       'gasPrice',
+      'gasToken',
       'safeTxHash',
       'sender',
     ],

--- a/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
@@ -14,7 +14,7 @@ export const proposeTransactionDtoSchema: JSONSchemaType<ProposeTransactionDto> 
       safeTxGas: { type: 'string' },
       baseGas: { type: 'string' },
       gasPrice: { type: 'string' },
-      gasToken: { type: 'string', nullable: true },
+      gasToken: { type: 'string' },
       refundReceiver: { type: 'string', nullable: true },
       safeTxHash: { type: 'string' },
       sender: { type: 'string' },

--- a/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
@@ -1,0 +1,35 @@
+import { JSONSchemaType } from 'ajv';
+import { ProposeTransactionDto } from '../propose-transaction.dto.entity';
+
+export const proposeTransactionDtoSchema: JSONSchemaType<ProposeTransactionDto> =
+  {
+    $id: 'https://safe-client.safe.global/schemas/transactions/propose-transaction.dto.json',
+    type: 'object',
+    properties: {
+      to: { type: 'string' },
+      value: { type: 'string' },
+      data: { type: 'string', nullable: true },
+      nonce: { type: 'string' },
+      operation: { type: 'number', enum: [0, 1] },
+      safeTxGas: { type: 'string' },
+      baseGas: { type: 'string' },
+      gasPrice: { type: 'string' },
+      gasToken: { type: 'string', nullable: true },
+      refundReceiver: { type: 'string', nullable: true },
+      safeTxHash: { type: 'string' },
+      sender: { type: 'string' },
+      signature: { type: 'string', nullable: true },
+      origin: { type: 'string', nullable: true },
+    },
+    required: [
+      'to',
+      'value',
+      'nonce',
+      'operation',
+      'safeTxGas',
+      'baseGas',
+      'gasPrice',
+      'safeTxHash',
+      'sender',
+    ],
+  };

--- a/src/routes/transactions/pipes/propose-transaction.dto.validation.pipe.ts
+++ b/src/routes/transactions/pipes/propose-transaction.dto.validation.pipe.ts
@@ -1,0 +1,31 @@
+import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
+import { ValidateFunction } from 'ajv';
+import { GenericValidator } from '../../../validation/providers/generic.validator';
+import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
+import { ProposeTransactionDto } from '../entities/propose-transaction.dto.entity';
+import { proposeTransactionDtoSchema } from '../entities/schemas/propose-transaction.dto.schema';
+
+@Injectable()
+export class ProposeTransactionDtoValidationPipe
+  implements PipeTransform<any, ProposeTransactionDto>
+{
+  private readonly isValid: ValidateFunction<ProposeTransactionDto>;
+
+  constructor(
+    private readonly genericValidator: GenericValidator,
+    private readonly jsonSchemaService: JsonSchemaService,
+  ) {
+    this.isValid = this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/transactions/propose-transaction.dto.json',
+      proposeTransactionDtoSchema,
+    );
+  }
+  transform(data: any): ProposeTransactionDto {
+    try {
+      return this.genericValidator.validate(this.isValid, data);
+    } catch (err) {
+      err.status = HttpStatus.BAD_REQUEST;
+      throw err;
+    }
+  }
+}

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -26,7 +26,10 @@ import { QueuedItem } from './entities/queued-item.entity';
 import { TransactionItemPage } from './entities/transaction-item-page.entity';
 import { TransactionPreview } from './entities/transaction-preview.entity';
 import { PreviewTransactionDtoValidationPipe } from './pipes/preview-transaction.validation.pipe';
+import { ProposeTransactionDto } from './entities/propose-transaction.dto.entity';
+import { ProposeTransactionDtoValidationPipe } from './pipes/propose-transaction.dto.validation.pipe';
 import { TransactionsService } from './transactions.service';
+import { Transaction } from './entities/transaction.entity';
 
 @ApiTags('transactions')
 @Controller({
@@ -179,6 +182,22 @@ export class TransactionsController {
       safeAddress,
       paginationData,
       timezoneOffset,
+    );
+  }
+
+  @HttpCode(200)
+  @ApiOkResponse({ type: Transaction })
+  @Post('chains/:chainId/transactions/:safeAddress/propose')
+  async proposeTransaction(
+    @Param('chainId') chainId: string,
+    @Param('safeAddress') safeAddress: string,
+    @Body(ProposeTransactionDtoValidationPipe)
+    proposeTransactionDto: ProposeTransactionDto,
+  ): Promise<Transaction> {
+    return this.transactionsService.proposeTransaction(
+      chainId,
+      safeAddress,
+      proposeTransactionDto,
     );
   }
 }

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -22,8 +22,10 @@ import { ModuleTransactionMapper } from './mappers/module-transactions/module-tr
 import { MultisigTransactionMapper } from './mappers/multisig-transactions/multisig-transaction.mapper';
 import { QueuedItemsMapper } from './mappers/queued-items/queued-items.mapper';
 import { TransactionPreviewMapper } from './mappers/transaction-preview.mapper';
+import { ProposeTransactionDto } from './entities/propose-transaction.dto.entity';
 import { TransactionsHistoryMapper } from './mappers/transactions-history.mapper';
 import { IncomingTransferMapper } from './mappers/transfers/transfer.mapper';
+import { Transaction } from './entities/transaction.entity';
 
 @Injectable()
 export class TransactionsService {
@@ -287,6 +289,30 @@ export class TransactionsService {
       previous: previousURL?.toString() ?? null,
       results,
     };
+  }
+
+  async proposeTransaction(
+    chainId: string,
+    safeAddress: string,
+    proposeTransactionDto: ProposeTransactionDto,
+  ): Promise<Transaction> {
+    await this.safeRepository.proposeTransaction(
+      chainId,
+      safeAddress,
+      proposeTransactionDto,
+    );
+
+    const safe = await this.safeRepository.getSafe(chainId, safeAddress);
+    const domainTransaction = await this.safeRepository.getMultiSigTransaction(
+      chainId,
+      proposeTransactionDto.safeTxHash,
+    );
+
+    return this.multisigTransactionMapper.mapTransaction(
+      chainId,
+      domainTransaction,
+      safe,
+    );
   }
 
   /**


### PR DESCRIPTION
This PR implements the  `POST /v1/chains/:chainId/transactions/:safeAddress/propose` endpoint.
- Unit (controller) tests were added for the route.
- OpenAPI specification was added.
