### PR TITLE
fix: centralise `exchange.cacheTtlSeconds` fallback

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -13,7 +13,7 @@ export default () => ({
       process.env.EXCHANGE_API_BASE_URI ||
       'https://api.apilayer.com/exchangerates_data',
     apiKey: process.env.EXCHANGE_API_KEY,
-    cacheTtlSeconds: process.env.EXCHANGE_API_CACHE_TTL_SECONDS,
+    cacheTtlSeconds: process.env.EXCHANGE_API_CACHE_TTL_SECONDS || 60 * 60 * 12,
   },
   safeConfig: {
     baseUri:

--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -13,8 +13,6 @@ export class ExchangeApi implements IExchangeApi {
   private readonly apiKey: string;
   private readonly cacheTtlSeconds: number;
 
-  private static readonly DEFAULT_CACHE_TTL_SECONDS = 60 * 60 * 12;
-
   constructor(
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
@@ -24,10 +22,9 @@ export class ExchangeApi implements IExchangeApi {
       this.configurationService.getOrThrow<string>('exchange.baseUri');
     this.apiKey =
       this.configurationService.getOrThrow<string>('exchange.apiKey');
-    this.cacheTtlSeconds =
-      this.configurationService.get<number | undefined>(
-        'exchange.cacheTtlSeconds',
-      ) ?? ExchangeApi.DEFAULT_CACHE_TTL_SECONDS;
+    this.cacheTtlSeconds = this.configurationService.getOrThrow<number>(
+      'exchange.cacheTtlSeconds',
+    );
   }
 
   async getFiatCodes(): Promise<ExchangeFiatCodes> {


### PR DESCRIPTION
Resolves #318

This centralises the `exchange.cacheTtlSeconds` fallback value by moving it from the `ExchangeApi` to the `configuration.ts`.