### PR TITLE
GetDataDecodedDto 'to' field is now optional

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -65,7 +65,7 @@ export class TransactionApi implements ITransactionApi {
     await this.cacheService.deleteByKey(cacheKey);
   }
 
-  async getDataDecoded(data: string, to: string): Promise<DataDecoded> {
+  async getDataDecoded(data: string, to?: string): Promise<DataDecoded> {
     try {
       const url = `${this.baseUrl}/api/v1/data-decoder/`;
       const { data: dataDecoded } = await this.networkService.post(url, {

--- a/src/domain/data-decoder/data-decoded.repository.ts
+++ b/src/domain/data-decoder/data-decoded.repository.ts
@@ -15,7 +15,7 @@ export class DataDecodedRepository implements IDataDecodedRepository {
   async getDataDecoded(
     chainId: string,
     data: string,
-    to: string,
+    to?: string,
   ): Promise<DataDecoded> {
     const api = await this.transactionApiManager.getTransactionApi(chainId);
     const dataDecoded = await api.getDataDecoded(data, to);

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -29,7 +29,7 @@ export interface ITransactionApi {
 
   clearLocalBalances(safeAddress: string): Promise<void>;
 
-  getDataDecoded(data: string, to: string): Promise<DataDecoded>;
+  getDataDecoded(data: string, to?: string): Promise<DataDecoded>;
 
   getCollectibles(
     safeAddress: string,

--- a/src/routes/data-decode/entities/get-data-decoded.dto.entity.ts
+++ b/src/routes/data-decode/entities/get-data-decoded.dto.entity.ts
@@ -1,10 +1,10 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class GetDataDecodedDto {
   @ApiProperty({ description: 'Hexadecimal value' })
   data: string;
-  @ApiProperty({ description: 'Hexadecimal value' })
-  to: string;
+  @ApiPropertyOptional({ description: 'The target Ethereum address' })
+  to?: string;
 
   constructor(data: string, to: string) {
     this.data = data;

--- a/src/routes/data-decode/entities/schemas/get-data-decoded.dto.schema.ts
+++ b/src/routes/data-decode/entities/schemas/get-data-decoded.dto.schema.ts
@@ -6,7 +6,7 @@ export const getDataDecodedDtoSchema: JSONSchemaType<GetDataDecodedDto> = {
   type: 'object',
   properties: {
     data: { type: 'string' },
-    to: { type: 'string' },
+    to: { type: 'string', nullable: true },
   },
-  required: ['data', 'to'],
+  required: ['data'],
 };


### PR DESCRIPTION
Closes #334 

- Sets `GetDataDecodedDto.to` as an optional field
- Improves description on the `to` field for Swagger