### PR TITLE
Add type to MultisigExecutionDetails

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -489,6 +489,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             addressInfoIndex: null,
           },
           detailedExecutionInfo: {
+            type: 'MULTISIG',
             submittedAt: tx.submissionDate.getTime(),
             nonce: tx.nonce,
             safeTxGas: safeTxGas.toString(),

--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Token } from '../../../balances/entities/token.entity';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
+import { ExecutionDetails } from './execution-details.entity';
 
 export class MultisigConfirmationDetails {
   @ApiProperty()
@@ -21,7 +22,7 @@ export class MultisigConfirmationDetails {
   }
 }
 
-export class MultisigExecutionDetails {
+export class MultisigExecutionDetails extends ExecutionDetails {
   @ApiProperty()
   submittedAt: number;
   @ApiProperty()
@@ -52,4 +53,39 @@ export class MultisigExecutionDetails {
   gasTokenInfo: Token | null;
   @ApiProperty()
   trusted: boolean;
+
+  constructor(
+    submittedAt: number,
+    nonce: number,
+    safeTxGas: string,
+    baseGas: string,
+    gasPrice: string,
+    gasToken: string,
+    refundReceiver: AddressInfo,
+    safeTxHash: string,
+    executor: AddressInfo | null,
+    signers: AddressInfo[],
+    confirmationsRequired: number,
+    confirmations: MultisigConfirmationDetails[],
+    rejectors: AddressInfo[] | null,
+    gasTokenInfo: Token | null,
+    trusted: boolean,
+  ) {
+    super('MULTISIG');
+    this.submittedAt = submittedAt;
+    this.nonce = nonce;
+    this.safeTxGas = safeTxGas;
+    this.baseGas = baseGas;
+    this.gasPrice = gasPrice;
+    this.gasToken = gasToken;
+    this.refundReceiver = refundReceiver;
+    this.safeTxHash = safeTxHash;
+    this.executor = executor;
+    this.signers = signers;
+    this.confirmationsRequired = confirmationsRequired;
+    this.confirmations = confirmations;
+    this.rejectors = rejectors;
+    this.gasTokenInfo = gasTokenInfo;
+    this.trusted = trusted;
+  }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -140,23 +140,23 @@ export class MultisigTransactionDetailsMapper {
     const [gasTokenInfo, executor, refundReceiver, rejectors] =
       await Promise.all(promises);
 
-    return {
-      submittedAt: transaction.submissionDate.getTime(),
-      nonce: transaction.nonce,
-      safeTxGas: transaction.safeTxGas?.toString() ?? '0',
-      baseGas: transaction.baseGas?.toString() ?? '0',
-      gasPrice: transaction.gasPrice?.toString() ?? '0',
-      refundReceiver: refundReceiver as AddressInfo,
-      safeTxHash: transaction.safeTxHash,
-      executor: executor as AddressInfo,
+    return new MultisigExecutionDetails(
+      transaction.submissionDate.getTime(),
+      transaction.nonce,
+      transaction.safeTxGas?.toString() ?? '0',
+      transaction.baseGas?.toString() ?? '0',
+      transaction.gasPrice?.toString() ?? '0',
+      gasToken,
+      refundReceiver as AddressInfo,
+      transaction.safeTxHash,
+      executor as AddressInfo,
       signers,
       confirmationsRequired,
       confirmations,
-      rejectors: rejectors as AddressInfo[] | null,
-      gasToken,
-      gasTokenInfo: gasTokenInfo as Token | null,
-      trusted: transaction.trusted,
-    };
+      rejectors as AddressInfo[] | null,
+      gasTokenInfo as Token | null,
+      transaction.trusted,
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #376 

- `MultisigExecutionDetails` now extends `ExecutionDetails`.
- `type` attribute is added to `MultisigExecutionDetails` via new class constructor.