### PR TITLE
fix: return `null` if guard is empty address

### DIFF
--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -4,6 +4,7 @@ import { IContractsRepository } from '../../../domain/contracts/contracts.reposi
 import { TokenRepository } from '../../../domain/tokens/token.repository';
 import { ITokenRepository } from '../../../domain/tokens/token.repository.interface';
 import { AddressInfo } from '../entities/address-info.entity';
+import { NULL_ADDRESS } from '../constants';
 
 export type Source = 'CONTRACT' | 'TOKEN';
 
@@ -35,8 +36,7 @@ export class AddressInfoHelper {
     address: string,
     source: Source = 'CONTRACT',
   ): Promise<AddressInfo | null> {
-    if (address == '0x0000000000000000000000000000000000000000')
-      return Promise.resolve(null);
+    if (address == NULL_ADDRESS) return Promise.resolve(null);
 
     return this._getFromSource(chainId, address, source);
   }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -40,9 +40,6 @@ export class SafesService {
       supportedMasterCopies,
     );
 
-    const masterCopyInfo: AddressInfo =
-      await this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy);
-
     let moduleAddressesInfo: AddressInfo[] | null = null;
     if (safe.modules) {
       const moduleInfoCollection: Array<AddressInfo> =
@@ -51,23 +48,21 @@ export class SafesService {
         moduleInfoCollection.length == 0 ? null : moduleInfoCollection;
     }
 
-    const fallbackHandlerInfo: AddressInfo =
-      await this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler);
-
-    const guardInfo: AddressInfo = await this.addressInfoHelper.getOrDefault(
-      chainId,
-      safe.guard,
-    );
-
-    const collectiblesTag = await this.getCollectiblesTag(chainId, safeAddress);
-    const queuedTransactionTag = await this.getQueuedTransactionTag(
-      chainId,
-      safe,
-    );
-    const transactionHistoryTag = await this.executedTransactionTag(
-      chainId,
-      safeAddress,
-    );
+    const [
+      masterCopyInfo,
+      fallbackHandlerInfo,
+      guardInfo,
+      collectiblesTag,
+      queuedTransactionTag,
+      transactionHistoryTag,
+    ] = await Promise.all([
+      this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy),
+      this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler),
+      this.addressInfoHelper.get(chainId, safe.guard).catch(() => null),
+      this.getCollectiblesTag(chainId, safeAddress),
+      this.getQueuedTransactionTag(chainId, safe),
+      this.executedTransactionTag(chainId, safeAddress),
+    ]);
 
     return new SafeState(
       new AddressInfo(safe.address),


### PR DESCRIPTION
Resolves #347

`SafeState['guard']` now returns `null` if the Safe's guard is an empty address (`0x0000000000000000000000000000000000000000`). It was previously defaulting to an `AddressInfo`. Test coverage for this has been added.

Note: a chain of promises were also combined into one `Promise.all` to improve performance.