### PR TITLE
Add trusted field to Multisig Transactions

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -44,6 +44,7 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
     .with('submissionDate', faker.date.recent())
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.datatype.hexadecimal())
+    .with('trusted', faker.datatype.boolean())
     .with('value', faker.datatype.hexadecimal());
 }
 

--- a/src/domain/safe/entities/multisig-transaction.entity.ts
+++ b/src/domain/safe/entities/multisig-transaction.entity.ts
@@ -37,5 +37,6 @@ export type MultisigTransaction = {
   submissionDate: Date | null;
   to: string;
   transactionHash: string | null;
+  trusted: boolean;
   value: string;
 };

--- a/src/domain/safe/entities/schemas/multisig-transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction-type.schema.ts
@@ -57,6 +57,7 @@ export const multisigTransactionTypeSchema: Schema = {
       default: null,
     },
     signatures: { type: 'string', nullable: true, default: null },
+    trusted: { type: 'boolean' },
   },
   required: [
     'txType',
@@ -66,5 +67,6 @@ export const multisigTransactionTypeSchema: Schema = {
     'nonce',
     'safeTxHash',
     'isExecuted',
+    'trusted',
   ],
 };

--- a/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
@@ -75,6 +75,7 @@ export const multisigTransactionSchema: Schema = {
       default: null,
     },
     signatures: { type: 'string', nullable: true, default: null },
+    trusted: { type: 'boolean' },
   },
   required: [
     'safe',
@@ -84,5 +85,6 @@ export const multisigTransactionSchema: Schema = {
     'submissionDate',
     'safeTxHash',
     'isExecuted',
+    'trusted',
   ],
 };


### PR DESCRIPTION
This PR aims to add the `trusted` field to `MultisigTransaction` entity, with a non-nullable boolean type.

- Transaction Service field definition: https://github.com/safe-global/safe-transaction-service/blob/d00ad8bd891e6ab991b0c32493dadda1ab0b0c60/safe_transaction_service/history/models.py#L1370
- This `trusted` field is also used to compose the `detailedExecutionInfo` part when requesting a multisig transaction by id to the current Client Gateway. Example: ```curl --location 'https://safe-client.staging.5afe.dev//v1/chains/5/transactions/multisig_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x8bd40d5b25f6c93e6d44e74c245d50518ec036ad0a16988c0c48c20fa8cc99e8'```