### PR TITLE
Fix returned messages order

### DIFF
--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -662,15 +662,11 @@ describe('Messages controller', () => {
               .with('results', [
                 {
                   type: 'DATE_LABEL',
-                  timestamp: Date.UTC(2025, 0, 1),
+                  timestamp: Date.UTC(2025, 0, 3),
                 },
                 expect.objectContaining({
                   type: 'MESSAGE',
-                  messageHash: messages[0].messageHash,
-                }),
-                expect.objectContaining({
-                  type: 'MESSAGE',
-                  messageHash: messages[2].messageHash,
+                  messageHash: messages[3].messageHash,
                 }),
                 {
                   type: 'DATE_LABEL',
@@ -682,11 +678,15 @@ describe('Messages controller', () => {
                 }),
                 {
                   type: 'DATE_LABEL',
-                  timestamp: Date.UTC(2025, 0, 3),
+                  timestamp: Date.UTC(2025, 0, 1),
                 },
                 expect.objectContaining({
                   type: 'MESSAGE',
-                  messageHash: messages[3].messageHash,
+                  messageHash: messages[0].messageHash,
+                }),
+                expect.objectContaining({
+                  type: 'MESSAGE',
+                  messageHash: messages[2].messageHash,
                 }),
               ])
               .build(),

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -592,8 +592,8 @@ describe('Messages controller', () => {
           .with(
             'created',
             faker.date.between(
-              new Date(Date.UTC(2025, 0, 1)).toISOString(),
-              new Date(Date.UTC(2025, 0, 2) - 1).toISOString(),
+              new Date(Date.UTC(2025, 0, 1, 16)).toISOString(),
+              new Date(Date.UTC(2025, 0, 1, 17)).toISOString(),
             ),
           )
           .build(),
@@ -612,8 +612,8 @@ describe('Messages controller', () => {
           .with(
             'created',
             faker.date.between(
-              new Date(Date.UTC(2025, 0, 1)).toISOString(),
-              new Date(Date.UTC(2025, 0, 2) - 1).toISOString(),
+              new Date(Date.UTC(2025, 0, 1, 10)).toISOString(),
+              new Date(Date.UTC(2025, 0, 1, 11)).toISOString(),
             ),
           )
           .build(),

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { groupBy, orderBy } from 'lodash';
+import { groupBy } from 'lodash';
 import { Message as DomainMessage } from '../../domain/messages/entities/message.entity';
 import { MessagesRepository } from '../../domain/messages/messages.repository';
 import { IMessagesRepository } from '../../domain/messages/messages.repository.interface';
@@ -105,16 +105,10 @@ export class MessagesService {
         // For each group we create a tuple of the timestamp of the day
         // with the messages for that day sorted by creation in descending order
         .map((groupKey) => {
-          return [
-            Number(groupKey),
-            orderBy(
-              groups[groupKey],
-              (message) => {
-                return message.created.getTime();
-              },
-              ['desc'],
-            ),
-          ];
+          const sortedMessages = groups[groupKey].sort((m1, m2) => {
+            return m2.created.getTime() - m1.created.getTime();
+          });
+          return [Number(groupKey), sortedMessages];
         })
     );
   }


### PR DESCRIPTION
Closes #353 

The messages returned by `GET chains/:chainId/safes/:safeAddress/messages` were being returned in ascending order (regarding their creation date). Descending order should be used instead.

Additionally, the results were being ~mapped~ pushed to an external array inside a `Promise.all` therefore breaking the deterministic sorting rules required.