### PR TITLE
fix: change estimation `value` type to `string`

### DIFF
--- a/src/domain/estimations/entities/get-estimation.dto.entity.ts
+++ b/src/domain/estimations/entities/get-estimation.dto.entity.ts
@@ -2,11 +2,11 @@ import { Operation } from '../../safe/entities/operation.entity';
 
 export class GetEstimationDto {
   to: string;
-  value: number;
+  value: string;
   data: string | null;
   operation: Operation;
 
-  constructor(to: string, value: number, data: string, operation: Operation) {
+  constructor(to: string, value: string, data: string, operation: Operation) {
     this.to = to;
     this.value = value;
     this.data = data;

--- a/src/routes/estimations/entities/get-estimation.dto.entity.ts
+++ b/src/routes/estimations/entities/get-estimation.dto.entity.ts
@@ -6,7 +6,7 @@ export class GetEstimationDto implements DomainGetEstimationDto {
   @ApiProperty()
   to: string;
   @ApiProperty()
-  value: number;
+  value: string;
   @ApiPropertyOptional({ type: String, nullable: true })
   data: string | null;
   @ApiProperty()

--- a/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
+++ b/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
@@ -6,7 +6,7 @@ export const getEstimationDtoSchema: JSONSchemaType<GetEstimationDto> = {
   type: 'object',
   properties: {
     to: { type: 'string' },
-    value: { type: 'number' },
+    value: { type: 'string', pattern: '^([0-9]+)$' },
     data: { type: 'string', nullable: true },
     operation: { type: 'number', enum: [0, 1] },
   },

--- a/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
+++ b/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
@@ -6,7 +6,7 @@ export const getEstimationDtoSchema: JSONSchemaType<GetEstimationDto> = {
   type: 'object',
   properties: {
     to: { type: 'string' },
-    value: { type: 'string', pattern: '^([0-9]+)$' },
+    value: { type: 'string', pattern: '^d*.?d+$' },
     data: { type: 'string', nullable: true },
     operation: { type: 'number', enum: [0, 1] },
   },

--- a/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
+++ b/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
@@ -6,7 +6,7 @@ export const getEstimationDtoSchema: JSONSchemaType<GetEstimationDto> = {
   type: 'object',
   properties: {
     to: { type: 'string' },
-    value: { type: 'string', pattern: '^d*.?d+$' },
+    value: { type: 'string' },
     data: { type: 'string', nullable: true },
     operation: { type: 'number', enum: [0, 1] },
   },

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -107,7 +107,7 @@ describe('Estimations Controller (Unit)', () => {
         .send(
           new GetEstimationDto(
             faker.finance.ethereumAddress(),
-            faker.datatype.number(),
+            faker.random.numeric(),
             faker.datatype.hexadecimal(32),
             0,
           ),
@@ -124,7 +124,7 @@ describe('Estimations Controller (Unit)', () => {
   it('Should get a validation error', async () => {
     const getEstimationDto = new GetEstimationDto(
       faker.finance.ethereumAddress(),
-      faker.datatype.number(),
+      faker.random.numeric(),
       faker.datatype.hexadecimal(32),
       1,
     );
@@ -181,7 +181,7 @@ describe('Estimations Controller (Unit)', () => {
       .send(
         new GetEstimationDto(
           faker.finance.ethereumAddress(),
-          faker.datatype.number(),
+          faker.random.numeric(),
           faker.datatype.hexadecimal(32),
           0,
         ),
@@ -230,7 +230,7 @@ describe('Estimations Controller (Unit)', () => {
       .send(
         new GetEstimationDto(
           faker.finance.ethereumAddress(),
-          faker.datatype.number(),
+          faker.random.numeric(),
           faker.datatype.hexadecimal(32),
           0,
         ),
@@ -285,7 +285,7 @@ describe('Estimations Controller (Unit)', () => {
       .send(
         new GetEstimationDto(
           faker.finance.ethereumAddress(),
-          faker.datatype.number(),
+          faker.random.numeric(),
           faker.datatype.hexadecimal(32),
           0,
         ),


### PR DESCRIPTION
Resolves #333

`GasEstimationDto['value']` was incorrectly typed as a `number`. It has been changed to a `string` and associated validation/tests updated accordingly.