### PR TITLE
Add support for multiple sources in AddressInfoHelper

### DIFF
--- a/src/routes/messages/mappers/message-mapper.ts
+++ b/src/routes/messages/mappers/message-mapper.ts
@@ -58,6 +58,7 @@ export class MessageMapper {
     const proposedBy = await this.addressInfoHelper.getOrDefault(
       chainId,
       message.proposedBy,
+      ['CONTRACT'],
     );
     const confirmations = await this.mapConfirmations(
       chainId,
@@ -93,6 +94,7 @@ export class MessageMapper {
         const owner = await this.addressInfoHelper.getOrDefault(
           chainId,
           confirmation.owner,
+          ['CONTRACT'],
         );
         return new MessageConfirmation(owner, confirmation.signature);
       }),

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -41,22 +41,29 @@ export class SafesService {
     );
 
     const masterCopyInfo: AddressInfo =
-      await this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy);
+      await this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy, [
+        'CONTRACT',
+      ]);
 
     let moduleAddressesInfo: AddressInfo[] | null = null;
     if (safe.modules) {
       const moduleInfoCollection: Array<AddressInfo> =
-        await this.addressInfoHelper.getCollection(chainId, safe.modules);
+        await this.addressInfoHelper.getCollection(chainId, safe.modules, [
+          'CONTRACT',
+        ]);
       moduleAddressesInfo =
         moduleInfoCollection.length == 0 ? null : moduleInfoCollection;
     }
 
     const fallbackHandlerInfo: AddressInfo =
-      await this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler);
+      await this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler, [
+        'CONTRACT',
+      ]);
 
     const guardInfo: AddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       safe.guard,
+      ['CONTRACT'],
     );
 
     const collectiblesTag = await this.getCollectiblesTag(chainId, safeAddress);

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -465,9 +465,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
           txInfo: {
             type: 'Custom',
             to: {
-              value: contract.address,
-              name: contract.displayName,
-              logoUri: contract.logoUri,
+              value: token.address,
+              name: token.name,
+              logoUri: token.logoUri,
             },
             dataSize: '16',
             value: Number(tx.value).toString(),

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -143,7 +143,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-      const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/`;
+      const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/0xdc31Ee1784292379Fbb2964b3B9C4124D8F89C60`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chain });
       }
@@ -166,7 +166,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
           detail: 'Not found',
         });
       }
-      if (url.includes(getTokenUrlPattern)) {
+      if (url === getTokenUrlPattern) {
         return Promise.resolve({
           data: getJsonResource(
             'incoming-transfers/erc20/token-source-data.json',
@@ -195,7 +195,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-      const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/`;
+      const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chain });
       }
@@ -218,7 +218,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
           detail: 'Not found',
         });
       }
-      if (url.includes(getTokenUrlPattern)) {
+      if (url === getTokenUrlPattern) {
         return Promise.resolve({
           data: getJsonResource(
             'incoming-transfers/erc721/token-source-data.json',

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -154,7 +154,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chain.transactionService}/api/v1/contracts/`;
-      const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/`;
+      const getTokenUrlPattern = `${chain.transactionService}/api/v1/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chain });
       }
@@ -177,7 +177,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
           detail: 'Not found',
         });
       }
