### PR TITLE
Refactor cache directions, implement pattern invalidations

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.spec.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import { range } from 'lodash';
 import { CacheDir } from '../entities/cache-dir.entity';
 import { FakeCacheService } from './fake.cache.service';
 
@@ -9,7 +10,7 @@ describe('FakeCacheService', () => {
     target = new FakeCacheService();
   });
 
-  it(`sets key`, async () => {
+  it('sets key', async () => {
     const cacheDir = new CacheDir(
       faker.random.alphaNumeric(),
       faker.random.alphaNumeric(),
@@ -22,21 +23,20 @@ describe('FakeCacheService', () => {
     expect(target.keyCount()).toBe(1);
   });
 
-  it(`deletes key`, async () => {
-    const cacheDir = new CacheDir(
-      faker.random.alphaNumeric(),
-      faker.random.alphaNumeric(),
-    );
+  it('deletes key', async () => {
+    const key = faker.random.alphaNumeric();
+    const field = faker.random.alphaNumeric();
+    const cacheDir = new CacheDir(key, field);
     const value = faker.random.alphaNumeric();
 
     await target.set(cacheDir, value, 0);
-    await target.delete(cacheDir);
+    await target.deleteByKey(key);
 
     await expect(target.get(cacheDir)).resolves.toBe(undefined);
     expect(target.keyCount()).toBe(0);
   });
 
-  it(`clears keys`, async () => {
+  it('clears keys', async () => {
     const actions: Promise<void>[] = [];
     for (let i = 0; i < 5; i++) {
       actions.push(
@@ -48,5 +48,49 @@ describe('FakeCacheService', () => {
     target.clear();
 
     expect(target.keyCount()).toBe(0);
+  });
+
+  it('deletes keys by pattern', async () => {
+    const prefix = faker.random.word();
+    // insert 5 items matching the pattern
+    await Promise.all(
+      range(5).map(() =>
+        target.set(new CacheDir(`${prefix}${faker.datatype.uuid()}`, ''), ''),
+      ),
+    );
+    // insert 4 items not matching the pattern
+    await Promise.all(
+      range(4).map(() =>
+        target.set(new CacheDir(`${faker.datatype.uuid()}`, ''), ''),
+      ),
+    );
+
+    await target.deleteByKeyPattern(`${prefix}*`);
+
+    expect(target.keyCount()).toBe(4);
+  });
+
+  it('deletes keys by pattern (2)', async () => {
+    const prefix = faker.random.word();
+    const suffix = faker.random.word();
+    // insert 5 items matching the pattern
+    await Promise.all(
+      range(5).map(() =>
+        target.set(
+          new CacheDir(`${prefix}_${faker.datatype.uuid()}_${suffix}`, ''),
+          '',
+        ),
+      ),
+    );
+    // insert 4 items not matching the pattern
+    await Promise.all(
+      range(4).map(() =>
+        target.set(new CacheDir(`${faker.datatype.uuid()}`, ''), ''),
+      ),
+    );
+
+    await target.deleteByKeyPattern(`${prefix}_*_${suffix}`);
+
+    expect(target.keyCount()).toBe(4);
   });
 });

--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -12,9 +12,19 @@ export class FakeCacheService implements ICacheService {
     this.cache = {};
   }
 
-  delete(cacheDir: CacheDir): Promise<number> {
-    delete this.cache[cacheDir.key];
+  deleteByKey(key: string): Promise<number> {
+    delete this.cache[key];
     return Promise.resolve(1);
+  }
+
+  deleteByKeyPattern(pattern: string): Promise<void> {
+    const patternRegex = RegExp(pattern.replace('*', '.*'));
+    for (const key in this.cache) {
+      if (patternRegex.test(key)) {
+        delete this.cache[key];
+      }
+    }
+    return Promise.resolve();
   }
 
   get(cacheDir: CacheDir): Promise<string | undefined> {

--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -24,6 +24,10 @@ export class CacheRouter {
   private static readonly TOKENS_KEY = 'tokens';
   private static readonly TRANSFERS_KEY = 'transfers';
 
+  static getBalancesCacheKey(chainId: string, safeAddress: string): string {
+    return `${chainId}_${CacheRouter.BALANCES_KEY}_${safeAddress}`;
+  }
+
   static getBalanceCacheDir(
     chainId: string,
     safeAddress: string,
@@ -31,14 +35,14 @@ export class CacheRouter {
     excludeSpam?: boolean,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.BALANCES_KEY}`,
+      CacheRouter.getBalancesCacheKey(chainId, safeAddress),
       `${trusted}_${excludeSpam}`,
     );
   }
 
   static getSafeCacheDir(chainId: string, safeAddress: string): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.SAFE_KEY}`,
+      `${chainId}_${CacheRouter.SAFE_KEY}_${safeAddress}`,
       '',
     );
   }
@@ -48,9 +52,13 @@ export class CacheRouter {
     contractAddress: string,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.CONTRACT_KEY}`,
-      contractAddress,
+      `${chainId}_${CacheRouter.CONTRACT_KEY}_${contractAddress}`,
+      '',
     );
+  }
+
+  static getContractsCachePattern(): string {
+    return `*_${CacheRouter.CONTRACT_KEY}_*`;
   }
 
   static getBackboneCacheDir(chainId: string): CacheDir {
@@ -70,7 +78,7 @@ export class CacheRouter {
     excludeSpam?: boolean,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.COLLECTIBLES_KEY}`,
+      `${chainId}_${CacheRouter.COLLECTIBLES_KEY}_${safeAddress}`,
       `${limit}_${offset}_${trusted}_${excludeSpam}`,
     );
   }
@@ -85,8 +93,8 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.DELEGATES_KEY}`,
-      `${safeAddress}_${delegate}_${delegator}_${label}_${limit}_${offset}`,
+      `${chainId}_${CacheRouter.DELEGATES_KEY}_${safeAddress}`,
+      `${delegate}_${delegator}_${label}_${limit}_${offset}`,
     );
   }
 
@@ -99,7 +107,7 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.TRANSFERS_KEY}`,
+      `${chainId}_${CacheRouter.TRANSFERS_KEY}_${safeAddress}`,
       `${onlyErc20}_${onlyErc721}_${limit}_${offset}`,
     );
   }
@@ -113,7 +121,7 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.MODULE_TRANSACTIONS_KEY}`,
+      `${chainId}_${CacheRouter.MODULE_TRANSACTIONS_KEY}_${safeAddress}`,
       `${to}_${module}_${limit}_${offset}`,
     );
   }
@@ -130,7 +138,7 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.INCOMING_TRANSFERS_KEY}`,
+      `${chainId}_${CacheRouter.INCOMING_TRANSFERS_KEY}_${safeAddress}`,
       `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`,
     );
   }
@@ -150,7 +158,7 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}`,
+      `${chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${safeAddress}`,
       `${ordering}_${executed}_${trusted}_${executionDateGte}_${executionDateLte}_${to}_${value}_${nonce}_${limit}_${offset}`,
     );
   }
@@ -160,7 +168,7 @@ export class CacheRouter {
     safeTransactionHash: string,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeTransactionHash}_${CacheRouter.MULTISIG_TRANSACTION_KEY}`,
+      `${chainId}_${CacheRouter.MULTISIG_TRANSACTION_KEY}_${safeTransactionHash}`,
       '',
     );
   }
@@ -170,7 +178,7 @@ export class CacheRouter {
     safeAddress: string,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.CREATION_TRANSACTION_KEY}`,
+      `${chainId}_${CacheRouter.CREATION_TRANSACTION_KEY}_${safeAddress}`,
       '',
     );
   }
@@ -185,13 +193,17 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.ALL_TRANSACTIONS_KEY}`,
+      `${chainId}_${CacheRouter.ALL_TRANSACTIONS_KEY}_${safeAddress}`,
       `${ordering}_${executed}_${queued}_${limit}_${offset}`,
     );
   }
 
   static getTokenCacheDir(chainId: string, address: string): CacheDir {
-    return new CacheDir(`${chainId}_${CacheRouter.TOKEN_KEY}`, address);
+    return new CacheDir(`${chainId}_${CacheRouter.TOKEN_KEY}_${address}`, '');
+  }
+
+  static getTokensCacheKey(chainId: string): string {
+    return `${chainId}_${CacheRouter.TOKENS_KEY}`;
   }
 
   static getTokensCacheDir(
@@ -200,9 +212,13 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.TOKENS_KEY}`,
+      CacheRouter.getTokensCacheKey(chainId),
       `${limit}_${offset}`,
     );
+  }
+
+  static getTokensCachePattern(chainId: string): string {
+    return `${chainId}_${CacheRouter.TOKEN_KEY}_*`;
   }
 
   static getSafesByOwnerCacheDir(
@@ -210,7 +226,7 @@ export class CacheRouter {
     ownerAddress: string,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${ownerAddress}_${CacheRouter.OWNERS_SAFE_KEY}`,
+      `${chainId}_${CacheRouter.OWNERS_SAFE_KEY}_${ownerAddress}`,
       '',
     );
   }
