### PR TITLE
Use discriminator for webhook schema

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -6,12 +6,12 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
-import { ExecutedTransaction } from './entities/executed-transaction.entity';
-import { NewConfirmation } from './entities/new-confirmation.entity';
-import { PendingTransaction } from './entities/pending-transaction.entity';
 import { EventValidationPipe } from './pipes/event-validation.pipe';
 import { CacheHooksService } from './cache-hooks.service';
 import { BasicAuthGuard } from '../common/auth/basic-auth.guard';
+import { ExecutedTransaction } from './entities/executed-transaction.entity';
+import { NewConfirmation } from './entities/new-confirmation.entity';
+import { PendingTransaction } from './entities/pending-transaction.entity';
 
 @Controller({
   path: '',

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -1,9 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { EventType } from './entities/event-payload.entity';
+import { IBalancesRepository } from '../../domain/balances/balances.repository.interface';
 import { ExecutedTransaction } from './entities/executed-transaction.entity';
 import { NewConfirmation } from './entities/new-confirmation.entity';
 import { PendingTransaction } from './entities/pending-transaction.entity';
-import { EventType } from './entities/event-payload.entity';
-import { IBalancesRepository } from '../../domain/balances/balances.repository.interface';
 
 @Injectable()
 export class CacheHooksService {

--- a/src/routes/cache-hooks/entities/schemas/executed-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/executed-transaction.schema.ts
@@ -9,7 +9,7 @@ export const executedTransactionEventSchema: JSONSchemaType<ExecutedTransaction>
     properties: {
       address: { type: 'string' },
       chainId: { type: 'string' },
-      type: { type: 'string', enum: [EventType.EXECUTED_MULTISIG_TRANSACTION] },
+      type: { type: 'string', const: EventType.EXECUTED_MULTISIG_TRANSACTION },
       safeTxHash: { type: 'string' },
       txHash: { type: 'string' },
     },

--- a/src/routes/cache-hooks/entities/schemas/new-confirmation.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/new-confirmation.schema.ts
@@ -8,7 +8,7 @@ export const newConfirmationEventSchema: JSONSchemaType<NewConfirmation> = {
   properties: {
     address: { type: 'string' },
     chainId: { type: 'string' },
-    type: { type: 'string', enum: [EventType.NEW_CONFIRMATION] },
+    type: { type: 'string', const: EventType.NEW_CONFIRMATION },
     owner: { type: 'string' },
     safeTxHash: { type: 'string' },
   },

--- a/src/routes/cache-hooks/entities/schemas/pending-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/pending-transaction.schema.ts
@@ -9,7 +9,7 @@ export const pendingTransactionEventSchema: JSONSchemaType<PendingTransaction> =
     properties: {
       address: { type: 'string' },
       chainId: { type: 'string' },
-      type: { type: 'string', enum: [EventType.PENDING_MULTISIG_TRANSACTION] },
+      type: { type: 'string', const: EventType.PENDING_MULTISIG_TRANSACTION },
       safeTxHash: { type: 'string' },
     },
     required: ['address', 'chainId', 'type', 'safeTxHash'],

--- a/src/routes/cache-hooks/entities/schemas/web-hook.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/web-hook.schema.ts
@@ -1,0 +1,24 @@
+import { JSONSchemaType } from 'ajv';
+import { ExecutedTransaction } from '../executed-transaction.entity';
+import { NewConfirmation } from '../new-confirmation.entity';
+import { PendingTransaction } from '../pending-transaction.entity';
+
+export const webHookSchema: JSONSchemaType<
+  ExecutedTransaction | NewConfirmation | PendingTransaction
+> = {
+  $id: 'https://safe-client.safe.global/schemas/cache-hooks/web-hook.json',
+  type: 'object',
+  discriminator: { propertyName: 'type' },
+  required: ['type', 'address', 'chainId'],
+  oneOf: [
+    {
+      $ref: 'executed-transaction.json',
+    },
+    {
+      $ref: 'new-confirmation.json',
+    },
+    {
+      $ref: 'pending-transaction.json',
+    },
+  ],
+};

--- a/src/routes/cache-hooks/pipes/event-validation.pipe.ts
+++ b/src/routes/cache-hooks/pipes/event-validation.pipe.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
-import { ExecutedTransaction } from '../entities/executed-transaction.entity';
-import { NewConfirmation } from '../entities/new-confirmation.entity';
-import { PendingTransaction } from '../entities/pending-transaction.entity';
 import { executedTransactionEventSchema } from '../entities/schemas/executed-transaction.schema';
 import { newConfirmationEventSchema } from '../entities/schemas/new-confirmation.schema';
 import { pendingTransactionEventSchema } from '../entities/schemas/pending-transaction.schema';
+import { webHookSchema } from '../entities/schemas/web-hook.schema';
+import { ExecutedTransaction } from '../entities/executed-transaction.entity';
+import { NewConfirmation } from '../entities/new-confirmation.entity';
+import { PendingTransaction } from '../entities/pending-transaction.entity';
 
 @Injectable()
 export class EventValidationPipe
@@ -16,35 +17,33 @@ export class EventValidationPipe
       ExecutedTransaction | NewConfirmation | PendingTransaction
     >
 {
-  private readonly isExecutedTransactionEvent: ValidateFunction<ExecutedTransaction>;
-  private readonly isNewConfirmationEvent: ValidateFunction<NewConfirmation>;
-  private readonly isPendingTransactionEvent: ValidateFunction<PendingTransaction>;
+  private readonly isWebHookEvent: ValidateFunction<
+    ExecutedTransaction | NewConfirmation | PendingTransaction
+  >;
 
   constructor(private readonly jsonSchemaService: JsonSchemaService) {
-    this.isExecutedTransactionEvent = jsonSchemaService.getSchema(
+    jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/cache-hooks/executed-transaction.json',
       executedTransactionEventSchema,
     );
-    this.isNewConfirmationEvent = jsonSchemaService.getSchema(
+    jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/cache-hooks/new-confirmation.json',
       newConfirmationEventSchema,
     );
-    this.isPendingTransactionEvent = jsonSchemaService.getSchema(
+    jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/cache-hooks/pending-transaction.json',
       pendingTransactionEventSchema,
+    );
+    this.isWebHookEvent = jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/cache-hooks/web-hook.json',
+      webHookSchema,
     );
   }
 
   transform(
     value: any,
   ): ExecutedTransaction | NewConfirmation | PendingTransaction {
-    this.isExecutedTransactionEvent(value);
-
-    if (
-      this.isExecutedTransactionEvent(value) ||
-      this.isNewConfirmationEvent(value) ||
-      this.isPendingTransactionEvent(value)
-    ) {
+    if (this.isWebHookEvent(value)) {
       return value;
     }
     throw new BadRequestException('Validation failed');


### PR DESCRIPTION
- Adds a root webhook schema that uses a `discriminator` on the payload `type`.
