### PR TITLE
Retrieve AddressInfo from Token

### DIFF
--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -17,17 +17,18 @@ export class AddressInfoHelper {
   ) {}
 
   /**
-   * Returns a promise for {@link AddressInfo} which contains the contract
+   * Returns a promise for {@link AddressInfo} which contains the source
    * information for {@link address}
    *
    * If the {@link address} is 0x0000000000000000000000000000000000000000,
    * null is returned
    *
-   * The promise can result in rejection if the contract information
+   * The promise can result in rejection if the source information
    * is not found or cannot be retrieved
    *
-   * @param chainId - the chain id where the contract exists
-   * @param address - the address of the contract to which we want to retrieve its metadata
+   * @param chainId - the chain id where the source exists
+   * @param address - the address of the source to which we want to retrieve its metadata
+   * @param source - the {@link Source} to which we want to retrieve its metadata
    */
   get(
     chainId: string,
@@ -43,20 +44,25 @@ export class AddressInfoHelper {
   /**
    * Similar to {@see get} but should never fail.
    *
-   * If a contract address cannot be retrieved, a {@link AddressInfo} is returned
-   * containing just the contract address
+   * If a source address cannot be retrieved, a {@link AddressInfo} is returned
+   * containing just the source address
    *
-   * @param chainId - the chain id where the contract exists
-   * @param address - the address of the contract to which we want to retrieve its metadata
+   * @param chainId - the chain id where the source exists
+   * @param address - the address of the source to which we want to retrieve its metadata
+   * @param source - the {@link Source} to which we want to retrieve its metadata
    */
-  getOrDefault(chainId: string, address: string): Promise<AddressInfo> {
-    return this.get(chainId, address)
+  getOrDefault(
+    chainId: string,
+    address: string,
+    source: Source = 'CONTRACT',
+  ): Promise<AddressInfo> {
+    return this.get(chainId, address, source)
       .then((addressInfo) => addressInfo ?? new AddressInfo(address))
       .catch(() => new AddressInfo(address));
   }
 
   /**
-   * Similar to {@see getOrDefault} but works with a collection
+   * Similar to {@see getOrDefault} but works with a collection of contract addresses
    *
    * @param chainId - the chain id where the contract exists
    * @param addresses - the collection of addresses to which we want to retrieve the respective metadata
@@ -66,7 +72,9 @@ export class AddressInfoHelper {
     addresses: string[],
   ): Promise<Array<AddressInfo>> {
     return Promise.allSettled(
-      addresses.map((address) => this.getOrDefault(chainId, address)),
+      addresses.map((address) =>
+        this.getOrDefault(chainId, address, 'CONTRACT'),
+      ),
     ).then((results) =>
       results.map((result) => {
         if (result.status == 'fulfilled') return result.value;

--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -62,19 +62,19 @@ export class AddressInfoHelper {
   }
 
   /**
-   * Similar to {@see getOrDefault} but works with a collection of contract addresses
+   * Similar to {@see getOrDefault} but works with a collection of source addresses
    *
-   * @param chainId - the chain id where the contract exists
+   * @param chainId - the chain id where the source exists
    * @param addresses - the collection of addresses to which we want to retrieve the respective metadata
+   * @param source - the {@link Source} to which we want to retrieve its metadata
    */
   getCollection(
     chainId: string,
     addresses: string[],
+    source: Source = 'CONTRACT',
   ): Promise<Array<AddressInfo>> {
     return Promise.allSettled(
-      addresses.map((address) =>
-        this.getOrDefault(chainId, address, 'CONTRACT'),
-      ),
+      addresses.map((address) => this.getOrDefault(chainId, address, source)),
     ).then((results) =>
       results.map((result) => {
         if (result.status == 'fulfilled') return result.value;


### PR DESCRIPTION
This is motivated because on https://github.com/safe-global/safe-client-gateway-nest/issues/262 we need to implement the possibility of picking up an `AddressInfo` from a `Token` entity. For instance, for the following `Custom` transaction:

```
curl --location 'https://safe-client.staging.5afe.dev//v1/chains/5/transactions/multisig_0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C_0x8bbe560e7d6f4d94fd29f175b716301b7da80ebf56102c1da94272af702632bf'
```

The object retrieved at `txData.to` is:
```
{
    "value": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
    "name": "Wrapped Ether",
    "logoUri": "https://safe-transaction-assets.staging.5afe.dev/tokens/logos/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6.png"
}
```

which should be retrieved from:

```
curl --location 'https://safe-transaction-goerli.safe.global/api/v1/tokens/0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6'
```

This utility to call Transaction Service's `/tokens` endpoint to get an `AddressInfo` wasn't needed before the implementation of https://github.com/safe-global/safe-client-gateway-nest/issues/262

For context, here is the Rust counterpart function: https://github.com/safe-global/safe-client-gateway/blob/e0d69faabd0a05d858eec81f235acc0945ac0993/src/providers/info.rs#L229