### PR TITLE
Remove FlushRepository datasource dependency

### DIFF
--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -7,6 +7,7 @@ import { SafeApp } from '../../domain/safe-apps/entities/safe-app.entity';
 import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { CacheRouter } from '../cache/cache.router';
 import { HttpErrorFactory } from '../errors/http-error-factory';
+import { CacheService, ICacheService } from '../cache/cache.service.interface';
 
 @Injectable()
 export class ConfigApi implements IConfigApi {
@@ -14,6 +15,7 @@ export class ConfigApi implements IConfigApi {
 
   constructor(
     private readonly dataSource: CacheFirstDataSource,
+    @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     private readonly httpErrorFactory: HttpErrorFactory,
@@ -31,6 +33,17 @@ export class ConfigApi implements IConfigApi {
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
+  }
+
+  clearChains(): Promise<void> {
+    const pattern = CacheRouter.getChainsCachePattern();
+
+    return Promise.all([
+      this.cacheService.deleteByKey(CacheRouter.getChainsCacheKey()),
+      this.cacheService.deleteByKeyPattern(pattern),
+    ]).then(() => {
+      return;
+    });
   }
 
   async getChain(chainId: string): Promise<Chain> {

--- a/src/domain/chains/chains.repository.interface.ts
+++ b/src/domain/chains/chains.repository.interface.ts
@@ -14,6 +14,11 @@ export interface IChainsRepository {
   getChains(limit?: number, offset?: number): Promise<Page<Chain>>;
 
   /**
+   * Triggers the removal of chain data stored in the DataSource (e.g. cache)
+   */
+  clearChains(): Promise<void>;
+
+  /**
    * Gets the {@link Chain} associated with {@link chainId}
    *
    * @param chainId

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -29,6 +29,10 @@ export class ChainsRepository implements IChainsRepository {
     return page;
   }
 
+  async clearChains(): Promise<void> {
+    return this.configApi.clearChains();
+  }
+
   async getMasterCopies(chainId: string): Promise<MasterCopy[]> {
     const transactionApi = await this.transactionApiManager.getTransactionApi(
       chainId,

--- a/src/domain/flush/flush.repository.ts
+++ b/src/domain/flush/flush.repository.ts
@@ -1,9 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { CacheRouter } from '../../datasources/cache/cache.router';
-import {
-  CacheService,
-  ICacheService,
-} from '../../datasources/cache/cache.service.interface';
 import { IConfigApi } from '../interfaces/config-api.interface';
 import { InvalidationPatternDto } from './entities/invalidation-pattern.dto.entity';
 import { InvalidationTarget } from './entities/invalidation-target.entity';
@@ -17,24 +12,17 @@ import {
 export class FlushRepository implements IFlushRepository {
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
-    @Inject(CacheService) private readonly cacheService: ICacheService,
     @Inject(IConfigApi) private readonly configApi: IConfigApi,
   ) {}
 
   async execute(pattern: InvalidationPatternDto): Promise<void> {
     switch (pattern.invalidate) {
       case InvalidationTarget[InvalidationTarget.Chains]:
-        return this.invalidateChains();
+        return this.configApi.clearChains();
       default:
         this.loggingService.debug(
           `Unknown flush pattern ${pattern.invalidate}`,
         );
     }
-  }
-
-  private async invalidateChains(): Promise<void> {
-    await this.cacheService.deleteByKey(CacheRouter.getChainsCacheKey());
-    const pattern = CacheRouter.getChainsCachePattern();
-    await this.cacheService.deleteByKeyPattern(pattern);
   }
 }

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -6,6 +6,7 @@ export const IConfigApi = Symbol('IConfigApi');
 
 export interface IConfigApi {
   getChains(limit?: number, offset?: number): Promise<Page<Chain>>;
+  clearChains(): Promise<void>;
   getChain(chainId: string): Promise<Chain>;
   getSafeApps(
     chainId?: string,


### PR DESCRIPTION
- Removes `ICacheService` dependency from `FlushRepository` – domain repositories should have no dependencies to a data source.
- Adds function to clear local chain data to `IConfigApi`