### PR TITLE
Fix bad DataDecoded schema

### DIFF
--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -6,7 +6,7 @@ export const dataDecodedParameterSchema: Schema = {
   properties: {
     name: { type: 'string' },
     type: { type: 'string' },
-    value: { type: 'string' },
+    value: {},
     valueDecoded: { type: ['object', 'array', 'null'] },
   },
   required: ['name', 'type', 'value'],

--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -6,6 +6,7 @@ export const dataDecodedParameterSchema: Schema = {
   properties: {
     name: { type: 'string' },
     type: { type: 'string' },
+    // bypassing validation for 'value' property, it has type 'any' in the source (Transaction Service)
     value: {},
     valueDecoded: { type: ['object', 'array', 'null'] },
   },

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
@@ -94,6 +94,10 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
           .with('parameters', [
             dataDecodedParameterBuilder()
               .with('name', 'transactions')
+              .with('value', [
+                faker.random.alphaNumeric(),
+                faker.random.alphaNumeric(),
+              ])
               .with('valueDecoded', [1, 2, 3])
               .build(),
           ])


### PR DESCRIPTION
Closes #331 

This PR fixes a bad schema definition for `DataDecoded`. This `value` property was defined as `string` within its schema, but the class defines an `unknown` type for its `value` property.

(for additional reference, [this is the Transaction Service](https://github.com/safe-global/safe-transaction-service/blob/d00ad8bd891e6ab991b0c32493dadda1ab0b0c60/safe_transaction_service/contracts/tx_decoder.py#L104) type definition)

Additionally, an existing test was modified in order to verify the `value` can contain other types besides `string` (`array` was used in the test).