### PR TITLE
Add contracts controller tests

### DIFF
--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -56,6 +56,10 @@ describe('Contracts controller', () => {
     await app.init();
   });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
   describe('GET contract data for an address', () => {
     it('Success', async () => {
       const chain = chainBuilder().build();

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -1,0 +1,140 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { TestAppProvider } from '../../app.provider';
+import {
+  fakeConfigurationService,
+  TestConfigurationModule,
+} from '../../config/__tests__/test.configuration.module';
+import {
+  fakeCacheService,
+  TestCacheModule,
+} from '../../datasources/cache/__tests__/test.cache.module';
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../../datasources/network/__tests__/test.network.module';
+import { DomainModule } from '../../domain.module';
+import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
+import { contractBuilder } from '../../domain/contracts/entities/__tests__/contract.builder';
+import { ValidationModule } from '../../validation/validation.module';
+import { ContractsModule } from './contracts.module';
+
+describe('Contracts controller', () => {
+  let app: INestApplication;
+
+  const safeConfigUrl = faker.internet.url();
+
+  beforeAll(async () => {
+    fakeConfigurationService.set('safeConfig.baseUri', safeConfigUrl);
+    fakeConfigurationService.set('exchange.baseUri', faker.internet.url());
+    fakeConfigurationService.set(
+      'exchange.apiKey',
+      faker.random.alphaNumeric(),
+    );
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        // feature
+        ContractsModule,
+        // common
+        DomainModule,
+        TestCacheModule,
+        TestConfigurationModule,
+        TestNetworkModule,
+        ValidationModule,
+      ],
+    }).compile();
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  describe('GET contract data for an address', () => {
+    it('Success', async () => {
+      const chain = chainBuilder().build();
+      const contract = contractBuilder().build();
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain });
+          case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
+            return Promise.resolve({ data: contract });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/contracts/${contract.address}`)
+        .expect(200)
+        .expect(contract);
+    });
+
+    it('Failure: Config API fails', async () => {
+      const chain = chainBuilder().build();
+      const contract = contractBuilder().build();
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.reject(new Error());
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/contracts/${contract.address}`)
+        .expect(503);
+    });
+
+    it('Failure: Transaction API fails', async () => {
+      const chain = chainBuilder().build();
+      const contract = contractBuilder().build();
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain });
+          case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
+            return Promise.reject(new Error());
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/contracts/${contract.address}`)
+        .expect(503);
+    });
+
+    it('should get a validation error', async () => {
+      const chain = chainBuilder().build();
+      const contract = contractBuilder().build();
+      mockNetworkService.get.mockImplementation((url) => {
+        switch (url) {
+          case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+            return Promise.resolve({ data: chain });
+          case `${chain.transactionService}/api/v1/contracts/${contract.address}`:
+            return Promise.resolve({ data: { ...contract, name: false } });
+          default:
+            return Promise.reject(`No matching rule for url: ${url}`);
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/contracts/${contract.address}`)
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds some tests for `ContractsController`. It covers the usual scenarios:
- A contract is successfully retrieved.
- Config Service fails.
- Transaction Service fails.
- Transaction Service returns a malformed item (validation error).