### PR TITLE
fix: forward balances params

### DIFF
--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -133,11 +133,8 @@ describe('Balances Controller (Unit)', () => {
       const chainId = '1';
       const safeAddress = '0x0000000000000000000000000000000000000001';
       const transactionApiBalancesResponse = [balanceBuilder().build()];
-      const exchangeApiResponse = exchangeRatesBuilder()
-        .with('success', true)
-        .with('rates', { USD: 2.0 })
-        .build();
-      const chainResponse = chainBuilder().with('chainId', chainId).build();
+      const exchangeApiResponse = exchangeRatesBuilder().build();
+      const chainResponse = chainBuilder().build();
       const excludeSpam = true;
       const trusted = true;
 

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -129,6 +129,50 @@ describe('Balances Controller (Unit)', () => {
       );
     });
 
+    it(`excludeSpam and trusted params are forwarded to tx service`, async () => {
+      const chainId = '1';
+      const safeAddress = '0x0000000000000000000000000000000000000001';
+      const transactionApiBalancesResponse = [balanceBuilder().build()];
+      const exchangeApiResponse = exchangeRatesBuilder()
+        .with('success', true)
+        .with('rates', { USD: 2.0 })
+        .build();
+      const chainResponse = chainBuilder().with('chainId', chainId).build();
+      const excludeSpam = true;
+      const trusted = true;
+
+      mockNetworkService.get.mockImplementation((url) => {
+        if (url == `https://test.safe.config/api/v1/chains/${chainId}`) {
+          return Promise.resolve({ data: chainResponse });
+        } else if (
+          url ==
+          `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/balances/usd/`
+        ) {
+          return Promise.resolve({
+            data: transactionApiBalancesResponse,
+          });
+        } else if (url == 'https://test.exchange/latest') {
+          return Promise.resolve({ data: exchangeApiResponse });
+        } else {
+          return Promise.reject(new Error(`Could not match ${url}`));
+        }
+      });
+
+      await request(app.getHttpServer())
+        .get(
+          `/v1/chains/${chainId}/safes/${safeAddress}/balances/usd/?trusted=${trusted}&exclude_spam=${excludeSpam}`,
+        )
+        .expect(200);
+
+      // trusted and exclude_spam params are passed
+      expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
+        params: {
+          trusted: trusted.toString(),
+          exclude_spam: excludeSpam.toString(),
+        },
+      });
+    });
+
     it(`maps native token correctly`, async () => {
       const safeAddress = faker.finance.ethereumAddress();
       const transactionApiBalancesResponse = [

--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { BalancesService } from './balances.service';
 import { Balances } from './entities/balances.entity';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
@@ -17,8 +17,16 @@ export class BalancesController {
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
     @Param('fiatCode') fiatCode: string,
+    @Query('trusted') trusted?: boolean,
+    @Query('exclude_spam') excludeSpam?: boolean,
   ): Promise<Balances> {
-    return this.balancesService.getBalances(chainId, safeAddress, fiatCode);
+    return this.balancesService.getBalances(
+      chainId,
+      safeAddress,
+      fiatCode,
+      trusted,
+      excludeSpam,
+    );
   }
 
   @Get('balances/supported-fiat-codes')

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -27,10 +27,14 @@ export class BalancesService {
     chainId: string,
     safeAddress: string,
     fiatCode: string,
+    trusted?: boolean,
+    excludeSpam?: boolean,
   ): Promise<Balances> {
     const txServiceBalances = await this.balancesRepository.getBalances(
       chainId,
       safeAddress,
+      trusted,
+      excludeSpam,
     );
 
     const usdToFiatRate: number = await this.exchangeRepository.convertRates(


### PR DESCRIPTION
Resolves #355

The `trusted` and `exclude_spam` parameters are now forwarded to the Transaction Service when requesting balances.

Example request to compare against:
`curl --location 'https://safe-client.staging.5afe.dev/v1/chains/5/safes/0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C/balances/EUR?trusted=true`