@@ -220,7 +236,7 @@ export class CacheRouter {
     messageHash: string,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${messageHash}_${CacheRouter.MESSAGE_KEY}`,
+      `${chainId}_${CacheRouter.MESSAGE_KEY}_${messageHash}`,
       '',
     );
   }
@@ -232,17 +248,25 @@ export class CacheRouter {
     offset?: number,
   ): CacheDir {
     return new CacheDir(
-      `${chainId}_${safeAddress}_${CacheRouter.MESSAGES_KEY}`,
+      `${chainId}_${CacheRouter.MESSAGES_KEY}_${safeAddress}`,
       `${limit}_${offset}`,
     );
   }
 
+  static getChainsCacheKey(): string {
+    return CacheRouter.CHAINS_KEY;
+  }
+
   static getChainsCacheDir(limit?: number, offset?: number): CacheDir {
-    return new CacheDir(CacheRouter.CHAINS_KEY, `${limit}_${offset}`);
+    return new CacheDir(CacheRouter.getChainsCacheKey(), `${limit}_${offset}`);
   }
 
   static getChainCacheDir(chainId: string): CacheDir {
     return new CacheDir(`${chainId}_${CacheRouter.CHAIN_KEY}`, '');
+  }
+
+  static getChainsCachePattern(): string {
+    return `*_${CacheRouter.CHAIN_KEY}$`;
   }
 
   static getSafeAppsCacheDir(
@@ -251,8 +275,8 @@ export class CacheRouter {
     url?: string,
   ): CacheDir {
     return new CacheDir(
-      CacheRouter.SAFE_APPS_KEY,
-      `${chainId}_${clientUrl}_${url}`,
+      `${chainId}_${CacheRouter.SAFE_APPS_KEY}`,
+      `${clientUrl}_${url}`,
     );
   }
 }

--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -11,5 +11,7 @@ export interface ICacheService {
 
   get(cacheDir: CacheDir): Promise<string | undefined>;
 
-  delete(cacheDir: CacheDir): Promise<number>;
+  deleteByKey(key: string): Promise<number>;
+
+  deleteByKeyPattern(pattern: string): Promise<void>;
 }

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -41,9 +41,15 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
     return await this.client.hGet(cacheDir.key, cacheDir.field);
   }
 
-  async delete(cacheDir: CacheDir): Promise<number> {
+  async deleteByKey(key: string): Promise<number> {
     // see https://redis.io/commands/unlink/
-    return await this.client.unlink(cacheDir.key);
+    return await this.client.unlink(key);
+  }
+
+  async deleteByKeyPattern(pattern: string): Promise<void> {
+    for await (const key of this.client.scanIterator({ MATCH: pattern })) {
+      await this.client.unlink(key);
+    }
   }
 
   /**

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -91,7 +91,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`safe_apps`, `${chainId}_undefined_undefined`),
+      new CacheDir(`${chainId}_safe_apps`, 'undefined_undefined'),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl: undefined, url: undefined } },
     );
@@ -109,7 +109,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`safe_apps`, `${chainId}_undefined_${url}`),
+      new CacheDir(`${chainId}_safe_apps`, `undefined_${url}`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl: undefined, url } },
     );
@@ -127,7 +127,7 @@ describe('ConfigApi', () => {
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
     expect(mockDataSource.get).toBeCalledWith(
-      new CacheDir(`safe_apps`, `${chainId}_${clientUrl}_undefined`),
+      new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl, url: undefined } },
     );

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -9,7 +9,6 @@ import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
 import { backboneBuilder } from '../../domain/backbone/entities/__tests__/backbone.builder';
 import { balanceBuilder } from '../../domain/balances/entities/__tests__/balance.builder';
 import { CacheDir } from '../cache/entities/cache-dir.entity';
-import { CacheRouter } from '../cache/cache.router';
 
 const dataSource = {
   get: jest.fn(),
@@ -17,7 +16,7 @@ const dataSource = {
 const mockDataSource = jest.mocked(dataSource);
 
 const cacheService = {
-  delete: jest.fn(),
+  deleteByKey: jest.fn(),
 } as unknown as ICacheService;
 const mockCacheService = jest.mocked(cacheService);
 
@@ -99,13 +98,13 @@ describe('TransactionApi', () => {
   describe('Clear Local Balances', () => {
     it('should call delete', async () => {
       const safeAddress = faker.finance.ethereumAddress();
-      mockCacheService.delete.mockResolvedValueOnce(1);
+      mockCacheService.deleteByKey.mockResolvedValueOnce(1);
 
       await service.clearLocalBalances(safeAddress);
 
-      expect(mockCacheService.delete).toBeCalledTimes(1);
-      expect(mockCacheService.delete).toBeCalledWith(
-        CacheRouter.getBalanceCacheDir(chainId, safeAddress),
+      expect(mockCacheService.deleteByKey).toBeCalledTimes(1);
+      expect(mockCacheService.deleteByKey).toBeCalledWith(
+        `${chainId}_balances_${safeAddress}`,
       );
       expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
     });
@@ -120,7 +119,7 @@ describe('TransactionApi', () => {
 
       expect(actual).toBe(safe);
       expect(mockDataSource.get).toBeCalledWith(
-        new CacheDir(`${chainId}_${safe.address}_safe`, ''),
+        new CacheDir(`${chainId}_safe_${safe.address}`, ''),
         `${baseUrl}/api/v1/safes/${safe.address}`,
       );
       expect(httpErrorFactory.from).toHaveBeenCalledTimes(0);

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -60,8 +60,8 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async clearLocalBalances(safeAddress: string): Promise<void> {
-    const cacheDir = CacheRouter.getBalanceCacheDir(this.chainId, safeAddress);
-    await this.cacheService.delete(cacheDir);
+    const cacheKey = CacheRouter.getBalancesCacheKey(this.chainId, safeAddress);
+    await this.cacheService.deleteByKey(cacheKey);
   }
 
   async getDataDecoded(data: string, to: string): Promise<DataDecoded> {

--- a/src/domain/flush/flush.repository.ts
+++ b/src/domain/flush/flush.repository.ts
@@ -32,34 +32,25 @@ export class FlushRepository implements IFlushRepository {
   }
 
   private async invalidateChains(): Promise<void> {
-    const chains = await this.configApi.getChains();
-    await this.cacheService.delete(CacheRouter.getChainsCacheDir());
-    await Promise.all(
-      chains.results.map((chain) =>
-        this.cacheService.delete(CacheRouter.getChainCacheDir(chain.chainId)),
-      ),
-    );
+    await this.cacheService.deleteByKey(CacheRouter.getChainsCacheKey());
+    const pattern = CacheRouter.getChainsCachePattern();
+    await this.cacheService.deleteByKeyPattern(pattern);
   }
 
   private async invalidateContracts(): Promise<void> {
-    const chains = await this.configApi.getChains();
-    await Promise.all(
-      chains.results.map((chain) =>
-        this.cacheService.delete(
-          CacheRouter.getContractCacheDir(chain.chainId, ''),
-        ),
-      ),
-    );
+    const pattern = CacheRouter.getContractsCachePattern();
+    await this.cacheService.deleteByKeyPattern(pattern);
   }
 
   private async invalidateTokens(
-    pattern: InvalidationPatternDto,
+    invalidationPatternDto: InvalidationPatternDto,
   ): Promise<void> {
-    const chainId = pattern?.patternDetails?.chainId;
+    const chainId = invalidationPatternDto?.patternDetails?.chainId;
     if (!chainId) {
       throw new UnprocessableEntityException(`Chain id parameter is required`);
     }
-    await this.cacheService.delete(CacheRouter.getTokensCacheDir(chainId));
-    await this.cacheService.delete(CacheRouter.getTokenCacheDir(chainId, ''));
+    await this.cacheService.deleteByKey(CacheRouter.getTokensCacheKey(chainId));
+    const pattern = CacheRouter.getTokensCachePattern(chainId);
+    await this.cacheService.deleteByKeyPattern(pattern);
   }
 }

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -177,7 +177,7 @@ describe('Post Hook Events (Unit)', () => {
       const safeAddress = faker.finance.ethereumAddress();
       const chainId = '1';
       const cacheDir = new CacheDir(
-        `${chainId}_${safeAddress}_balances`,
+        `${chainId}_balances_${safeAddress}`,
         faker.random.alpha(),
       );
       await fakeCacheService.set(cacheDir, faker.random.alpha());

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -46,8 +46,8 @@ describe('Get contract e2e test', () => {
       });
 
     const cacheContent = await redisClient.hGet(
-      `${chainId}_contract`,
-      contractAddress,
+      `${chainId}_contract_${contractAddress}`,
+      '',
     );
     expect(cacheContent).toEqual(JSON.stringify(expectedResponse));
   });

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -176,7 +176,7 @@ describe('Flush Controller (Unit)', () => {
         contracts.map(async (contract) =>
           expect(
             await fakeCacheService.get(
-              new CacheDir(`${chain.chainId}_contract`, contract.address),
+              new CacheDir(`${chain.chainId}_contract_${contract.address}`, ''),
             ),
           ).toBeDefined(),
         ),
@@ -199,7 +199,7 @@ describe('Flush Controller (Unit)', () => {
         contracts.map(async (contract) =>
           expect(
             await fakeCacheService.get(
-              new CacheDir(`${chain.chainId}_contract`, contract.address),
+              new CacheDir(`${chain.chainId}_contract_${contract.address}`, ''),
             ),
           ).toBeUndefined(),
         ),
@@ -262,7 +262,7 @@ describe('Flush Controller (Unit)', () => {
         tokens.map(async (token) =>
           expect(
             await fakeCacheService.get(
-              new CacheDir(`${chain.chainId}_token`, token.address),
+              new CacheDir(`${chain.chainId}_token_${token.address}`, ''),
             ),
           ).toBeDefined(),
         ),
@@ -290,7 +290,7 @@ describe('Flush Controller (Unit)', () => {
         tokens.map(async (token) =>
           expect(
             await fakeCacheService.get(
-              new CacheDir(`${chain.chainId}_token`, token.address),
+              new CacheDir(`${chain.chainId}_token_${token.address}`, ''),
             ),
           ).toBeUndefined(),
         ),
@@ -302,7 +302,7 @@ describe('Flush Controller (Unit)', () => {
       ).toBeDefined();
       expect(
         await fakeCacheService.get(
-          new CacheDir(`${chain.chainId}_${safe.address}_safe`, ''),
+          new CacheDir(`${chain.chainId}_safe_${safe.address}`, ''),
         ),
       ).toBeDefined();
     });

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('Get safes by owner e2e test', () => {
 
   it('GET /owners/<owner_address>/safes', async () => {
     const ownerAddress = '0xf10E2042ec19747401E5EA174EfB63A0058265E6';
-    const ownerCacheKey = `${chainId}_${ownerAddress}_owner_safes`;
+    const ownerCacheKey = `${chainId}_owner_safes_${ownerAddress}`;
 
     await request(app.getHttpServer())
       .get(`/chains/${chainId}/owners/${ownerAddress}/safes`)

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -26,8 +26,8 @@ describe('Get Safe Apps e2e test', () => {
   });
 
   it('GET /chains/<chainId>/safe-apps', async () => {
-    const safeAppsCacheKey = 'safe_apps';
-    const safeAppsCacheField = `${chainId}_undefined_undefined`;
+    const safeAppsCacheKey = `${chainId}_safe_apps`;
+    const safeAppsCacheField = 'undefined_undefined';
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safe-apps`)
@@ -54,9 +54,9 @@ describe('Get Safe Apps e2e test', () => {
   });
 
   it('GET /chains/<chainId>/safe-apps?url=${transactionBuilderUrl}', async () => {
-    const safeAppsCacheKey = 'safe_apps';
+    const safeAppsCacheKey = `${chainId}_safe_apps`;
     const transactionBuilderUrl = 'https://safe-apps.dev.5afe.dev/tx-builder';
-    const safeAppsCacheField = `${chainId}_undefined_${transactionBuilderUrl}`;
+    const safeAppsCacheField = `undefined_${transactionBuilderUrl}`;
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safe-apps/?url=${transactionBuilderUrl}`)

--- a/src/routes/transactions/__tests__/get-incoming-transfers.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-incoming-transfers.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('Get incoming transfers e2e test', () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const executionDateGte = '2022-10-20T00:00:00.000Z';
     const executionDateLte = '2022-11-03T00:00:00.000Z';
-    const cacheKey = `${chainId}_${safeAddress}_incoming_transfers`;
+    const cacheKey = `${chainId}_incoming_transfers_${safeAddress}`;
     const cacheKeyField = `${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expected = getJsonResource('e2e/erc20-expected-response.json');
 
@@ -51,7 +51,7 @@ describe('Get incoming transfers e2e test', () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const executionDateGte = '2022-08-01T00:00:00.000Z';
     const executionDateLte = '2022-08-04T12:50:00.000Z';
-    const cacheKey = `${chainId}_${safeAddress}_incoming_transfers`;
+    const cacheKey = `${chainId}_incoming_transfers_${safeAddress}`;
     const cacheKeyField = `${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expected = getJsonResource('e2e/erc721-expected-response.json');
 

--- a/src/routes/transactions/__tests__/get-module-transactions.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-module-transactions.e2e-spec.ts
@@ -28,7 +28,7 @@ describe('Get module transactions e2e test', () => {
 
   it('GET /safes/<address>/module-transactions (native token)', async () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
-    const cacheKey = `${chainId}_${safeAddress}_module_transactions`;
+    const cacheKey = `${chainId}_module_transactions_${safeAddress}`;
     const cacheKeyField = `undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/module-transactions/native-token-expected-response.json',

--- a/src/routes/transactions/__tests__/get-multisig-transactions.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-multisig-transactions.e2e-spec.ts
@@ -30,7 +30,7 @@ describe('Get multisig transactions e2e test', () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const executionDateGte = '2022-11-04T00:00:00.000Z';
     const executionDateLte = '2022-11-08T00:00:00.000Z';
-    const cacheKey = `${chainId}_${safeAddress}_multisig_transactions`;
+    const cacheKey = `${chainId}_multisig_transactions_${safeAddress}`;
     const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/native-token-expected-response.json',
@@ -53,7 +53,7 @@ describe('Get multisig transactions e2e test', () => {
     const safeAddress = '0xCe95F1F4ACADEe697993B0E3a0FE48B444679046';
     const executionDateGte = '2022-12-01T00:00:00.000Z';
     const executionDateLte = '2022-12-07T11:00:00.000Z';
-    const cacheKey = `${chainId}_${safeAddress}_multisig_transactions`;
+    const cacheKey = `${chainId}_multisig_transactions_${safeAddress}`;
     const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/erc20-expected-response.json',
@@ -76,7 +76,7 @@ describe('Get multisig transactions e2e test', () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const executionDateGte = '2022-11-29T14:00:00.000Z';
     const executionDateLte = '2022-12-06T00:00:00.000Z';
-    const cacheKey = `${chainId}_${safeAddress}_multisig_transactions`;
+    const cacheKey = `${chainId}_multisig_transactions_${safeAddress}`;
     const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/erc721-expected-response.json',


### PR DESCRIPTION
Closes #297 

This PR:
- Changes the cache data storage directions format. This PR unifies the _key_ format to `$chainId_$feature_$additional-identifier(s)`.
- Derived from the previous point, `SCAN` can be used to delete _by feature_ (for example, to delete all the transactions/contracts/tokens/etc. belonging to one/all chains) without the need of knowing the configured chains beforehand.