### PR TITLE
Fix SafeApp entity, schema, and service mappings

### DIFF
--- a/src/domain/safe-apps/entities/__tests__/safe-app-access-control.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-access-control.builder.ts
@@ -1,7 +1,16 @@
 import { faker } from '@faker-js/faker';
-import { SafeAppAccessControl } from '../safe-app-access-control.entity';
+import { random, range } from 'lodash';
 import { Builder, IBuilder } from '../../../../__tests__/builder';
+import {
+  SafeAppAccessControl,
+  SafeAppAccessControlPolicies,
+} from '../safe-app-access-control.entity';
 
 export function safeAppAccessControlBuilder(): IBuilder<SafeAppAccessControl> {
-  return Builder.new<SafeAppAccessControl>().with('type', faker.random.word());
+  return Builder.new<SafeAppAccessControl>()
+    .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
+    .with(
+      'value',
+      range(random(2, 5)).map(() => faker.internet.url()),
+    );
 }

--- a/src/domain/safe-apps/entities/__tests__/safe-app-social-profile.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app-social-profile.builder.ts
@@ -1,0 +1,9 @@
+import { faker } from '@faker-js/faker';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { SafeAppSocialProfile } from '../safe-app-social-profile.entity';
+
+export function safeAppSocialProfileBuilder(): IBuilder<SafeAppSocialProfile> {
+  return Builder.new<SafeAppSocialProfile>()
+    .with('platform', faker.random.word())
+    .with('url', faker.internet.url());
+}

--- a/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
+++ b/src/domain/safe-apps/entities/__tests__/safe-app.builder.ts
@@ -1,8 +1,10 @@
 import { faker } from '@faker-js/faker';
-import { SafeApp } from '../safe-app.entity';
+import { random, range } from 'lodash';
 import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { SafeApp } from '../safe-app.entity';
 import { safeAppAccessControlBuilder } from './safe-app-access-control.builder';
 import { safeAppProviderBuilder } from './safe-app-provider.builder';
