### PR TITLE
Fix Token property name in balances endpoint

### DIFF
--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -97,7 +97,7 @@ describe('Balances Controller (Unit)', () => {
           items: [
             {
               tokenInfo: {
-                tokenType: 'ERC20',
+                type: 'ERC20',
                 address: expectedBalance.tokenAddress,
                 decimals: expectedBalance.token?.decimals,
                 symbol: expectedBalance.token?.symbol,

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -79,7 +79,7 @@ export class BalancesService {
 
     return <Balance>{
       tokenInfo: <Token>{
-        tokenType: tokenType,
+        type: tokenType,
         address: txBalance.tokenAddress,
         decimals: txBalance.token?.decimals,
         symbol: txBalance.token?.symbol,

--- a/src/routes/balances/entities/token.entity.ts
+++ b/src/routes/balances/entities/token.entity.ts
@@ -13,5 +13,5 @@ export class Token {
   @ApiProperty()
   symbol: string;
   @ApiProperty({ enum: Object.values(TokenType) })
-  tokenType: TokenType;
+  type: TokenType;
 }


### PR DESCRIPTION
Closes #311

The property `tokenType` in `Token` (mapped in the balances route) should be named `type` instead to match the current API