### PR TITLE
Fix Multisig Transaction cache direction

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -391,7 +391,7 @@ export class TransactionApi implements ITransactionApi {
     safeTransactionHash: string,
   ): Promise<MultisigTransaction> {
     try {
-      const cacheDir = CacheRouter.getMultisigTransactionsCacheDir(
+      const cacheDir = CacheRouter.getMultisigTransactionCacheDir(
         this.chainId,
         safeTransactionHash,
       );


### PR DESCRIPTION
This PR fixes a bug which was found while working in the transaction creation endpoint:

- `TransactionApi.getMultisigTransaction` was using `CacheRouter.getMultisigTransactionsCacheDir` instead of`CacheRouter.getMultisigTransactionCacheDir`.

The compiler allowed this because the input parameters types matched, but the inner logic to compose the key is different between functions. This Transaction API function and cache direction weren't used until now so the bug wasn't detected.