### PR TITLE
Update external_request logs

### DIFF
--- a/src/datasources/network/axios.network.service.spec.ts
+++ b/src/datasources/network/axios.network.service.spec.ts
@@ -121,10 +121,10 @@ describe('AxiosNetworkService', () => {
       expect(loggingService.debug).toBeCalledWith({
         type: 'external_request',
         protocol: error.request.protocol,
-        host: error.request.host,
+        target_host: error.request.host,
         path: error.request.path,
-        status: error.response.status,
-        message: error.response.statusText,
+        request_status: error.response.status,
+        detail: error.response.statusText,
         response_time_ms: expect.any(Number),
       });
     });
@@ -224,10 +224,10 @@ describe('AxiosNetworkService', () => {
       expect(loggingService.debug).toBeCalledWith({
         type: 'external_request',
         protocol: error.request.protocol,
-        host: error.request.host,
+        target_host: error.request.host,
         path: error.request.path,
-        status: error.response.status,
-        message: error.response.statusText,
+        request_status: error.response.status,
+        detail: error.response.statusText,
         response_time_ms: expect.any(Number),
       });
     });
@@ -314,10 +314,10 @@ describe('AxiosNetworkService', () => {
       expect(loggingService.debug).toBeCalledWith({
         type: 'external_request',
         protocol: error.request.protocol,
-        host: error.request.host,
+        target_host: error.request.host,
         path: error.request.path,
-        status: error.response.status,
-        message: error.response.statusText,
+        request_status: error.response.status,
+        detail: error.response.statusText,
         response_time_ms: expect.any(Number),
       });
     });

--- a/src/datasources/network/axios.network.service.ts
+++ b/src/datasources/network/axios.network.service.ts
@@ -79,10 +79,10 @@ export class AxiosNetworkService implements INetworkService {
     this.loggingService.debug({
       type: 'external_request',
       protocol: error.request.protocol,
-      host: error.request.host,
+      target_host: error.request.host,
       path: error.request.path,
-      status: error.response.status,
-      message: error.response.statusText,
+      request_status: error.response.status,
+      detail: error.response.statusText,
       response_time_ms: responseTimeMs,
     });
   }


### PR DESCRIPTION
To improve compatibility with Datadog defaults, some properties of the `external_request` log changed. More specifically:

- `host` – is used as the originating host of the log by Datadog. We want to represent to which host was the external request made to instead. Changed to `target_host`.
- `status` – is used to set the level/severity of the log. We want to represent the HTTP status code of the external request made instead. Change to `request_status`
- `message` – its contents are displayed in views like Live Tail. Changed to `detail` as `message` is already set as the JSON payload.

See https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes