### PR TITLE
Do not return cancelled transactions as queued

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -156,12 +156,13 @@ export class CacheRouter {
     to?: string,
     value?: string,
     nonce?: string,
+    nonceGte?: number,
     limit?: number,
     offset?: number,
   ): CacheDir {
     return new CacheDir(
       `${chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${safeAddress}`,
-      `${ordering}_${executed}_${trusted}_${executionDateGte}_${executionDateLte}_${to}_${value}_${nonce}_${limit}_${offset}`,
+      `${ordering}_${executed}_${trusted}_${executionDateGte}_${executionDateLte}_${to}_${value}_${nonce}_${nonceGte}_${limit}_${offset}`,
     );
   }
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -364,6 +364,7 @@ export class TransactionApi implements ITransactionApi {
     to?: string,
     value?: string,
     nonce?: string,
+    nonceGte?: number,
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>> {
@@ -379,6 +380,7 @@ export class TransactionApi implements ITransactionApi {
         to,
         value,
         nonce,
+        nonceGte,
         limit,
         offset,
       );
@@ -394,6 +396,7 @@ export class TransactionApi implements ITransactionApi {
           to,
           value,
           nonce,
+          nonce__gte: nonceGte,
           limit,
           offset,
         },

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -123,6 +123,7 @@ export interface ITransactionApi {
     to?: string,
     value?: string,
     nonce?: string,
+    nonceGte?: number,
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -48,16 +48,37 @@ export interface ISafeRepository {
     offset?: number,
   ): Promise<Page<ModuleTransaction>>;
 
-  getTransactionQueueByModified(
+  /**
+   * Returns the Safe Transaction Queue in ascending order.
+   *
+   * The ascending order is first considered for the nonce.
+   * If multiple transactions have the same nonce, then they
+   * will be sorted according to the submission date
+   *
+   * @param chainId - the chain id from where to retrieve the transactions from
+   * @param safe - the target safe from where to get the transaction from
+   * @param limit - the maximum number of transactions to be returned
+   * @param offset - the starting point from which to start the pagination
+   */
+  getTransactionQueue(
     chainId: string,
-    safeAddress: string,
+    safe: Safe,
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;
 
-  getTransactionQueueByNonce(
+  /**
+   * Returns the Safe Transaction Queue sorted by modified status.
+   * (from most recently modified to last)
+   *
+   * @param chainId - the chain id from where to retrieve the transactions from
+   * @param safe - the target safe from where to get the transaction from
+   * @param limit - the maximum number of transactions to be returned
+   * @param offset - the starting point from which to start the pagination
+   */
+  getTransactionQueueByModified(
     chainId: string,
-    safeAddress: string,
+    safe: Safe,
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>>;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -132,39 +132,33 @@ export class SafeRepository implements ISafeRepository {
     return page;
   }
 
+  async getTransactionQueue(
+    chainId: string,
+    safe: Safe,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<MultisigTransaction>> {
+    return this._getTransactionQueue(
+      chainId,
+      safe,
+      'nonce,submissionDate',
+      limit,
+      offset,
+    );
+  }
+
   async getTransactionQueueByModified(
     chainId: string,
-    safeAddress: string,
+    safe: Safe,
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>> {
-    return this.getTransactionQueue(
-      chainId,
-      safeAddress,
-      '-modified',
-      limit,
-      offset,
-    );
+    return this._getTransactionQueue(chainId, safe, '-modified', limit, offset);
   }
 
-  async getTransactionQueueByNonce(
+  private async _getTransactionQueue(
     chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>> {
-    return this.getTransactionQueue(
-      chainId,
-      safeAddress,
-      'nonce',
-      limit,
-      offset,
-    );
-  }
-
-  private async getTransactionQueue(
-    chainId: string,
-    safeAddress: string,
+    safe: Safe,
     ordering: string,
     limit?: number,
     offset?: number,
@@ -173,7 +167,7 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(chainId);
     const page: Page<MultisigTransaction> =
       await transactionService.getMultisigTransactions(
-        safeAddress,
+        safe.address,
         ordering,
         false,
         true,
@@ -182,6 +176,7 @@ export class SafeRepository implements ISafeRepository {
         undefined,
         undefined,
         undefined,
+        safe.nonce,
         limit,
         offset,
       );
@@ -282,6 +277,7 @@ export class SafeRepository implements ISafeRepository {
     to?: string,
     value?: string,
     nonce?: string,
+    nonceGte?: number,
     limit?: number,
     offset?: number,
   ): Promise<Page<MultisigTransaction>> {
@@ -297,6 +293,7 @@ export class SafeRepository implements ISafeRepository {
       to,
       value,
       nonce,
+      nonceGte,
       limit,
       offset,
     );

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -62,7 +62,7 @@ export class SafesService {
     const collectiblesTag = await this.getCollectiblesTag(chainId, safeAddress);
     const queuedTransactionTag = await this.getQueuedTransactionTag(
       chainId,
-      safeAddress,
+      safe,
     );
     const transactionHistoryTag = await this.executedTransactionTag(
       chainId,
@@ -109,14 +109,10 @@ export class SafesService {
 
   private async getQueuedTransactionTag(
     chainId: string,
-    safeAddress: string,
+    safe: Safe,
   ): Promise<Date | null> {
     const lastQueuedTransaction =
-      await this.safeRepository.getTransactionQueueByModified(
-        chainId,
-        safeAddress,
-        1,
-      );
+      await this.safeRepository.getTransactionQueueByModified(chainId, safe, 1);
 
     return lastQueuedTransaction.results[0]?.modified ?? null;
   }

--- a/src/routes/transactions/__tests__/get-multisig-transactions.e2e-spec.ts
+++ b/src/routes/transactions/__tests__/get-multisig-transactions.e2e-spec.ts
@@ -5,7 +5,6 @@ import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
-import { PaginationData } from '../../common/pagination/pagination.data';
 
 describe('Get multisig transactions e2e test', () => {
   let app: INestApplication;
@@ -30,8 +29,6 @@ describe('Get multisig transactions e2e test', () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const executionDateGte = '2022-11-04T00:00:00.000Z';
     const executionDateLte = '2022-11-08T00:00:00.000Z';
-    const cacheKey = `${chainId}_multisig_transactions_${safeAddress}`;
-    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/native-token-expected-response.json',
     );
@@ -44,17 +41,12 @@ describe('Get multisig transactions e2e test', () => {
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);
       });
-
-    const cacheContent = await redisClient.hGet(cacheKey, cacheKeyField);
-    expect(cacheContent).not.toBeNull();
   }, 60000);
 
   it('GET /safes/<address>/multisig-transactions (ERC-20 + Settings change)', async () => {
     const safeAddress = '0xCe95F1F4ACADEe697993B0E3a0FE48B444679046';
     const executionDateGte = '2022-12-01T00:00:00.000Z';
     const executionDateLte = '2022-12-07T11:00:00.000Z';
-    const cacheKey = `${chainId}_multisig_transactions_${safeAddress}`;
-    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/erc20-expected-response.json',
     );
@@ -67,17 +59,12 @@ describe('Get multisig transactions e2e test', () => {
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);
       });
-
-    const cacheContent = await redisClient.hGet(cacheKey, cacheKeyField);
-    expect(cacheContent).not.toBeNull();
   }, 60000);
 
   it('GET /safes/<address>/multisig-transactions (ERC-721)', async () => {
     const safeAddress = '0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C';
     const executionDateGte = '2022-11-29T14:00:00.000Z';
     const executionDateLte = '2022-12-06T00:00:00.000Z';
-    const cacheKey = `${chainId}_multisig_transactions_${safeAddress}`;
-    const cacheKeyField = `-modified_undefined_true_${executionDateGte}_${executionDateLte}_undefined_undefined_undefined_${PaginationData.DEFAULT_LIMIT}_${PaginationData.DEFAULT_OFFSET}`;
     const expectedResponse = getJsonResource(
       'e2e/erc721-expected-response.json',
     );
@@ -90,9 +77,6 @@ describe('Get multisig transactions e2e test', () => {
       .then(({ body }) => {
         expect(body).toEqual(expectedResponse);
       });
-
-    const cacheContent = await redisClient.hGet(cacheKey, cacheKeyField);
-    expect(cacheContent).not.toBeNull();
   }, 60000);
 
   afterAll(async () => {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -62,6 +62,7 @@ export class TransactionsService {
         to,
         value,
         nonce,
+        undefined,
         paginationData.limit,
         paginationData.offset,
       );
@@ -239,9 +240,9 @@ export class TransactionsService {
   ): Promise<Page<QueuedItem>> {
     const pagination = this.getAdjustedPaginationForQueue(paginationData);
     const safeInfo = await this.safeRepository.getSafe(chainId, safeAddress);
-    const transactions = await this.safeRepository.getTransactionQueueByNonce(
+    const transactions = await this.safeRepository.getTransactionQueue(
       chainId,
-      safeAddress,
+      safeInfo,
       pagination.limit,
       pagination.offset,
     );


### PR DESCRIPTION
Closes #335

- The method `SafeRepository.getTransactionQueueByNonce` was requesting all non-executed transaction sorted by nonce. The issue with returning non-executed transactions is that is also returns cancelled transactions.
- `nonceGte` should be used instead so that we can return all the transactions with nonce greater than the current Safe one.
- `getTransactionQueueByModified` was updated to consider `nonceGte`
- `getTransactionQueueByNonce` was renamed to `getTransactionQueue` – this should be considered the standard "operation" when requesting the queue