-      if (url.includes(getTokenUrlPattern)) {
+      if (url === getTokenUrlPattern) {
         return Promise.resolve({
           data: getJsonResource(
             'multisig-transactions/erc20/token-source-data.json',
@@ -206,7 +206,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
-      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/0x7Af3460d552f832fD7E2DE973c628ACeA59B0712`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse });
       }
@@ -229,7 +229,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
           detail: 'Not found',
         });
       }
-      if (url.includes(getTokenUrlPattern)) {
+      if (url === getTokenUrlPattern) {
         return Promise.resolve({
           data: getJsonResource(
             'multisig-transactions/erc721/token-source-data.json',

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
@@ -22,6 +22,7 @@ export class CustomTransactionMapper {
     const toAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       transaction.to,
+      ['TOKEN', 'CONTRACT'],
     );
 
     return new CustomTransactionInfo(

--- a/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc20-transfer.mapper.ts
@@ -34,10 +34,13 @@ export class Erc20TransferMapper {
     const senderAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       sender,
+      ['TOKEN', 'CONTRACT'],
     );
+
     const recipientAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       recipient,
+      ['TOKEN', 'CONTRACT'],
     );
 
     return new TransferTransactionInfo(

--- a/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/erc721-transfer.mapper.ts
@@ -34,10 +34,13 @@ export class Erc721TransferMapper {
     const senderAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       sender,
+      ['TOKEN', 'CONTRACT'],
     );
+
     const recipientAddressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       recipient,
+      ['TOKEN', 'CONTRACT'],
     );
 
     return new TransferTransactionInfo(

--- a/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
@@ -22,6 +22,7 @@ export class NativeCoinTransferMapper {
     const recipient = await this.addressInfoHelper.getOrDefault(
       chainId,
       transaction.to,
+      ['TOKEN', 'CONTRACT'],
     );
 
     return new TransferTransactionInfo(

--- a/src/routes/transactions/mappers/common/settings-change.mapper.ts
+++ b/src/routes/transactions/mappers/common/settings-change.mapper.ts
@@ -59,6 +59,7 @@ export class SettingsChangeMapper {
     const addressInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       handler,
+      ['CONTRACT'],
     );
     return new SetFallbackHandler(addressInfo);
   }
@@ -123,6 +124,7 @@ export class SettingsChangeMapper {
     const implementationInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       implementation,
+      ['CONTRACT'],
     );
     return new ChangeMasterCopy(implementationInfo);
   }
@@ -141,6 +143,7 @@ export class SettingsChangeMapper {
     const moduleInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       module,
+      ['CONTRACT'],
     );
     return new EnableModule(moduleInfo);
   }
@@ -159,6 +162,7 @@ export class SettingsChangeMapper {
     const moduleInfo = await this.addressInfoHelper.getOrDefault(
       chainId,
       module,
+      ['CONTRACT'],
     );
     return new DisableModule(moduleInfo);
   }
@@ -190,6 +194,7 @@ export class SettingsChangeMapper {
       const guardAddressInfo = await this.addressInfoHelper.getOrDefault(
         chainId,
         guardValue,
+        ['CONTRACT'],
       );
       return new SetGuard(guardAddressInfo);
     } else {

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -37,6 +37,7 @@ export class TransactionDataMapper {
     const toAddress = await this.addressInfoHelper.getOrDefault(
       chainId,
       previewTransactionDto.to,
+      ['CONTRACT'],
     );
     const isTrustedDelegateCall = await this.isTrustedDelegateCall(
       chainId,
@@ -170,8 +171,7 @@ export class TransactionDataMapper {
   ): Promise<AddressInfo | null> {
     if (typeof value === 'string' && value !== NULL_ADDRESS) {
       const addressInfo = await this.addressInfoHelper
-        .get(chainId, value, 'TOKEN')
-        .catch(() => this.addressInfoHelper.get(chainId, value, 'CONTRACT'))
+        .get(chainId, value, ['TOKEN', 'CONTRACT'])
         .catch(() => null);
       return addressInfo?.name ? addressInfo : null;
     }

--- a/src/routes/transactions/mappers/creation-transaction/creation-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/creation-transaction/creation-transaction.mapper.ts
@@ -9,6 +9,7 @@ import { CreationTransactionInfo } from '../../entities/creation-transaction-inf
 @Injectable()
 export class CreationTransactionMapper {
   private static readonly TRANSACTION_TYPE = 'creation';
+
   constructor(private readonly addressInfoHelper: AddressInfoHelper) {}
 
   async mapTransaction(
@@ -19,16 +20,19 @@ export class CreationTransactionMapper {
     const creator = await this.addressInfoHelper.getOrDefault(
       chainId,
       transaction.creator,
+      ['CONTRACT'],
     );
     const implementation = transaction.masterCopy
       ? await this.addressInfoHelper.getOrDefault(
           chainId,
           transaction.masterCopy,
+          ['CONTRACT'],
         )
       : null;
     const factory = await this.addressInfoHelper.getOrDefault(
       chainId,
       transaction.factoryAddress,
+      ['CONTRACT'],
     );
     const txInfo = new CreationTransactionInfo(
       creator,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
@@ -29,7 +29,9 @@ export class ModuleTransactionDetailsMapper {
     safe: Safe,
   ): Promise<TransactionDetails> {
     const [moduleAddress, txInfo, txData] = await Promise.all([
-      this.addressInfoHelper.getOrDefault(chainId, transaction.module),
+      this.addressInfoHelper.getOrDefault(chainId, transaction.module, [
+        'CONTRACT',
+      ]),
       this.transactionInfoMapper.mapTransactionInfo(chainId, transaction, safe),
       this.mapTransactionData(chainId, transaction),
     ]);
@@ -63,7 +65,10 @@ export class ModuleTransactionDetailsMapper {
           transaction.to,
           transaction.dataDecoded,
         ),
-        this.addressInfoHelper.getOrDefault(chainId, transaction.to),
+        this.addressInfoHelper.getOrDefault(chainId, transaction.to, [
+          'TOKEN',
+          'CONTRACT',
+        ]),
       ]);
 
     return {

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -31,7 +31,9 @@ export class ModuleTransactionMapper {
       safe,
     );
     const executionInfo = new ModuleExecutionInfo(
-      await this.addressInfoHelper.getOrDefault(chainId, transaction.module),
+      await this.addressInfoHelper.getOrDefault(chainId, transaction.module, [
+        'CONTRACT',
+      ]),
     );
     return new Transaction(
       `${MODULE_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${transaction.safe}${TRANSACTION_ID_SEPARATOR}${transaction.moduleTransactionId}`,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -8,8 +8,8 @@ import { Token } from '../../../../domain/tokens/entities/token.entity';
 import { TokenRepository } from '../../../../domain/tokens/token.repository';
 import { ITokenRepository } from '../../../../domain/tokens/token.repository.interface';
 import {
-  LoggingService,
   ILoggingService,
+  LoggingService,
 } from '../../../../logging/logging.interface';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { NULL_ADDRESS } from '../../../common/constants';
@@ -123,13 +123,16 @@ export class MultisigTransactionDetailsMapper {
     );
     promises.push(
       transaction.executor
-        ? this.addressInfoHelper.getOrDefault(chainId, transaction.executor)
+        ? this.addressInfoHelper.getOrDefault(chainId, transaction.executor, [
+            'CONTRACT',
+          ])
         : Promise.resolve(null),
     );
     promises.push(
       this.addressInfoHelper.getOrDefault(
         chainId,
         transaction.refundReceiver ?? NULL_ADDRESS,
+        ['CONTRACT'],
       ),
     );
     promises.push(
@@ -172,16 +175,10 @@ export class MultisigTransactionDetailsMapper {
     chainId: string,
     address: string,
   ): Promise<AddressInfo> {
-    try {
-      const tokenAddressInfo = await this.addressInfoHelper.get(
-        chainId,
-        address,
-        'TOKEN',
-      );
-      return tokenAddressInfo ?? new AddressInfo(address);
-    } catch (err) {
-      return this.addressInfoHelper.getOrDefault(chainId, address, 'CONTRACT');
-    }
+    return await this.addressInfoHelper.getOrDefault(chainId, address, [
+      'TOKEN',
+      'CONTRACT',
+    ]);
   }
 
   /**

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -34,8 +34,16 @@ export class TransferInfoMapper {
     safe: Safe,
   ): Promise<TransferTransactionInfo> {
     const { from, to } = domainTransfer;
-    const sender = await this.addressInfoHelper.getOrDefault(chainId, from);
-    const recipient = await this.addressInfoHelper.getOrDefault(chainId, to);
+    const sender = await this.addressInfoHelper.getOrDefault(chainId, from, [
+      'TOKEN',
+      'CONTRACT',
+    ]);
+
+    const recipient = await this.addressInfoHelper.getOrDefault(chainId, to, [
+      'TOKEN',
+      'CONTRACT',
+    ]);
+
     const direction = getTransferDirection(safe.address, from, to);
 
     return new TransferTransactionInfo(

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -329,7 +329,7 @@ describe('Transactions History Controller (Unit)', () => {
       const getChainUrl = `${safeConfigApiUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
-      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/`;
+      const getTokenUrlPattern = `${chainResponse.transactionService}/api/v1/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`;
       if (url === getChainUrl) {
         return Promise.resolve({ data: chainResponse });
       }
@@ -343,7 +343,7 @@ describe('Transactions History Controller (Unit)', () => {
           data: safe,
         });
       }
-      if (url.includes(getTokenUrlPattern)) {
+      if (url === getTokenUrlPattern) {
         return Promise.resolve({
           data: tokenResponse,
         });


### PR DESCRIPTION
Closes #329 

- `AddressInfoHelper` now supports multiple sources. Source can be provided via an array and are fetched in the order they are declared. E.g. `['CONTRACT', 'TOKEN']` would fetch first from the contracts source and, if unsuccessful, would then fetch from the token source.
- Removes default arguments from `AddressInfoHelper` – by explicitly specifying the source in the caller functions we provide more context to which sources are used and in which order in each feature.
- Fixes some tests where the url was being matched to a base one and therefore returning the same payload for consecutive calls on that same base url (while having a different path)