### PR TITLE
Add id prefixes

### DIFF
--- a/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc20-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc20-expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "i276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a27000,0,0",
+        "id": "transfer_i276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a27000,0,0",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -34,7 +34,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700181",
+        "id": "transfer_e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700181",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -68,7 +68,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700182",
+        "id": "transfer_e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700182",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -102,7 +102,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700183",
+        "id": "transfer_e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700183",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -136,7 +136,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700184",
+        "id": "transfer_e276abf83da6aabc61b429a1663b2bd647d5c9ff5594aa1d55ba49c70e99a2700184",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667395620000,
@@ -170,7 +170,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "eb16cbf2479d8bd20485bbb8683480d38be244cb9fbc047bd68b1fd475263040986",
+        "id": "transfer_eb16cbf2479d8bd20485bbb8683480d38be244cb9fbc047bd68b1fd475263040986",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667373708000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc721-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/e2e/erc721-expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "i5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b0,0,10",
+        "id": "transfer_i5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b0,0,10",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,
@@ -34,7 +34,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b25",
+        "id": "transfer_e5009500e71ff0dc12ddce3cbe64fd346df9bce9f2413f4dd4c4e82877313112b25",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/erc20/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/erc20/expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
+        "id": "transfer_e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1667811828000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/erc721/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/erc721/expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
+        "id": "transfer_e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,

--- a/src/routes/transactions/__tests__/resources/incoming-transfers/native-coin/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/incoming-transfers/native-coin/expected-response.json
@@ -5,7 +5,7 @@
     {
       "type": "TRANSACTION",
       "transaction": {
-        "id": "e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
+        "id": "transfer_e1015fc6905859c6957ab918abc19840f035e3da0c9fc9fa9df075d5c72dcfd31167",
         "executionInfo": null,
         "safeAppInfo": null,
         "timestamp": 1659617062000,

--- a/src/routes/transactions/__tests__/resources/module-transactions/expected-response.json
+++ b/src/routes/transactions/__tests__/resources/module-transactions/expected-response.json
@@ -5,7 +5,7 @@
       {
         "type": "TRANSACTION",
         "transaction": {
-          "id": "i5a6754140f0432d3b5e6d8341597ec3c5338239f8d311de9061fbc959f443d590",
+          "id": "module_i5a6754140f0432d3b5e6d8341597ec3c5338239f8d311de9061fbc959f443d590",
           "safeAppInfo": null,
           "timestamp": 1671023952000,
           "txStatus": "SUCCESS",

--- a/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/module-transactions/native-token-expected-response.json
+++ b/src/routes/transactions/__tests__/resources/multisig-transactions/e2e/module-transactions/native-token-expected-response.json
@@ -5,7 +5,7 @@
         {
           "type": "TRANSACTION",
           "transaction": {
-            "id": "if4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b440,0",
+            "id": "module_if4d5521a554f9a889ba4fd642265ed9688405752f8c2574eca05d325487c0b440,0",
             "timestamp": 1671023952000,
             "txStatus": "SUCCESS",
             "txInfo": {

--- a/src/routes/transactions/constants.ts
+++ b/src/routes/transactions/constants.ts
@@ -1,3 +1,6 @@
 export const MULTI_SEND_METHOD_NAME = 'multiSend';
 export const TRANSACTIONS_PARAMETER_NAME = 'transactions';
 export const ADDRESS_PARAMETER_TYPE = 'address';
+export const TRANSFER_PREFIX = 'transfer';
+export const MODULE_TRANSACTION_PREFIX = 'module';
+export const MULTISIG_TRANSACTION_PREFIX = 'multisig';

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -6,6 +6,7 @@ import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper
 import { ModuleTransactionStatusMapper } from './module-transaction-status.mapper';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { ModuleExecutionInfo } from '../../entities/module-execution-info.entity';
+import { MODULE_TRANSACTION_PREFIX } from '../../constants';
 
 @Injectable()
 export class ModuleTransactionMapper {
@@ -30,7 +31,7 @@ export class ModuleTransactionMapper {
       await this.addressInfoHelper.getOrDefault(chainId, transaction.module),
     );
     return new Transaction(
-      transaction.moduleTransactionId,
+      `${MODULE_TRANSACTION_PREFIX}_${transaction.moduleTransactionId}`,
       transaction.executionDate.getTime(),
       txStatus,
       txInfo,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -6,6 +6,7 @@ import { MultisigTransactionExecutionInfoMapper } from './multisig-transaction-e
 import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper';
 import { MultisigTransactionStatusMapper } from './multisig-transaction-status.mapper';
 import { SafeAppInfoMapper } from '../common/safe-app-info.mapper';
+import { MULTISIG_TRANSACTION_PREFIX } from '../../constants';
 
 @Injectable()
 export class MultisigTransactionMapper {
@@ -39,7 +40,7 @@ export class MultisigTransactionMapper {
     const timestamp = transaction.executionDate ?? transaction.submissionDate;
 
     return new Transaction(
-      `multisig_${transaction.safe}_${transaction.safeTxHash}`,
+      `${MULTISIG_TRANSACTION_PREFIX}_${transaction.safe}_${transaction.safeTxHash}`,
       timestamp?.getTime() ?? null,
       txStatus,
       txInfo,

--- a/src/routes/transactions/mappers/transfers/transfer.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer.mapper.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { Transfer } from '../../../../domain/safe/entities/transfer.entity';
+import { TRANSFER_PREFIX } from '../../constants';
 import { TransactionStatus } from '../../entities/transaction-status.entity';
 import { Transaction } from '../../entities/transaction.entity';
 import { TransferInfoMapper } from './transfer-info.mapper';
@@ -15,7 +16,7 @@ export class IncomingTransferMapper {
     safe: Safe,
   ): Promise<Transaction> {
     return new Transaction(
-      transfer.transferId,
+      `${TRANSFER_PREFIX}_${transfer.transferId}`,
       transfer.executionDate.getTime(),
       TransactionStatus.Success,
       await this.transferInfoMapper.mapTransferInfo(chainId, transfer, safe),


### PR DESCRIPTION
- This PR partially amends the changes introduced in https://github.com/safe-global/safe-client-gateway-nest/pull/315
- This is a prior work in order to implement https://github.com/safe-global/safe-client-gateway-nest/issues/262

**Motivation**
In order to get a detailed transfer/module transaction by ID, we shifted the approach by sending unique IDs to the clients, so they could use those IDs to ask for a concrete item afterward. The problem here is the Transaction Service has two different endpoints for module transactions and transfers, ([see Swagger](https://safe-transaction-mainnet.staging.5afe.dev/)) so we need a way to distinguish between these two types having the ID only.

**Solution**
Prepend the item type (`module`/`transfer`) to the ID so the CGW knows which Transaction Service endpoint has to call beforehand when a client is trying to get a transaction detail by ID.