### PR TITLE
Update ExchangeApi endpoints

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -10,7 +10,8 @@ export default () => ({
   },
   exchange: {
     baseUri:
-      process.env.EXCHANGE_API_BASE_URI || 'http://api.exchangeratesapi.io/v1',
+      process.env.EXCHANGE_API_BASE_URI ||
+      'https://api.apilayer.com/exchangerates_data',
     apiKey: process.env.EXCHANGE_API_KEY,
     cacheTtlSeconds: process.env.EXCHANGE_API_CACHE_TTL_SECONDS,
   },

--- a/src/datasources/exchange-api/exchange-api.service.spec.ts
+++ b/src/datasources/exchange-api/exchange-api.service.spec.ts
@@ -109,7 +109,7 @@ describe('ExchangeApi', () => {
     expect(mockCacheFirstDataSource.get).toBeCalledWith(
       new CacheDir('exchange_rates', ''),
       `${exchangeBaseUri}/latest`,
-      { params: { access_key: exchangeApiKey } },
+      { headers: { apikey: exchangeApiKey } },
       60 * 60 * 12, // 12h in seconds
     );
   });
@@ -134,7 +134,7 @@ describe('ExchangeApi', () => {
     expect(mockCacheFirstDataSource.get).toBeCalledWith(
       new CacheDir('exchange_rates', ''),
       `${exchangeBaseUri}/latest`,
-      { params: { access_key: exchangeApiKey } },
+      { headers: { apikey: exchangeApiKey } },
       ttl, // 60 seconds
     );
   });

--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -51,7 +51,7 @@ export class ExchangeApi implements IExchangeApi {
         CacheRouter.getExchangeRatesCacheDir(),
         `${this.baseUrl}/latest`,
         {
-          params: { access_key: this.apiKey },
+          headers: { apikey: this.apiKey },
         },
         this.cacheTtlSeconds,
       );


### PR DESCRIPTION
- The API provided by `exchangeratesapi.io` changed:
  * The API key is no longer a query parameter – it should be provided as a header instead
  * The base url changed – the new one is `https://api.apilayer.com/exchangerates_data` *