### PR TITLE
Remove cache invalidation on tx proposal/confirmation

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -19,16 +19,10 @@ import { CreationTransaction } from './entities/creation-transaction.entity';
 import { CreationTransactionValidator } from './creation-transaction.validator';
 import { ProposeTransactionDto } from '../transactions/entities/propose-transaction.dto.entity';
 import { AddConfirmationDto } from '../transactions/entities/add-confirmation.dto.entity';
-import {
-  CacheService,
-  ICacheService,
-} from '../../datasources/cache/cache.service.interface';
-import { CacheRouter } from '../../datasources/cache/cache.router';
 
 @Injectable()
 export class SafeRepository implements ISafeRepository {
   constructor(
-    @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject(ITransactionApiManager)
     private readonly transactionApiManager: ITransactionApiManager,
     private readonly multisigTransactionValidator: MultisigTransactionValidator,
@@ -103,9 +97,11 @@ export class SafeRepository implements ISafeRepository {
   ): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(chainId);
-    await transactionService.postConfirmation(safeTxHash, addConfirmationDto);
-    const transaction = await this.getMultiSigTransaction(chainId, safeTxHash);
-    await this.invalidateTransactions(chainId, transaction.safe);
+    return transactionService
+      .postConfirmation(safeTxHash, addConfirmationDto)
+      .then(() => {
+        return;
+      });
   }
 
   async getModuleTransaction(
@@ -368,32 +364,9 @@ export class SafeRepository implements ISafeRepository {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(chainId);
 
-    const transaction = await transactionService.postMultisigTransaction(
+    return transactionService.postMultisigTransaction(
       safeAddress,
       proposeTransactionDto,
     );
-
-    await this.invalidateTransactions(chainId, safeAddress);
-    return transaction;
-  }
-
-  private async invalidateTransactions(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
-    const cacheDirs = [
-      CacheRouter.getMultisigTransactionsCacheDir(chainId, safeAddress),
-      CacheRouter.getModuleTransactionsCacheDir(chainId, safeAddress),
-      CacheRouter.getTransfersCacheDir(chainId, safeAddress, false, false),
-      CacheRouter.getIncomingTransfersCacheDir(chainId, safeAddress),
-      CacheRouter.getBalanceCacheDir(chainId, safeAddress),
-      CacheRouter.getSafeCacheDir(chainId, safeAddress),
-      CacheRouter.getCollectiblesCacheDir(chainId, safeAddress),
-      CacheRouter.getAllTransactionsCacheDir(chainId, safeAddress),
-    ];
-
-    for (const cacheDir of cacheDirs) {
-      await this.cacheService.deleteByKey(cacheDir.key);
-    }
   }
 }


### PR DESCRIPTION
Removes the cache invalidation step when adding a confirmation or when proposing a transaction – we should rely on the event hooks from the Safe Transaction Service instead to invalidate cache entries

Since we are removing the reference to `CacheService` we effectively remove a dependency from the domain layer to the datasource layer.