### PR TITLE
Use chain vpc url if enabled

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -19,6 +19,9 @@ export default () => ({
     baseUri:
       process.env.SAFE_CONFIG_BASE_URI || 'https://safe-config.safe.global/',
   },
+  safeTransaction: {
+    useVpcUrl: process.env.USE_TX_SERVICE_VPC_URL?.toLowerCase() === 'true',
+  },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -1,0 +1,90 @@
+import { TransactionApiManager } from './transaction-api.manager';
+import { IConfigurationService } from '../../config/configuration.service.interface';
+import { IConfigApi } from '../../domain/interfaces/config-api.interface';
+import { ICacheService } from '../cache/cache.service.interface';
+import { INetworkService } from '../network/network.service.interface';
+import { CacheFirstDataSource } from '../cache/cache.first.data.source';
+import { HttpErrorFactory } from '../errors/http-error-factory';
+import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
+
+const configurationService = {
+  get: jest.fn(),
+} as unknown as IConfigurationService;
+
+const configurationServiceMock = jest.mocked(configurationService);
+
+const configApi = {
+  getChain: jest.fn(),
+} as unknown as IConfigApi;
+
+const configApiMock = jest.mocked(configApi);
+
+const dataSource = {
+  get: jest.fn(),
+} as unknown as CacheFirstDataSource;
+
+const dataSourceMock = jest.mocked(dataSource);
+
+const cacheService = {} as unknown as ICacheService;
+
+const httpErrorFactory = {} as unknown as HttpErrorFactory;
+
+const networkService = {} as unknown as INetworkService;
+
+describe('Transaction API Manager Tests', () => {
+  let target: TransactionApiManager;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    target = new TransactionApiManager(
+      configurationServiceMock,
+      configApiMock,
+      dataSourceMock,
+      cacheService,
+      httpErrorFactory,
+      networkService,
+    );
+  });
+
+  /**
+   * In the following tests, getBackbone is used to check the parameters to
+   * which {@link CacheFirstDataSource} was called with.
+   */
+  describe('VPC Url', () => {
+    it('useVpcUrl is true', async () => {
+      const chain = chainBuilder().build();
+      configurationServiceMock.get.mockImplementation((key) => {
+        if (key !== 'safeTransaction.useVpcUrl')
+          throw new Error(`Expected key safeTransaction.useVpcUrl. Got ${key}`);
+        return true;
+      });
+      configApiMock.getChain.mockResolvedValue(chain);
+
+      const transactionApi = await target.getTransactionApi(chain.chainId);
+      await transactionApi.getBackbone();
+
+      expect(dataSourceMock.get).toBeCalledWith(
+        expect.anything(),
+        `${chain.vpcTransactionService}/api/v1/about`,
+      );
+    });
+
+    it('useVpcUrl is false', async () => {
+      const chain = chainBuilder().build();
+      configurationServiceMock.get.mockImplementation((key) => {
+        if (key !== 'safeTransaction.useVpcUrl')
+          throw new Error(`Expected key safeTransaction.useVpcUrl. Got ${key}`);
+        return false;
+      });
+      configApiMock.getChain.mockResolvedValue(chain);
+
+      const transactionApi = await target.getTransactionApi(chain.chainId);
+      await transactionApi.getBackbone();
+
+      expect(dataSourceMock.get).toBeCalledWith(
+        expect.anything(),
+        `${chain.transactionService}/api/v1/about`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #327

The `Chain.vpcTransactionService` was not being used. However, if the virtual private cloud url is accessible by the service and is preferred, it can now be used by setting `USE_TX_SERVICE_VPC_URL` to `true` in the environment.