### PR TITLE
Add support for X-Forwarded-Proto header

### DIFF
--- a/src/routes/common/decorators/utils.spec.ts
+++ b/src/routes/common/decorators/utils.spec.ts
@@ -1,0 +1,51 @@
+import { getRouteUrl } from './utils';
+import { faker } from '@faker-js/faker';
+
+describe('utils tests', () => {
+  describe('getRouteUrl tests', () => {
+    const request = {
+      get: jest.fn(),
+      originalUrl: faker.system.filePath(),
+      protocol: faker.internet.protocol(),
+    } as unknown as any;
+
+    const requestMock = jest.mocked(request);
+
+    it('Uses X-Forwarded-Proto as protocol if set', () => {
+      const protocol = faker.internet.protocol();
+      const host = faker.internet.domainName();
+      request.get.mockImplementation((arg) => {
+        if (arg == 'X-Forwarded-Proto') {
+          return protocol;
+        } else if (arg == 'Host') {
+          return host;
+        } else {
+          throw Error('Unknown arg');
+        }
+      });
+
+      const actual = getRouteUrl(requestMock).toString();
+
+      expect(actual).toBe(`${protocol}://${host}${request.originalUrl}`);
+    });
+
+    it('Uses request protocol if X-Forwarded-Proto is not set', () => {
+      const host = faker.internet.domainName();
+      request.get.mockImplementation((arg) => {
+        if (arg == 'X-Forwarded-Proto') {
+          return undefined;
+        } else if (arg == 'Host') {
+          return host;
+        } else {
+          throw Error('Unknown arg');
+        }
+      });
+
+      const actual = getRouteUrl(requestMock).toString();
+
+      expect(actual).toBe(
+        `${request.protocol}://${host}${request.originalUrl}`,
+      );
+    });
+  });
+});

--- a/src/routes/common/decorators/utils.ts
+++ b/src/routes/common/decorators/utils.ts
@@ -1,5 +1,4 @@
 export function getRouteUrl(request: any) {
-  return new URL(
-    `${request.protocol}://${request.get('Host')}${request.originalUrl}`,
-  );
+  const protocol = request.get('X-Forwarded-Proto') ?? request.protocol;
+  return new URL(`${protocol}://${request.get('Host')}${request.originalUrl}`);
 }


### PR DESCRIPTION
Closes #336 

- When using the service behind a proxy server (such as Nginx), we should first check if `X-Forwarded-Proto` is set when setting the protocol for any returned url – https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
- The reason is that the request between the proxy service and the NestJS instance might be done under a different protocol than the request that was made from the client to the proxy service.
- If the protocol is different then we should return the original protocol back to the clients (which we should retrieve from `X-Forwarded-Proto`)
- If `X-Forwarded-Proto` is not set, it assumes the protocol set in the request