### PR TITLE
Fix native token mapping

### DIFF
--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -63,7 +63,7 @@ describe('Balances Controller (Unit)', () => {
     await app.close();
   });
 
-  describe('Maps ERC20 token correctly', () => {
+  describe('GET /balances maps ERC20 token correctly', () => {
     it(`Success`, async () => {
       const chainId = '1';
       const safeAddress = '0x0000000000000000000000000000000000000001';
@@ -129,7 +129,7 @@ describe('Balances Controller (Unit)', () => {
       );
     });
 
-    it(`Maps native token correctly`, async () => {
+    it(`GET /balances maps native token correctly`, async () => {
       const safeAddress = faker.finance.ethereumAddress();
       const transactionApiBalancesResponse = [
         balanceBuilder().with('tokenAddress', null).build(),

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -63,8 +63,8 @@ describe('Balances Controller (Unit)', () => {
     await app.close();
   });
 
-  describe('GET /balances maps ERC20 token correctly', () => {
-    it(`Success`, async () => {
+  describe('GET /balances', () => {
+    it(`maps ERC20 token correctly`, async () => {
       const chainId = '1';
       const safeAddress = '0x0000000000000000000000000000000000000001';
       const transactionApiBalancesResponse = [balanceBuilder().build()];
@@ -129,7 +129,7 @@ describe('Balances Controller (Unit)', () => {
       );
     });
 
-    it(`GET /balances maps native token correctly`, async () => {
+    it(`maps native token correctly`, async () => {
       const safeAddress = faker.finance.ethereumAddress();
       const transactionApiBalancesResponse = [
         balanceBuilder().with('tokenAddress', null).build(),


### PR DESCRIPTION
Closes #325

- Fixes native token mapping in `GET /v1/chains/:chainId/safes/:safeAddress/balances/:fiatCode`
- The token type is now correctly assigned – it was comparing to `undefined` with a strict comparison (the value can be `null` but not `undefined`)
- Uses the Native Token metadata from the chain correctly – this is used for retrieving respective decimals, symbol, name and logo URI