### PR TITLE
Validate mandatory environment at startup

### DIFF
--- a/src/config/configuration.module.ts
+++ b/src/config/configuration.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { IConfigurationService } from './configuration.service.interface';
 import { NestConfigurationService } from './nest.configuration.service';
 import configuration from './entities/configuration';
+import { validate } from './configuration.validator';
 
 /**
  * A {@link Global} Module which provides local configuration support via {@link IConfigurationService}
@@ -15,6 +16,7 @@ import configuration from './entities/configuration';
 @Module({
   imports: [
     ConfigModule.forRoot({
+      validate,
       load: [configuration],
     }),
   ],

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -1,0 +1,33 @@
+import { faker } from '@faker-js/faker';
+import { validate } from './configuration.validator';
+
+describe('Configuration validator', () => {
+  const { NODE_ENV } = process.env;
+
+  afterAll(() => {
+    process.env.NODE_ENV = NODE_ENV;
+  });
+
+  it('should bypass this validation on tests', () => {
+    process.env.NODE_ENV = 'test';
+    const expected = JSON.parse(faker.datatype.json());
+    const validated = validate(expected);
+    expect(validated).toBe(expected);
+  });
+
+  it('should detect a malformed configuration in production environment', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() => validate(JSON.parse(faker.datatype.json()))).toThrow();
+  });
+
+  it('should return the input configuration if validated in production environment', () => {
+    process.env.NODE_ENV = 'production';
+    const expected = {
+      ...JSON.parse(faker.datatype.json()),
+      AUTH_TOKEN: 'foo',
+      EXCHANGE_API_KEY: 'bar',
+    };
+    const validated = validate(expected);
+    expect(validated).toBe(expected);
+  });
+});

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -2,12 +2,6 @@ import { faker } from '@faker-js/faker';
 import { validate } from './configuration.validator';
 
 describe('Configuration validator', () => {
-  const { NODE_ENV } = process.env;
-
-  afterAll(() => {
-    process.env.NODE_ENV = NODE_ENV;
-  });
-
   it('should bypass this validation on tests', () => {
     process.env.NODE_ENV = 'test';
     const expected = JSON.parse(faker.datatype.json());
@@ -17,15 +11,17 @@ describe('Configuration validator', () => {
 
   it('should detect a malformed configuration in production environment', () => {
     process.env.NODE_ENV = 'production';
-    expect(() => validate(JSON.parse(faker.datatype.json()))).toThrow();
+    expect(() => validate(JSON.parse(faker.datatype.json()))).toThrow(
+      /Mandatory configuration is missing: .*AUTH_TOKEN.*EXCHANGE_API_KEY/,
+    );
   });
 
   it('should return the input configuration if validated in production environment', () => {
     process.env.NODE_ENV = 'production';
     const expected = {
       ...JSON.parse(faker.datatype.json()),
-      AUTH_TOKEN: 'foo',
-      EXCHANGE_API_KEY: 'bar',
+      AUTH_TOKEN: faker.datatype.uuid(),
+      EXCHANGE_API_KEY: faker.datatype.uuid(),
     };
     const validated = validate(expected);
     expect(validated).toBe(expected);

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -1,0 +1,23 @@
+import Ajv, { Schema } from 'ajv';
+
+const configurationSchema: Schema = {
+  type: 'object',
+  properties: {
+    AUTH_TOKEN: { type: 'string' },
+    EXCHANGE_API_KEY: { type: 'string' },
+  },
+  required: ['AUTH_TOKEN', 'EXCHANGE_API_KEY'],
+};
+
+export function validate(
+  configuration: Record<string, unknown>,
+): Record<string, unknown> {
+  if (process.env.NODE_ENV !== 'test') {
+    const ajv = new Ajv({ allErrors: true });
+    if (!ajv.validate(configurationSchema, configuration)) {
+      const errors = ajv.errors?.reduce((acc, e) => [...acc, e.message], []);
+      throw Error(`Mandatory configuration is missing: ${errors?.join(', ')}`);
+    }
+  }
+  return configuration;
+}

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -15,8 +15,8 @@ export function validate(
   if (process.env.NODE_ENV !== 'test') {
     const ajv = new Ajv({ allErrors: true });
     if (!ajv.validate(configurationSchema, configuration)) {
-      const errors = ajv.errors?.reduce((acc, e) => [...acc, e.message], []);
-      throw Error(`Mandatory configuration is missing: ${errors?.join(', ')}`);
+      const errors = ajv.errors?.map((error) => error.message)?.join(', ');
+      throw Error(`Mandatory configuration is missing: ${errors}`);
     }
   }
   return configuration;


### PR DESCRIPTION
This PR aims to check the required environment is present at the service startup time, preventing the application from unexpected failures at runtime.

The official Nest.js documentation talks about this use case [here](https://docs.nestjs.com/techniques/configuration#schema-validation). The approach taken was heavily inspired by this documentation but AJV was used (which is already a service dependency) instead of Joi for configuration validation.