### PR TITLE
Change transaction id mappings

### DIFF
--- a/src/domain/safe/entities/schemas/module-transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/module-transaction-type.schema.ts
@@ -24,6 +24,7 @@ export const moduleTransactionTypeSchema: Schema = {
     isSuccessful: { type: 'boolean' },
     transactionHash: { type: 'string' },
     module: { type: 'string' },
+    moduleTransactionId: { type: 'string' },
   },
   required: [
     'safe',
@@ -35,5 +36,6 @@ export const moduleTransactionTypeSchema: Schema = {
     'isSuccessful',
     'transactionHash',
     'module',
+    'moduleTransactionId',
   ],
 };

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc20-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc20-expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700",
+        "id": "i276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a27000,0,0",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -34,7 +34,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700",
+        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700181",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -68,7 +68,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700",
+        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700182",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -102,7 +102,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700",
+        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700183",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -136,7 +136,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700",
+        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700184",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -170,7 +170,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0xb16cbf2479d8bd20485bbb8683480d38be244cb9fbc047bd68b1fd4752630409",
+        "id": "eb16cbf2479d8bd20485bbb8683480d38be244cb9fbc047bd68b1fd475263040986",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667373708000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc721-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc721-expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b",
+        "id": "i5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b0,0,10",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,
@@ -34,7 +34,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b",
+        "id": "e5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b25",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/erc20/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/erc20/expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x454bd2bb4496ac9c716b59118477ce79508ed1de2b9dced8023d8a6ce3eff470",
+        "id": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667811828000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/erc721/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/erc721/expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b",
+        "id": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/native-coin/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/native-coin/expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "ethereum_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b",
+        "id": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,

--- a/src/routes/transactions/__tests__/resources/module-transactions/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/module-transactions/expected-response.json
@@ -5,7 +5,7 @@
       {
         "type": "TRANSACTION",
         "transaction": {
-          "id": "module_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0xf4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b44",
+          "id": "i5a6754140f0432d3b5e6d8341597ec3c5338239f8d311de9061fbc959f443d590",
           "safeAppInfo": null,
           "timestamp": 1671023952000,
           "txStatus": "SUCCESS",

--- a/src/routes/transactions/__tests__/resources/module-transactions/module-transaction-domain.json
+++ b/src/routes/transactions/__tests__/resources/module-transactions/module-transaction-domain.json
@@ -1,14 +1,15 @@
 {
-    "created": "2022-12-14T13:19:12Z",
-    "executionDate": "2022-12-14T13:19:12Z",
-    "blockNumber": 8133661,
-    "isSuccessful": true,
-    "transactionHash": "0xf4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b44",
-    "safe": "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C",
-    "module": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
-    "to": "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C",
-    "value": "39900000000000000",
-    "data": null,
-    "operation": 0,
-    "dataDecoded": null
+  "created": "2022-12-14T13:19:12Z",
+  "executionDate": "2022-12-14T13:19:12Z",
+  "blockNumber": 8133661,
+  "isSuccessful": true,
+  "transactionHash": "0xf4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b44",
+  "safe": "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C",
+  "module": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+  "to": "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C",
+  "value": "39900000000000000",
+  "data": null,
+  "operation": 0,
+  "dataDecoded": null,
+  "moduleTransactionId": "i5a6754140f0432d3b5e6d8341597ec3c5338239f8d311de9061fbc959f443d590"
 }

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/module-transactions/native-token-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/module-transactions/native-token-expected-response.json
@@ -5,7 +5,7 @@
         {
           "type": "TRANSACTION",
           "transaction": {
-            "id": "module_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0xf4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b44",
+            "id": "if4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b440,0",
             "timestamp": 1671023952000,
             "txStatus": "SUCCESS",
             "txInfo": {

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -30,7 +30,7 @@ export class ModuleTransactionMapper {
       await this.addressInfoHelper.getOrDefault(chainId, transaction.module),
     );
     return new Transaction(
-      `module_${transaction.safe}_${transaction.transactionHash}`,
+      transaction.moduleTransactionId,
       transaction.executionDate.getTime(),
       txStatus,
       txInfo,

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.ts
@@ -15,8 +15,7 @@ export class IncomingTransferMapper {
     safe: Safe,
   ): Promise<Transaction> {
     return new Transaction(
-      // TODO: include ID from source (https://github.com/safe-global/safe-transaction-service/issues/1230)
-      `ethereum_${safe.address}_${transfer.transactionHash}`,
+      transfer.transferId,
       transfer.executionDate.getTime(),
       TransactionStatus.Success,
       await this.transferInfoMapper.mapTransferInfo(chainId, transfer, safe),


### PR DESCRIPTION
This PR applies the domain changes introduced by https://github.com/safe-global/safe-client-gateway-nest/pull/312 into the route-level mappings. So instead of composing transfers and module transactions ids by a custom logic (merging stringified parts of the objects) into the Client Gateway, the unique ids coming from the Transaction Service are sent to the clients.

For module transactions:
```
`module_${transaction.safe}_${transaction.transactionHash}` -> moduleTransactionId
```
For transfers:
```
`ethereum_${safe.address}_${transfer.transactionHash}` -> transferId
```
