### PR TITLE
Add ids into domain models and schemas

### DIFF
--- a/src/domain/safe/entities/__tests__/erc20-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/erc20-transfer.builder.ts
@@ -10,7 +10,8 @@ export function erc20TransferBuilder(): IBuilder<ERC20Transfer> {
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.datatype.hexadecimal())
     .with('tokenAddress', faker.finance.ethereumAddress())
-    .with('value', faker.datatype.hexadecimal());
+    .with('value', faker.datatype.hexadecimal())
+    .with('transferId', faker.datatype.string());
 }
 
 export function toJson(erc20Transfer: ERC20Transfer): unknown {

--- a/src/domain/safe/entities/__tests__/erc721-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/erc721-transfer.builder.ts
@@ -10,7 +10,8 @@ export function erc721TransferBuilder(): IBuilder<ERC721Transfer> {
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.datatype.hexadecimal())
     .with('tokenAddress', faker.finance.ethereumAddress())
-    .with('tokenId', faker.datatype.string());
+    .with('tokenId', faker.datatype.string())
+    .with('transferId', faker.datatype.string());
 }
 
 export function toJson(erc721Transfer: ERC721Transfer): unknown {

--- a/src/domain/safe/entities/__tests__/module-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/module-transaction.builder.ts
@@ -16,7 +16,8 @@ export function moduleTransactionBuilder(): IBuilder<ModuleTransaction> {
     .with('safe', faker.finance.ethereumAddress())
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.datatype.hexadecimal())
-    .with('value', faker.datatype.hexadecimal());
+    .with('value', faker.datatype.hexadecimal())
+    .with('moduleTransactionId', faker.datatype.string());
 }
 
 export function toJson(moduleTransaction: ModuleTransaction): unknown {

--- a/src/domain/safe/entities/__tests__/native-token-transfer.builder.ts
+++ b/src/domain/safe/entities/__tests__/native-token-transfer.builder.ts
@@ -9,7 +9,8 @@ export function nativeTokenTransferBuilder(): IBuilder<NativeTokenTransfer> {
     .with('from', faker.finance.ethereumAddress())
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.datatype.hexadecimal())
-    .with('value', faker.datatype.hexadecimal());
+    .with('value', faker.datatype.hexadecimal())
+    .with('transferId', faker.datatype.string());
 }
 
 export function toJson(nativeTokenTransfer: NativeTokenTransfer): unknown {

--- a/src/domain/safe/entities/module-transaction.entity.ts
+++ b/src/domain/safe/entities/module-transaction.entity.ts
@@ -9,6 +9,7 @@ export interface ModuleTransaction {
   executionDate: Date;
   isSuccessful: boolean;
   module: string;
+  moduleTransactionId: string;
   operation: Operation;
   safe: string;
   to: string;

--- a/src/domain/safe/entities/schemas/erc20-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/erc20-transfer.schema.ts
@@ -15,6 +15,7 @@ export const erc20TransferSchema: Schema = {
     from: { type: 'string' },
     value: { type: 'string' },
     tokenAddress: { type: 'string', nullable: true, default: null },
+    transferId: { type: 'string' },
   },
   required: [
     'type',
@@ -24,5 +25,6 @@ export const erc20TransferSchema: Schema = {
     'to',
     'from',
     'value',
+    'transferId',
   ],
 };

--- a/src/domain/safe/entities/schemas/erc721-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/erc721-transfer.schema.ts
@@ -15,6 +15,7 @@ export const erc721TransferSchema: Schema = {
     from: { type: 'string' },
     tokenId: { type: 'string' },
     tokenAddress: { type: 'string', nullable: true, default: null },
+    transferId: { type: 'string' },
   },
   required: [
     'type',
@@ -24,5 +25,6 @@ export const erc721TransferSchema: Schema = {
     'to',
     'from',
     'tokenId',
+    'transferId',
   ],
 };

--- a/src/domain/safe/entities/schemas/module-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/module-transaction.schema.ts
@@ -23,6 +23,7 @@ export const moduleTransactionSchema: Schema = {
     isSuccessful: { type: 'boolean' },
     transactionHash: { type: 'string' },
     module: { type: 'string' },
+    moduleTransactionId: { type: 'string' },
   },
   required: [
     'safe',
@@ -34,5 +35,6 @@ export const moduleTransactionSchema: Schema = {
     'isSuccessful',
     'transactionHash',
     'module',
+    'moduleTransactionId',
   ],
 };

--- a/src/domain/safe/entities/schemas/native-token-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/native-token-transfer.schema.ts
@@ -11,6 +11,7 @@ export const nativeTokenTransferSchema: Schema = {
     to: { type: 'string' },
     from: { type: 'string' },
     value: { type: 'string' },
+    transferId: { type: 'string' },
   },
   required: [
     'type',
@@ -20,5 +21,6 @@ export const nativeTokenTransferSchema: Schema = {
     'to',
     'from',
     'value',
+    'transferId',
   ],
 };

--- a/src/domain/safe/entities/transfer.entity.ts
+++ b/src/domain/safe/entities/transfer.entity.ts
@@ -4,6 +4,7 @@ export interface Transfer {
   from: string;
   to: string;
   transactionHash: string;
+  transferId: string;
 }
 
 export interface ERC20Transfer extends Transfer {

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/erc20/transfer-source-data.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/erc20/transfer-source-data.json
@@ -20,7 +20,8 @@
         "decimals": 18,
         "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0xdc31Ee1784292379Fbb2964b3B9C4124D8F89C60.png"
       },
-      "from": "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C"
+      "from": "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C",
+      "transferId": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167"
     }
   ]
 }

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/erc721/transfer-source-data.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/erc721/transfer-source-data.json
@@ -20,7 +20,8 @@
         "decimals": null,
         "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/ENS.png"
       },
-      "from": "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5"
+      "from": "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5",
+      "transferId": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167"
     }
   ]
 }

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/native-coin/transfer-source-data.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/native-coin/transfer-source-data.json
@@ -13,7 +13,8 @@
       "tokenId": null,
       "tokenAddress": null,
       "tokenInfo": null,
-      "from": "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5"
+      "from": "0x283Af0B28c62C092C9727F1Ee09c02CA627EB7F5",
+      "transferId": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167"
     }
   ]
 }


### PR DESCRIPTION
Related to https://github.com/safe-global/safe-transaction-service/pull/1365

This PR adds the new fields (`transferId`, `moduleTransactionId`) for Transfers and Module Transactions into the associated entities, validation schemas, and test instance builders.