### PR TITLE
Add fallback when a token cannot be retrieved

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -103,40 +103,33 @@ export class MultisigTransactionInfoMapper {
       );
     }
 
-    if (!this.isValidTokenTransfer(transaction)) {
-      return this.customTransactionMapper.mapCustomTransaction(
-        transaction,
-        value,
-        dataSize,
-        chainId,
-      );
+    if (this.isValidTokenTransfer(transaction)) {
+      const token = await this.tokenRepository
+        .getToken(chainId, transaction.to)
+        .catch(() => null);
+
+      switch (token?.type) {
+        case TokenType.Erc20:
+          return this.erc20TransferMapper.mapErc20Transfer(
+            token,
+            chainId,
+            transaction,
+          );
+        case TokenType.Erc721:
+          return this.erc721TransferMapper.mapErc721Transfer(
+            token,
+            chainId,
+            transaction,
+          );
+      }
     }
 
-    const token = await this.tokenRepository
-      .getToken(chainId, transaction.to)
-      .catch(() => null);
-
-    switch (token?.type) {
-      case TokenType.Erc20:
-        return this.erc20TransferMapper.mapErc20Transfer(
-          token,
-          chainId,
-          transaction,
-        );
-      case TokenType.Erc721:
-        return this.erc721TransferMapper.mapErc721Transfer(
-          token,
-          chainId,
-          transaction,
-        );
-      default:
-        return this.customTransactionMapper.mapCustomTransaction(
-          transaction,
-          value,
-          dataSize,
-          chainId,
-        );
-    }
+    return this.customTransactionMapper.mapCustomTransaction(
+      transaction,
+      value,
+      dataSize,
+      chainId,
+    );
   }
 
   private isCustomTransaction(

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.spec.ts
@@ -37,7 +37,7 @@ describe('Transfer Info mapper (Unit)', () => {
     const transfer = erc20TransferBuilder().build();
     const safe = safeBuilder().build();
     const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
-    const token = tokenBuilder().build();
+    const token = tokenBuilder().with('address', transfer.tokenAddress).build();
     addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
     tokenRepository.getToken.mockResolvedValue(token);
 
@@ -68,7 +68,7 @@ describe('Transfer Info mapper (Unit)', () => {
     const transfer = erc721TransferBuilder().build();
     const safe = safeBuilder().build();
     const addressInfo = new AddressInfo(faker.finance.ethereumAddress());
-    const token = tokenBuilder().build();
+    const token = tokenBuilder().with('address', transfer.tokenAddress).build();
     addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
     tokenRepository.getToken.mockResolvedValue(token);
 

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -52,24 +52,29 @@ export class TransferInfoMapper {
   ): Promise<Transfer> {
     if (isERC20Transfer(domainTransfer)) {
       const { tokenAddress, value } = domainTransfer;
-      const token = await this.getToken(chainId, tokenAddress);
+      const token: Token | null = await this.getToken(
+        chainId,
+        tokenAddress,
+      ).catch(() => null);
       return new Erc20Transfer(
-        token.address,
+        tokenAddress,
         value,
-        token.name,
-        token.symbol,
-        token.logoUri,
-        token.decimals,
+        token?.name,
+        token?.symbol,
+        token?.logoUri,
+        token?.decimals,
       );
     } else if (isERC721Transfer(domainTransfer)) {
       const { tokenAddress, tokenId } = domainTransfer;
-      const token = await this.getToken(chainId, tokenAddress);
+      const token = await this.getToken(chainId, tokenAddress).catch(
+        () => null,
+      );
       return new Erc721Transfer(
-        token.address,
+        tokenAddress,
         tokenId,
-        token.name,
-        token.symbol,
-        token.logoUri,
+        token?.name,
+        token?.symbol,
+        token?.logoUri,
       );
     } else if (isNativeTokenTransfer(domainTransfer)) {
       return new NativeCoinTransfer(domainTransfer.value);


### PR DESCRIPTION
Depends on https://github.com/safe-global/safe-client-gateway-nest/pull/378

Adds a fallback to `MultisigTransactionInfoMapper` and `TransferInfoMapper` if the information regarding a specific token cannot be retrieved.

Previously if a token was not retrieved successfully (e.g. 404) – this error would propagate to the route and be returned to the clients.