### PR TITLE
Handle non-JSON payloads for tx origin

### DIFF
--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.spec.ts
@@ -83,6 +83,17 @@ describe('SafeAppInfo mapper (Unit)', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should return null origin on invalid JSON', async () => {
+    const chainId = faker.random.numeric();
+    const transaction = multisigTransactionBuilder()
+      .with('origin', faker.datatype.string())
+      .build();
+
+    const actual = await mapper.mapSafeAppInfo(chainId, transaction);
+
+    expect(actual).toBeNull();
+  });
+
   it('should replace IPFS origin urls', async () => {
     const chainId = faker.random.numeric();
     const originUrl = 'https://ipfs.io/test';

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -50,12 +50,8 @@ export class SafeAppInfoMapper {
   }
 
   private getOriginUrl(transaction: MultisigTransaction): string | null {
-    if (!transaction.origin) {
-      return null;
-    }
-
     try {
-      return JSON.parse(transaction.origin).url ?? null;
+      return transaction.origin ? JSON.parse(transaction.origin).url : null;
     } catch (e) {
       this.loggingService.debug(
         `Safe TX Hash ${transaction.safeTxHash} origin is not valid JSON. origin=${transaction.origin}`,

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -50,8 +50,17 @@ export class SafeAppInfoMapper {
   }
 
   private getOriginUrl(transaction: MultisigTransaction): string | null {
-    return transaction.origin
-      ? JSON.parse(transaction.origin).url ?? null
-      : null;
+    if (!transaction.origin) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(transaction.origin).url ?? null;
+    } catch (e) {
+      this.loggingService.debug(
+        `Safe TX Hash ${transaction.safeTxHash} origin is not valid JSON. origin=${transaction.origin}`,
+      );
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Closes #340 

- If a transaction had an `origin` which was not a JSON payload the service would throw an exception. The expected behaviour however, is to return `null` for non-JSON payloads