+import { safeAppSocialProfileBuilder } from './safe-app-social-profile.builder';
 
 export function safeAppBuilder(): IBuilder<SafeApp> {
   return Builder.new<SafeApp>()
@@ -15,5 +17,10 @@ export function safeAppBuilder(): IBuilder<SafeApp> {
     .with('provider', safeAppProviderBuilder().build())
     .with('accessControl', safeAppAccessControlBuilder().build())
     .with('tags', [faker.random.word(), faker.random.word()])
-    .with('features', [faker.random.word(), faker.random.word()]);
+    .with('features', [faker.random.word(), faker.random.word()])
+    .with('developerWebsite', faker.internet.url())
+    .with(
+      'socialProfiles',
+      range(random(5)).map(() => safeAppSocialProfileBuilder().build()),
+    );
 }

--- a/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
@@ -5,6 +5,6 @@ export enum SafeAppAccessControlPolicies {
 }
 
 export interface SafeAppAccessControl {
-  type: string;
+  type: SafeAppAccessControlPolicies;
   value: string[] | null;
 }

--- a/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
@@ -1,4 +1,10 @@
+export enum SafeAppAccessControlPolicies {
+  NoRestrictions = 'NO_RESTRICTIONS',
+  DomainAllowlist = 'DOMAIN_ALLOWLIST',
+  Unknown = 'UNKNOWN',
+}
+
 export interface SafeAppAccessControl {
-  type: string;
+  type: SafeAppAccessControlPolicies;
   value: string[] | null;
 }

--- a/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
@@ -5,6 +5,6 @@ export enum SafeAppAccessControlPolicies {
 }
 
 export interface SafeAppAccessControl {
-  type: SafeAppAccessControlPolicies;
+  type: string;
   value: string[] | null;
 }

--- a/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app-access-control.entity.ts
@@ -1,3 +1,4 @@
 export interface SafeAppAccessControl {
   type: string;
+  value: string[] | null;
 }

--- a/src/domain/safe-apps/entities/safe-app-social-profile.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app-social-profile.entity.ts
@@ -1,0 +1,4 @@
+export interface SafeAppSocialProfile {
+  platform: string;
+  url: string;
+}

--- a/src/domain/safe-apps/entities/safe-app.entity.ts
+++ b/src/domain/safe-apps/entities/safe-app.entity.ts
@@ -1,5 +1,6 @@
 import { SafeAppAccessControl } from './safe-app-access-control.entity';
 import { SafeAppProvider } from './safe-app-provider.entity';
+import { SafeAppSocialProfile } from './safe-app-social-profile.entity';
 
 export interface SafeApp {
   id: number;
@@ -12,4 +13,6 @@ export interface SafeApp {
   accessControl: SafeAppAccessControl;
   tags: string[];
   features: string[];
+  developerWebsite: string | null;
+  socialProfiles: SafeAppSocialProfile[];
 }

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -39,10 +39,7 @@ export const safeAppAccessControlSchema: JSONSchemaType<SafeAppAccessControl> =
         properties: {
           type: {
             type: 'string',
-            enum: [
-              SafeAppAccessControlPolicies.NoRestrictions,
-              SafeAppAccessControlPolicies.Unknown,
-            ],
+            not: { enum: [SafeAppAccessControlPolicies.DomainAllowlist] },
           },
         },
       },

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -1,5 +1,8 @@
 import { JSONSchemaType, Schema } from 'ajv';
-import { SafeAppAccessControl } from '../safe-app-access-control.entity';
+import {
+  SafeAppAccessControl,
+  SafeAppAccessControlPolicies,
+} from '../safe-app-access-control.entity';
 import { SafeAppProvider } from '../safe-app-provider.entity';
 import { SafeAppSocialProfile } from '../safe-app-social-profile.entity';
 
@@ -17,10 +20,33 @@ export const safeAppAccessControlSchema: JSONSchemaType<SafeAppAccessControl> =
   {
     $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app-access-control.json',
     type: 'object',
-    properties: {
-      type: { type: 'string' },
-      value: { type: 'array', items: { type: 'string' }, nullable: true },
-    },
+    anyOf: [
+      {
+        properties: {
+          type: {
+            type: 'string',
+            enum: [SafeAppAccessControlPolicies.DomainAllowlist],
+          },
+          value: {
+            type: 'array',
+            items: { type: 'string', format: 'uri' },
+            nullable: true,
+          },
+        },
+        required: ['type', 'value'],
+      },
+      {
+        properties: {
+          type: {
+            type: 'string',
+            enum: [
+              SafeAppAccessControlPolicies.NoRestrictions,
+              SafeAppAccessControlPolicies.Unknown,
+            ],
+          },
+        },
+      },
+    ],
     required: ['type'],
   };
 
@@ -30,7 +56,7 @@ export const safeAppSocialProfileSchema: JSONSchemaType<SafeAppSocialProfile> =
     type: 'object',
     properties: {
       platform: { type: 'string' },
-      url: { type: 'string' },
+      url: { type: 'string', format: 'uri' },
     },
     required: ['platform', 'url'],
   };
