### PR TITLE
Remove global fakeCacheService reference

### DIFF
--- a/src/datasources/cache/__tests__/test.cache.module.ts
+++ b/src/datasources/cache/__tests__/test.cache.module.ts
@@ -3,17 +3,6 @@ import { CacheService } from '../cache.service.interface';
 import { FakeCacheService } from './fake.cache.service';
 
 /**
- * {@link fakeCacheService} should be used in a test setup.
- *
- * It provides the ability to change the cache state by adding/removing keys
- * associated with the cache
- *
- * {@link fakeCacheService} is available only when a module imports
- * {@link TestCacheModule}
- */
-export const fakeCacheService = new FakeCacheService();
-
-/**
  * The {@link TestCacheModule} should be used whenever you want to
  * override the values provided by the {@link CacheService}
  *
@@ -21,11 +10,11 @@ export const fakeCacheService = new FakeCacheService();
  * Test.createTestingModule({ imports: [ModuleA, TestCacheModule]}).compile();
  *
  * This will create a TestModule which uses the implementation of ModuleA but
- * overrides the real Cache Module with a fake one – {@link fakeCacheService}
+ * overrides the real Cache Module with a fake one – {@link FakeCacheService}
  */
 @Global()
 @Module({
-  providers: [{ provide: CacheService, useValue: fakeCacheService }],
+  providers: [{ provide: CacheService, useClass: FakeCacheService }],
   exports: [CacheService],
 })
 export class TestCacheModule {}

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -2,10 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -31,7 +28,6 @@ describe('Balances Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { CacheDir } from '../../datasources/cache/entities/cache-dir.entity';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -19,15 +16,17 @@ import { CacheHooksModule } from './cache-hooks.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
+import { CacheService } from '../../datasources/cache/cache.service.interface';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication;
   let authToken;
   let safeConfigUrl;
+  let fakeCacheService: FakeCacheService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
@@ -43,6 +42,8 @@ describe('Post Hook Events (Unit)', () => {
       ],
     }).compile();
     app = moduleFixture.createNestApplication();
+
+    fakeCacheService = moduleFixture.get<FakeCacheService>(CacheService);
 
     const configurationService = moduleFixture.get(IConfigurationService);
     authToken = configurationService.get('auth.token');

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 import {
   mockNetworkService,
@@ -49,7 +46,6 @@ describe('Chains Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -1,7 +1,4 @@
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DomainModule } from '../../domain.module';
 import {
@@ -37,7 +34,6 @@ describe('Collectibles Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/common/decorators/pagination.data.decorator.spec.ts
+++ b/src/routes/common/decorators/pagination.data.decorator.spec.ts
@@ -1,7 +1,6 @@
 import { PaginationDataDecorator } from './pagination.data.decorator';
 import { PaginationData } from '../pagination/pagination.data';
 import { Controller, Get, INestApplication, Module } from '@nestjs/common';
-import { fakeCacheService } from '../../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 
@@ -23,7 +22,6 @@ describe('PaginationDataDecorator', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [TestModule],

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -2,10 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -26,7 +23,6 @@ describe('Contracts controller', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -32,7 +29,6 @@ describe('Delegates controller', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -35,7 +32,6 @@ describe('Estimations Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -3,10 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { CacheDir } from '../../datasources/cache/entities/cache-dir.entity';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -32,15 +29,17 @@ import { FlushModule } from './flush.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
+import { CacheService } from '../../datasources/cache/cache.service.interface';
 
 describe('Flush Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
   let authToken;
+  let fakeCacheService: FakeCacheService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
@@ -59,6 +58,7 @@ describe('Flush Controller (Unit)', () => {
       ],
     }).compile();
 
+    fakeCacheService = moduleFixture.get<FakeCacheService>(CacheService);
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
     authToken = configurationService.get('auth.token');

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { random, range } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -38,7 +35,6 @@ describe('Messages controller', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { range } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 import {
   mockNetworkService,
@@ -30,7 +27,7 @@ describe('Notifications Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         // feature

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -26,7 +23,6 @@ describe('Owners Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -29,7 +26,6 @@ describe('Safe Apps Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -1,8 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DomainModule } from '../../domain.module';
 import {
@@ -46,7 +43,6 @@ describe('Safes Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -35,7 +32,6 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -45,7 +42,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { readFileSync } from 'fs';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -27,7 +24,6 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -31,7 +28,6 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { readFileSync } from 'fs';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -38,7 +35,6 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -34,7 +31,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -37,7 +34,6 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -35,7 +32,6 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { readFileSync } from 'fs';
 import * as request from 'supertest';
-import {
-  fakeCacheService,
-  TestCacheModule,
-} from '../../datasources/cache/__tests__/test.cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import {
   mockNetworkService,
   TestNetworkModule,
@@ -48,7 +45,6 @@ describe('Transactions History Controller (Unit)', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    fakeCacheService.clear();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [


### PR DESCRIPTION
- Removes global reference to `FakeCacheService`
- A `FakeCacheService` instance can be retrieved via the module API (to retrieve injected components)
- `TestCacheModule` now instantiates the `FakeCacheService` instead of using a global reference. This means that we no longer need to clear the cache manually before each test as long as a new module is instantiated before each test.