### PR TITLE
Change ordering for  Multisig Transaction list

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -297,7 +297,7 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(chainId);
     const page = await transactionService.getMultisigTransactions(
       safeAddress,
-      '-modified',
+      '-nonce',
       executed,
       true,
       executionDateGte,

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -113,7 +113,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`,
       expect.objectContaining({
         params: expect.objectContaining({
-          ordering: '-modified',
+          ordering: '-nonce',
           safe: safeAddress,
           trusted: true,
         }),


### PR DESCRIPTION
Closes #339 

This PR changes the ordering when retrieving a list of multisig transactions by changing `ordering` parameter of the request sent to the Transaction Service.

- This change only affects `GET /v1/chains/:chainId/safes/:safeAddress/multisig-transactions`.
- `MultisigTransactionDetailsMapper._getRejectors` also uses this datasource function but the ordering doesn't affect this function's behavior.

Note: Ordering by nonce [is the default behavior in the Transaction Service](https://github.com/safe-global/safe-transaction-service/blob/d00ad8bd891e6ab991b0c32493dadda1ab0b0c60/safe_transaction_service/history/views.py#L449) but this PR assumes is a best practice to enforce that in this service, in order to ensure the clients' requirements even if this changes in the Transaction Service for some reason.