@@ -49,7 +75,7 @@ export const safeAppSchema: Schema = {
     accessControl: { $ref: 'safe-app-access-control.json' },
     tags: { type: 'array', items: { type: 'string' } },
     features: { type: 'array', items: { type: 'string' } },
-    developerWebsite: { type: 'string', nullable: true },
+    developerWebsite: { type: 'string', format: 'uri', nullable: true },
     socialProfiles: {
       type: 'array',
       items: { $ref: 'safe-app-social-profile.json' },

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -1,6 +1,7 @@
 import { JSONSchemaType, Schema } from 'ajv';
 import { SafeAppAccessControl } from '../safe-app-access-control.entity';
 import { SafeAppProvider } from '../safe-app-provider.entity';
+import { SafeAppSocialProfile } from '../safe-app-social-profile.entity';
 
 export const safeAppProviderSchema: JSONSchemaType<SafeAppProvider> = {
   $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app-provider.json',
@@ -18,8 +19,20 @@ export const safeAppAccessControlSchema: JSONSchemaType<SafeAppAccessControl> =
     type: 'object',
     properties: {
       type: { type: 'string' },
+      value: { type: 'array', items: { type: 'string' }, nullable: true },
     },
     required: ['type'],
+  };
+
+export const safeAppSocialProfileSchema: JSONSchemaType<SafeAppSocialProfile> =
+  {
+    $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app-social-profile.json',
+    type: 'object',
+    properties: {
+      platform: { type: 'string' },
+      url: { type: 'string' },
+    },
+    required: ['platform', 'url'],
   };
 
 export const safeAppSchema: Schema = {
@@ -36,6 +49,11 @@ export const safeAppSchema: Schema = {
     accessControl: { $ref: 'safe-app-access-control.json' },
     tags: { type: 'array', items: { type: 'string' } },
     features: { type: 'array', items: { type: 'string' } },
+    developerWebsite: { type: 'string', nullable: true },
+    socialProfiles: {
+      type: 'array',
+      items: { $ref: 'safe-app-social-profile.json' },
+    },
   },
   required: [
     'id',
@@ -47,5 +65,6 @@ export const safeAppSchema: Schema = {
     'accessControl',
     'tags',
     'features',
+    'socialProfiles',
   ],
 };

--- a/src/domain/safe-apps/safe-apps.validator.ts
+++ b/src/domain/safe-apps/safe-apps.validator.ts
@@ -8,6 +8,7 @@ import {
   safeAppAccessControlSchema,
   safeAppProviderSchema,
   safeAppSchema,
+  safeAppSocialProfileSchema,
 } from './entities/schemas/safe-app.schema';
 
 @Injectable()
@@ -26,6 +27,11 @@ export class SafeAppsValidator implements IValidator<SafeApp> {
     this.jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/safe-apps/safe-app-access-control.json',
       safeAppAccessControlSchema,
+    );
+
+    this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/safe-apps/safe-app-social-profile.json',
+      safeAppSocialProfileSchema,
     );
 
     this.isValidSafeApp = this.jsonSchemaService.getSchema(

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -1,10 +1,10 @@
-import * as request from 'supertest';
-import { RedisClientType } from 'redis';
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { RedisClientType } from 'redis';
+import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
-import { redisClientFactory } from '../../../__tests__/redis-client.factory';
 import { TestAppProvider } from '../../../app.provider';
+import { redisClientFactory } from '../../../__tests__/redis-client.factory';
 
 describe('Get Safe Apps e2e test', () => {
   let app: INestApplication;
@@ -32,9 +32,9 @@ describe('Get Safe Apps e2e test', () => {
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safe-apps`)
       .expect(200)
-      .then(({ body }) => {
-        expect(body).toEqual(expect.any(Array));
-        body.map((safeApp) =>
+      .expect(({ body }) => {
+        expect(body).toBeInstanceOf(Array);
+        body.forEach((safeApp) =>
           expect(safeApp).toEqual(
             expect.objectContaining({
               id: expect.any(Number),
@@ -69,8 +69,8 @@ describe('Get Safe Apps e2e test', () => {
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safe-apps/?url=${transactionBuilderUrl}`)
       .expect(200)
-      .then(({ body }) => {
-        expect(body).toEqual(expect.any(Array));
+      .expect(({ body }) => {
+        expect(body).toBeInstanceOf(Array);
         expect(body.length).toBe(1);
         expect(body[0]).toEqual(
           expect.objectContaining({

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -41,6 +41,14 @@ describe('Get Safe Apps e2e test', () => {
               name: expect.any(String),
               url: expect.any(String),
               chainIds: expect.arrayContaining([chainId]),
+              iconUrl: expect.any(String),
+              description: expect.any(String),
+              accessControl: expect.objectContaining({
+                type: expect.any(String),
+              }),
+              tags: expect.any(Array),
+              features: expect.any(Array),
+              socialProfiles: expect.any(Array),
             }),
           ),
         );
@@ -70,6 +78,14 @@ describe('Get Safe Apps e2e test', () => {
             name: 'Transaction Builder',
             url: transactionBuilderUrl,
             chainIds: expect.arrayContaining([chainId]),
+            iconUrl: expect.any(String),
+            description: expect.any(String),
+            accessControl: expect.objectContaining({
+              type: expect.any(String),
+            }),
+            tags: expect.any(Array),
+            features: expect.any(Array),
+            socialProfiles: expect.any(Array),
           }),
         );
       });

--- a/src/routes/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-access-control.entity.ts
@@ -1,7 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SafeAppAccessControl as DomainSafeAppAccessControl } from '../../../domain/safe-apps/entities/safe-app-access-control.entity';
 
 export class SafeAppAccessControl implements DomainSafeAppAccessControl {
   @ApiProperty()
   type: string;
+  @ApiPropertyOptional({ type: String, isArray: true, nullable: true })
+  value: string[] | null;
 }

--- a/src/routes/safe-apps/entities/safe-app-access-control.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-access-control.entity.ts
@@ -1,9 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { SafeAppAccessControl as DomainSafeAppAccessControl } from '../../../domain/safe-apps/entities/safe-app-access-control.entity';
+import {
+  SafeAppAccessControl as DomainSafeAppAccessControl,
+  SafeAppAccessControlPolicies,
+} from '../../../domain/safe-apps/entities/safe-app-access-control.entity';
 
 export class SafeAppAccessControl implements DomainSafeAppAccessControl {
   @ApiProperty()
-  type: string;
+  type: SafeAppAccessControlPolicies;
   @ApiPropertyOptional({ type: String, isArray: true, nullable: true })
   value: string[] | null;
 }

--- a/src/routes/safe-apps/entities/safe-app-social-profile.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app-social-profile.entity.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SafeAppSocialProfile as DomainSafeAppSocialProfile } from '../../../domain/safe-apps/entities/safe-app-social-profile.entity';
+
+export class SafeAppSocialProfile implements DomainSafeAppSocialProfile {
+  @ApiProperty()
+  platform: string;
+  @ApiProperty()
+  url: string;
+}

--- a/src/routes/safe-apps/entities/safe-app.entity.ts
+++ b/src/routes/safe-apps/entities/safe-app.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SafeAppAccessControl } from './safe-app-access-control.entity';
 import { SafeAppProvider } from './safe-app-provider.entity';
+import { SafeAppSocialProfile } from './safe-app-social-profile.entity';
 
 export class SafeApp {
   @ApiProperty()
@@ -15,12 +16,18 @@ export class SafeApp {
   description: string;
   @ApiProperty()
   chainIds: string[];
+  @ApiPropertyOptional({ type: SafeAppProvider, nullable: true })
+  provider: SafeAppProvider | null;
   @ApiProperty()
   accessControl: SafeAppAccessControl;
   @ApiProperty()
   tags: string[];
-  @ApiPropertyOptional({ type: SafeAppProvider, nullable: true })
-  provider: SafeAppProvider | null;
+  @ApiProperty()
+  features: string[];
+  @ApiPropertyOptional({ type: String, nullable: true })
+  developerWebsite: string | null;
+  @ApiProperty({ type: SafeAppSocialProfile })
+  socialProfiles: SafeAppSocialProfile[];
 
   constructor(
     id: number,
@@ -29,9 +36,12 @@ export class SafeApp {
     iconUrl: string,
     description: string,
     chainIds: string[],
+    provider: SafeAppProvider | null,
     accessControl: SafeAppAccessControl,
     tags: string[],
-    provider: SafeAppProvider | null,
+    features: string[],
+    developerWebsite: string | null,
+    socialProfiles: SafeAppSocialProfile[],
   ) {
     this.id = id;
     this.url = url;
@@ -39,8 +49,11 @@ export class SafeApp {
     this.iconUrl = iconUrl;
     this.description = description;
     this.chainIds = chainIds;
+    this.provider = provider;
     this.accessControl = accessControl;
     this.tags = tags;
-    this.provider = provider;
+    this.features = features;
+    this.developerWebsite = developerWebsite;
+    this.socialProfiles = socialProfiles;
   }
 }

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -1,0 +1,184 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { TestAppProvider } from '../../app.provider';
+import {
+  fakeConfigurationService,
+  TestConfigurationModule,
+} from '../../config/__tests__/test.configuration.module';
+import {
+  fakeCacheService,
+  TestCacheModule,
+} from '../../datasources/cache/__tests__/test.cache.module';
+import {
+  mockNetworkService,
+  TestNetworkModule,
+} from '../../datasources/network/__tests__/test.network.module';
+import { DomainModule } from '../../domain.module';
+import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
+import { SafeAppAccessControlPolicies } from '../../domain/safe-apps/entities/safe-app-access-control.entity';
+import { safeAppAccessControlBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app-access-control.builder';
+import { safeAppBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app.builder';
+import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
+import { ValidationModule } from '../../validation/validation.module';
+import { SafeAppsModule } from './safe-apps.module';
+
+describe('Safe Apps Controller (Unit)', () => {
+  let app: INestApplication;
+  let safeConfigApiUrl: string;
+
+  beforeAll(async () => {
+    safeConfigApiUrl = faker.internet.url();
+    fakeConfigurationService.set('safeConfig.baseUri', safeConfigApiUrl);
+    fakeConfigurationService.set('exchange.baseUri', faker.internet.url());
+    fakeConfigurationService.set('exchange.apiKey', faker.datatype.uuid());
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fakeCacheService.clear();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        // feature
+        SafeAppsModule,
+        // common
+        DomainModule,
+        TestCacheModule,
+        TestConfigurationModule,
+        TestLoggingModule,
+        TestNetworkModule,
+        ValidationModule,
+      ],
+    }).compile();
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('Get Safe Apps', () => {
+    it('Success with DOMAIN_ALLOWLIST accessControl', async () => {
+      const chain = chainBuilder().build();
+      const safeAppsResponse = [
+        safeAppBuilder().build(),
+        safeAppBuilder()
+          .with(
+            'accessControl',
+            safeAppAccessControlBuilder()
+              .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
+              .build(),
+          )
+          .build(),
+      ];
+
+      mockNetworkService.get.mockImplementation((url) => {
+        const getSafeAppsUrl = `${safeConfigApiUrl}/api/v1/safe-apps/`;
+        if (url === getSafeAppsUrl) {
+          return Promise.resolve({ data: safeAppsResponse });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/safe-apps`)
+        .expect(200);
+    });
+
+    it('Success with NO_RESTRICTIONS accessControl', async () => {
+      const chain = chainBuilder().build();
+      const safeAppsResponse = [
+        safeAppBuilder().build(),
+        safeAppBuilder()
+          .with(
+            'accessControl',
+            safeAppAccessControlBuilder()
+              .with('type', SafeAppAccessControlPolicies.NoRestrictions)
+              .with('value', null)
+              .build(),
+          )
+          .build(),
+      ];
+
+      mockNetworkService.get.mockImplementation((url) => {
+        const getSafeAppsUrl = `${safeConfigApiUrl}/api/v1/safe-apps/`;
+        if (url === getSafeAppsUrl) {
+          return Promise.resolve({ data: safeAppsResponse });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/safe-apps`)
+        .expect(200);
+    });
+
+    it('Success with UNKNOWN accessControl', async () => {
+      const chain = chainBuilder().build();
+      const safeAppsResponse = [
+        safeAppBuilder().build(),
+        safeAppBuilder()
+          .with(
+            'accessControl',
+            safeAppAccessControlBuilder()
+              .with('type', SafeAppAccessControlPolicies.Unknown)
+              .with('value', null)
+              .build(),
+          )
+          .build(),
+      ];
+
+      mockNetworkService.get.mockImplementation((url) => {
+        const getSafeAppsUrl = `${safeConfigApiUrl}/api/v1/safe-apps/`;
+        if (url === getSafeAppsUrl) {
+          return Promise.resolve({ data: safeAppsResponse });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/safe-apps`)
+        .expect(200);
+    });
+
+    it('Should get a data source validation error: DOMAIN_ALLOWLIST values are not URIs', async () => {
+      const chain = chainBuilder().build();
+      const safeAppsResponse = [
+        safeAppBuilder().build(),
+        safeAppBuilder()
+          .with(
+            'accessControl',
+            safeAppAccessControlBuilder()
+              .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
+              .with('value', [
+                faker.datatype.hexadecimal(),
+                faker.datatype.hexadecimal(),
+              ])
+              .build(),
+          )
+          .build(),
+      ];
+
+      mockNetworkService.get.mockImplementation((url) => {
+        const getSafeAppsUrl = `${safeConfigApiUrl}/api/v1/safe-apps/`;
+        if (url === getSafeAppsUrl) {
+          return Promise.resolve({ data: safeAppsResponse });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+
+      await request(app.getHttpServer())
+        .get(`/v1/chains/${chain.chainId}/safe-apps`)
+        .expect(500)
+        .expect({
+          message: 'Validation failed',
+          code: 42,
+          arguments: [],
+        });
+    });
+  });
+});

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
+import { SafeAppAccessControlPolicies } from '../../domain/safe-apps/entities/safe-app-access-control.entity';
 import { safeAppAccessControlBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app-access-control.builder';
 import { safeAppBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app.builder';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
@@ -68,7 +69,7 @@ describe('Safe Apps Controller (Unit)', () => {
           .with(
             'accessControl',
             safeAppAccessControlBuilder()
-              .with('type', 'DOMAIN_ALLOWLIST')
+              .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
               .build(),
           )
           .build(),
@@ -76,13 +77,11 @@ describe('Safe Apps Controller (Unit)', () => {
           .with(
             'accessControl',
             safeAppAccessControlBuilder()
-              .with('type', 'NO_RESTRICTIONS')
-              .with('value', null)
+              .with('type', SafeAppAccessControlPolicies.NoRestrictions)
               .build(),
           )
           .build(),
       ];
-
       mockNetworkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigApiUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
@@ -131,22 +130,21 @@ describe('Safe Apps Controller (Unit)', () => {
 
     it('Success with UNKNOWN accessControl', async () => {
       const chain = chainBuilder().build();
-      const safeAppsResponse = [
-        safeAppBuilder()
-          .with(
-            'accessControl',
-            safeAppAccessControlBuilder()
-              .with('type', faker.random.word())
-              .with('value', null)
-              .build(),
-          )
-          .build(),
-      ];
-
+      const safeAppsResponse = [safeAppBuilder().build()];
       mockNetworkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigApiUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
-          return Promise.resolve({ data: safeAppsResponse });
+          return Promise.resolve({
+            data: [
+              {
+                ...safeAppsResponse[0],
+                accessControl: {
+                  type: faker.random.word(),
+                  value: safeAppsResponse[0].accessControl.value,
+                },
+              },
+            ],
+          });
         }
         return Promise.reject(new Error(`Could not match ${url}`));
       });
@@ -180,7 +178,7 @@ describe('Safe Apps Controller (Unit)', () => {
           .with(
             'accessControl',
             safeAppAccessControlBuilder()
-              .with('type', 'DOMAIN_ALLOWLIST')
+              .with('type', SafeAppAccessControlPolicies.DomainAllowlist)
               .with('value', [
                 faker.datatype.hexadecimal(),
                 faker.datatype.hexadecimal(),

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -94,11 +94,39 @@ describe('Safe Apps Controller (Unit)', () => {
       await request(app.getHttpServer())
         .get(`/v1/chains/${chain.chainId}/safe-apps`)
         .expect(200)
-        .expect(({ body }) => {
-          expect(body).toBeInstanceOf(Array);
-          expect(body[0].accessControl.type).toBe('DOMAIN_ALLOWLIST');
-          expect(body[1].accessControl.type).toBe('NO_RESTRICTIONS');
-        });
+        .expect([
+          {
+            id: safeAppsResponse[0].id,
+            url: safeAppsResponse[0].url,
+            name: safeAppsResponse[0].name,
+            iconUrl: safeAppsResponse[0].iconUrl,
+            description: safeAppsResponse[0].description,
+            chainIds: safeAppsResponse[0].chainIds.map((c) => c.toString()),
+            provider: safeAppsResponse[0].provider,
+            accessControl: {
+              type: 'DOMAIN_ALLOWLIST',
+              value: safeAppsResponse[0].accessControl.value,
+            },
+            tags: safeAppsResponse[0].tags,
+            features: safeAppsResponse[0].features,
+            developerWebsite: safeAppsResponse[0].developerWebsite,
+            socialProfiles: safeAppsResponse[0].socialProfiles,
+          },
+          {
+            id: safeAppsResponse[1].id,
+            url: safeAppsResponse[1].url,
+            name: safeAppsResponse[1].name,
+            iconUrl: safeAppsResponse[1].iconUrl,
+            description: safeAppsResponse[1].description,
+            chainIds: safeAppsResponse[1].chainIds.map((c) => c.toString()),
+            provider: safeAppsResponse[1].provider,
+            accessControl: { type: 'NO_RESTRICTIONS' },
+            tags: safeAppsResponse[1].tags,
+            features: safeAppsResponse[1].features,
+            developerWebsite: safeAppsResponse[1].developerWebsite,
+            socialProfiles: safeAppsResponse[1].socialProfiles,
+          },
+        ]);
     });
 
     it('Success with UNKNOWN accessControl', async () => {
@@ -126,10 +154,22 @@ describe('Safe Apps Controller (Unit)', () => {
       await request(app.getHttpServer())
         .get(`/v1/chains/${chain.chainId}/safe-apps`)
         .expect(200)
-        .expect(({ body }) => {
-          expect(body).toBeInstanceOf(Array);
-          expect(body[0].accessControl.type).toBe('UNKNOWN');
-        });
+        .expect([
+          {
+            id: safeAppsResponse[0].id,
+            url: safeAppsResponse[0].url,
+            name: safeAppsResponse[0].name,
+            iconUrl: safeAppsResponse[0].iconUrl,
+            description: safeAppsResponse[0].description,
+            chainIds: safeAppsResponse[0].chainIds.map((c) => c.toString()),
+            provider: safeAppsResponse[0].provider,
+            accessControl: { type: 'UNKNOWN' },
+            tags: safeAppsResponse[0].tags,
+            features: safeAppsResponse[0].features,
+            developerWebsite: safeAppsResponse[0].developerWebsite,
+            socialProfiles: safeAppsResponse[0].socialProfiles,
+          },
+        ]);
     });
 
     it('Should get a data source validation error: DOMAIN_ALLOWLIST values are not URIs', async () => {

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -29,9 +29,12 @@ export class SafeAppsService {
           safeApp.iconUrl,
           safeApp.description,
           safeApp.chainIds.map((chainId) => chainId.toString()),
+          safeApp.provider,
           safeApp.accessControl,
           safeApp.tags,
-          safeApp.provider,
+          safeApp.features,
+          safeApp.developerWebsite,
+          safeApp.socialProfiles,
         ),
     );
   }

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -1,6 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { SafeAppAccessControlPolicies } from '../../domain/safe-apps/entities/safe-app-access-control.entity';
+import { SafeApp as DomainSafeApp } from '../../domain/safe-apps/entities/safe-app.entity';
 import { SafeAppsRepository } from '../../domain/safe-apps/safe-apps.repository';
 import { ISafeAppsRepository } from '../../domain/safe-apps/safe-apps.repository.interface';
+import { SafeAppAccessControl } from './entities/safe-app-access-control.entity';
 import { SafeApp } from './entities/safe-app.entity';
 
 @Injectable()
@@ -20,6 +23,7 @@ export class SafeAppsService {
       clientUrl,
       url,
     );
+
     return result.map(
       (safeApp) =>
         new SafeApp(
@@ -30,12 +34,34 @@ export class SafeAppsService {
           safeApp.description,
           safeApp.chainIds.map((chainId) => chainId.toString()),
           safeApp.provider,
-          safeApp.accessControl,
+          this._parseAccessControl(safeApp),
           safeApp.tags,
           safeApp.features,
           safeApp.developerWebsite,
           safeApp.socialProfiles,
         ),
     );
+  }
+
+  private _parseAccessControl(
+    domainSafeApp: DomainSafeApp,
+  ): SafeAppAccessControl {
+    switch (domainSafeApp.accessControl.type) {
+      case SafeAppAccessControlPolicies.NoRestrictions:
+        return <SafeAppAccessControl>{
+          type: SafeAppAccessControlPolicies.NoRestrictions,
+          value: domainSafeApp.accessControl.value,
+        };
+      case SafeAppAccessControlPolicies.DomainAllowlist:
+        return <SafeAppAccessControl>{
+          type: SafeAppAccessControlPolicies.DomainAllowlist,
+          value: domainSafeApp.accessControl.value,
+        };
+      default:
+        return <SafeAppAccessControl>{
+          type: SafeAppAccessControlPolicies.Unknown,
+          value: domainSafeApp.accessControl.value,
+        };
+    }
   }
 }


### PR DESCRIPTION
Closes #338 

This PR:
- Adds `developerWebsite` and `socialProfiles` properties to `SafeApp` route entity, and adjust related mappings, schemas, and test builders.
- Adjust `SafeAppAccessControl` to include a nullable `value` ([Rust implementation ref](https://github.com/safe-global/safe-client-gateway/blob/e0d69faabd0a05d858eec81f235acc0945ac0993/src/routes/safe_apps/models.rs#L43)).
- `SafeAppAccessControl.value` returns an array of URIs (if provided) when `SafeAppAccessControl.type` is `DOMAIN_ALLOWLIST`.
- `SafeAppAccessControl.type` is `UNKNOWN` when the value received from the Config Service is different from `DOMAIN_ALLOWLIST` or `NO_RESTRICTIONS`.
- Adapts the related unit/e2e tests.
- Adapts the OpenApi specification to the new properties.