### PR TITLE
Add header support to NetworkRequest

### DIFF
--- a/src/datasources/cache/cache.first.data.source.ts
+++ b/src/datasources/cache/cache.first.data.source.ts
@@ -40,13 +40,13 @@ export class CacheFirstDataSource {
    *
    * @param cacheDir - {@link CacheDir} containing the key and field to be used to retrieve from cache
    * @param url - the HTTP endpoint to retrieve the JSON payload
-   * @param params - the parameters to be used for the HTTP request
+   * @param networkRequest - the HTTP request to be used if there is a cache miss
    * @param expireTimeSeconds - the time to live in seconds for the payload behind {@link CacheDir}
    */
   async get<T>(
     cacheDir: CacheDir,
     url: string,
-    params?: NetworkRequest,
+    networkRequest?: NetworkRequest,
     expireTimeSeconds?: number,
   ): Promise<T> {
     const cached = await this.cacheService.get(cacheDir);
@@ -68,7 +68,7 @@ export class CacheFirstDataSource {
         key: cacheDir.key,
         field: cacheDir.field,
       });
-      const { data } = await this.networkService.get(url, params);
+      const { data } = await this.networkService.get(url, networkRequest);
       const rawJson = JSON.stringify(data);
       await this.cacheService.set(cacheDir, rawJson, expireTimeSeconds);
       return data;

--- a/src/datasources/network/entities/network.request.entity.ts
+++ b/src/datasources/network/entities/network.request.entity.ts
@@ -1,3 +1,4 @@
 export interface NetworkRequest {
+  headers?: Record<string, string | number | boolean>;
   params?: any;
 }

--- a/src/datasources/network/network.service.interface.ts
+++ b/src/datasources/network/network.service.interface.ts
@@ -6,13 +6,13 @@ export const NetworkService = Symbol('INetworkService');
 export interface INetworkService {
   get<T = any, R = NetworkResponse<T>>(
     url: string,
-    config?: NetworkRequest,
+    networkRequest?: NetworkRequest,
   ): Promise<R>;
 
   post<T = any, R = NetworkResponse<T>>(
     url: string,
     data: object,
-    config?: NetworkRequest,
+    networkRequest?: NetworkRequest,
   ): Promise<R>;
 
   delete<T = any, R = NetworkResponse<T>>(


### PR DESCRIPTION
- Adds header support to `NetworkRequest`. Headers are a record of a `string` to `string | number | boolean` which matches Axios interface
- Renamed the parameter `config` in `INetworkService` to `networkRequest` as it is more representative of what is expected by the function