### PR TITLE
feat: validate `GetDataDecodedDto` by pattern

### DIFF
--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -6,7 +6,7 @@ export const dataDecodedParameterSchema: Schema = {
   properties: {
     name: { type: 'string' },
     type: { type: 'string' },
-    value: {},
+    value: { type: 'string' },
     valueDecoded: { type: ['object', 'array', 'null'] },
   },
   required: ['name', 'type', 'value'],

--- a/src/routes/data-decode/entities/schemas/get-data-decoded.dto.schema.ts
+++ b/src/routes/data-decode/entities/schemas/get-data-decoded.dto.schema.ts
@@ -1,12 +1,13 @@
 import { JSONSchemaType } from 'ajv';
 import { GetDataDecodedDto } from '../get-data-decoded.dto.entity';
+import { HEX_PATTERN } from '../../../../validation/patterns';
 
 export const getDataDecodedDtoSchema: JSONSchemaType<GetDataDecodedDto> = {
   $id: 'https://safe-client.safe.global/schemas/delegates/get-data-decoded.dto.json',
   type: 'object',
   properties: {
-    data: { type: 'string' },
-    to: { type: 'string', nullable: true },
+    data: { type: 'string', pattern: HEX_PATTERN },
+    to: { type: 'string', pattern: HEX_PATTERN, nullable: true },
   },
   required: ['data'],
 };

--- a/src/routes/data-decode/pipes/get-data-decoded.dto.validation.pipe.ts
+++ b/src/routes/data-decode/pipes/get-data-decoded.dto.validation.pipe.ts
@@ -2,8 +2,6 @@ import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
-import { ValidationErrorFactory } from '../../../validation/providers/validation-error-factory';
-import { isHex } from '../../common/utils/utils';
 import { GetDataDecodedDto } from '../entities/get-data-decoded.dto.entity';
 import { getDataDecodedDtoSchema } from '../entities/schemas/get-data-decoded.dto.schema';
 
@@ -16,7 +14,6 @@ export class GetDataDecodedDtoValidationPipe
   constructor(
     private readonly genericValidator: GenericValidator,
     private readonly jsonSchemaService: JsonSchemaService,
-    private readonly validationErrorFactory: ValidationErrorFactory,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/delegates/get-data-decoded.dto.json',
@@ -25,18 +22,10 @@ export class GetDataDecodedDtoValidationPipe
   }
   transform(data: any): GetDataDecodedDto {
     try {
-      this.genericValidator.validate(this.isValid, data);
-      if (!this.isGetDataDecodeDto(data)) {
-        throw this.validationErrorFactory.from([]);
-      }
-      return data as GetDataDecodedDto;
+      return this.genericValidator.validate(this.isValid, data);
     } catch (err) {
       err.status = HttpStatus.BAD_REQUEST;
       throw err;
     }
-  }
-
-  private isGetDataDecodeDto(dto: GetDataDecodedDto): dto is GetDataDecodedDto {
-    return isHex(dto.data) && isHex(dto.to);
   }
 }

--- a/src/validation/patterns.ts
+++ b/src/validation/patterns.ts
@@ -1,0 +1,1 @@
+export const HEX_PATTERN = '0[x][0-9a-fA-F]+';


### PR DESCRIPTION
Resolves #334

`GetDataDecodedDto['to']` was previously made optional, but was still being validated in `GetDataDecodedDtoValidationPipe`. This has been removed and the pipe cleaned up in favour of pattern matching in the `getDataDecodedDtoSchema` instead.