### PR TITLE
Move exchange.cacheTtlSeconds default to configuration

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -13,7 +13,9 @@ export default () => ({
       process.env.EXCHANGE_API_BASE_URI ||
       'https://api.apilayer.com/exchangerates_data',
     apiKey: process.env.EXCHANGE_API_KEY,
-    cacheTtlSeconds: process.env.EXCHANGE_API_CACHE_TTL_SECONDS,
+    cacheTtlSeconds: parseInt(
+      process.env.EXCHANGE_API_CACHE_TTL_SECONDS ?? `${60 * 60 * 12}`,
+    ),
   },
   safeConfig: {
     baseUri:

--- a/src/datasources/exchange-api/exchange-api.service.spec.ts
+++ b/src/datasources/exchange-api/exchange-api.service.spec.ts
@@ -15,11 +15,16 @@ describe('ExchangeApi', () => {
   let fakeConfigurationService: FakeConfigurationService;
   const exchangeBaseUri = faker.internet.url();
   const exchangeApiKey = faker.random.alphaNumeric();
+  const exchangeCacheTtlSeconds = faker.datatype.number();
 
   beforeAll(async () => {
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('exchange.baseUri', exchangeBaseUri);
     fakeConfigurationService.set('exchange.apiKey', exchangeApiKey);
+    fakeConfigurationService.set(
+      'exchange.cacheTtlSeconds',
+      exchangeCacheTtlSeconds,
+    );
   });
 
   beforeEach(async () => {
@@ -49,20 +54,6 @@ describe('ExchangeApi', () => {
     const fiatCodes = await service.getFiatCodes();
 
     expect(fiatCodes).toBe(expectedFiatCodes);
-  });
-
-  it('fiatCodes uses default cache TTL (12h) if none is set', async () => {
-    const expectedFiatCodes = exchangeFiatCodesBuilder().build();
-    mockCacheFirstDataSource.get.mockResolvedValue(expectedFiatCodes);
-
-    await service.getFiatCodes();
-
-    expect(mockCacheFirstDataSource.get).toBeCalledWith(
-      new CacheDir('exchange_fiat_codes', ''),
-      `${exchangeBaseUri}/symbols`,
-      { headers: { apikey: exchangeApiKey } },
-      60 * 60 * 12, // 12h in seconds
-    );
   });
 
   it('fiatCodes uses set cache TTL', async () => {
@@ -101,17 +92,6 @@ describe('ExchangeApi', () => {
     const rates = await service.getRates();
 
     expect(rates).toBe(expectedRates);
-  });
-
-  it('exchangeRates uses default cache TTL (12h) if none is set', async () => {
-    await service.getRates();
-
-    expect(mockCacheFirstDataSource.get).toBeCalledWith(
-      new CacheDir('exchange_rates', ''),
-      `${exchangeBaseUri}/latest`,
-      { headers: { apikey: exchangeApiKey } },
-      60 * 60 * 12, // 12h in seconds
-    );
   });
 
   it('exchangeRates uses set cache TTL', async () => {

--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -13,8 +13,6 @@ export class ExchangeApi implements IExchangeApi {
   private readonly apiKey: string;
   private readonly cacheTtlSeconds: number;
 
-  private static readonly DEFAULT_CACHE_TTL_SECONDS = 60 * 60 * 12;
-
   constructor(
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
@@ -24,10 +22,9 @@ export class ExchangeApi implements IExchangeApi {
       this.configurationService.getOrThrow<string>('exchange.baseUri');
     this.apiKey =
       this.configurationService.getOrThrow<string>('exchange.apiKey');
-    this.cacheTtlSeconds =
-      this.configurationService.get<number | undefined>(
-        'exchange.cacheTtlSeconds',
-      ) ?? ExchangeApi.DEFAULT_CACHE_TTL_SECONDS;
+    this.cacheTtlSeconds = this.configurationService.getOrThrow<number>(
+      'exchange.cacheTtlSeconds',
+    );
   }
 
   async getFiatCodes(): Promise<ExchangeFiatCodes> {


### PR DESCRIPTION
Closes #318 

Instead of providing a default in `ExchangeApi`, the default value is now provided in the `configuration` itself.