### PR TITLE
Clear collectibles on incoming/outgoing token event

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -91,6 +91,10 @@ export class CacheRouter {
     );
   }
 
+  static getCollectiblesKey(chainId: string, safeAddress: string) {
+    return `${chainId}_${CacheRouter.COLLECTIBLES_KEY}_${safeAddress}`;
+  }
+
   static getDelegatesCacheDir(
     chainId: string,
     safeAddress?: string,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -109,6 +109,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  clearCollectibles(safeAddress: string): Promise<void> {
+    const key = CacheRouter.getCollectiblesKey(this.chainId, safeAddress);
+    return this.cacheService.deleteByKey(key).then(() => {
+      return;
+    });
+  }
+
   async getBackbone(): Promise<Backbone> {
     try {
       const cacheDir = CacheRouter.getBackboneCacheDir(this.chainId);

--- a/src/domain/collectibles/collectibles.repository.interface.ts
+++ b/src/domain/collectibles/collectibles.repository.interface.ts
@@ -14,4 +14,6 @@ export interface ICollectiblesRepository {
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Page<Collectible>>;
+
+  clearCollectibles(chainId: string, safeAddress: string): Promise<void>;
 }

--- a/src/domain/collectibles/collectibles.repository.ts
+++ b/src/domain/collectibles/collectibles.repository.ts
@@ -35,4 +35,12 @@ export class CollectiblesRepository implements ICollectiblesRepository {
     page?.results.map((result) => this.validator.validate(result));
     return page;
   }
+
+  async clearCollectibles(chainId: string, safeAddress: string): Promise<void> {
+    const transactionApi = await this.transactionApiManager.getTransactionApi(
+      chainId,
+    );
+
+    return transactionApi.clearCollectibles(safeAddress);
+  }
 }

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -40,6 +40,8 @@ export interface ITransactionApi {
     excludeSpam?: boolean,
   ): Promise<Page<Collectible>>;
 
+  clearCollectibles(safeAddress: string): Promise<void>;
+
   getBackbone(): Promise<Backbone>;
 
   getMasterCopies(): Promise<MasterCopy[]>;


### PR DESCRIPTION
Clears locally stored collectible data (safe collection) on `EXECUTED_MULTISIG_TRANSACTION`, `INCOMING_TOKEN` and `OUTGOING_TOKEN`