### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @5afe/safe-client-gateway-nest-maintainers
+* @safe-global/safe-client-gateway-maintainers


### PR DESCRIPTION
- Sets `@safe-global/safe-client-gateway-maintainers` instead of `@5afe/safe-client-gateway-nest-maintainers` as the main codeowners of this project
- `@5afe/safe-client-gateway-nest-maintainers` does not exist in the `safe-global` org and its equivalent is `@safe-global/safe-client-gateway-maintainers`