### PR TITLE
Set headers when requesting Fiat Codes

### DIFF
--- a/src/datasources/exchange-api/exchange-api.service.spec.ts
+++ b/src/datasources/exchange-api/exchange-api.service.spec.ts
@@ -60,7 +60,7 @@ describe('ExchangeApi', () => {
     expect(mockCacheFirstDataSource.get).toBeCalledWith(
       new CacheDir('exchange_fiat_codes', ''),
       `${exchangeBaseUri}/symbols`,
-      { params: { access_key: exchangeApiKey } },
+      { headers: { apikey: exchangeApiKey } },
       60 * 60 * 12, // 12h in seconds
     );
   });
@@ -85,7 +85,7 @@ describe('ExchangeApi', () => {
     expect(mockCacheFirstDataSource.get).toBeCalledWith(
       new CacheDir('exchange_fiat_codes', ''),
       `${exchangeBaseUri}/symbols`,
-      { params: { access_key: exchangeApiKey } },
+      { headers: { apikey: exchangeApiKey } },
       ttl, // 60 seconds
     );
   });

--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -36,7 +36,7 @@ export class ExchangeApi implements IExchangeApi {
         CacheRouter.getExchangeFiatCodesCacheDir(),
         `${this.baseUrl}/symbols`,
         {
-          params: { access_key: this.apiKey },
+          headers: { apikey: this.apiKey },
         },
         this.cacheTtlSeconds,
       );


### PR DESCRIPTION
`ExchangeApi.getFiatCodes` was incorrectly using query parameters to set the API key (to match the requirements of the older API version).