### PR TITLE
Clear collectibles transfers on incoming/outgoing token event

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -131,6 +131,10 @@ export class CacheRouter {
     );
   }
 
+  static getTransfersCacheKey(chainId: string, safeAddress: string) {
+    return `${chainId}_${CacheRouter.TRANSFERS_KEY}_${safeAddress}`;
+  }
+
   static getModuleTransactionCacheDir(
     chainId: string,
     moduleTransactionId: string,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -298,6 +298,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
+  clearTransfers(safeAddress: string): Promise<void> {
+    const key = CacheRouter.getTransfersCacheKey(this.chainId, safeAddress);
+    return this.cacheService.deleteByKey(key).then(() => {
+      return;
+    });
+  }
+
   async getIncomingTransfers(
     safeAddress: string,
     executionDateGte?: string,

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -91,6 +91,8 @@ export interface ITransactionApi {
     offset?: number,
   ): Promise<Page<Transfer>>;
 
+  clearTransfers(safeAddress: string): Promise<void>;
+
   getIncomingTransfers(
     safeAddress: string,
     executionDateGte?: string,

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -23,6 +23,11 @@ export interface ISafeRepository {
     offset?: number,
   ): Promise<Page<Transfer>>;
 
+  clearCollectibleTransfers(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<void>;
+
   getIncomingTransfers(
     chainId: string,
     safeAddress: string,

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -68,6 +68,16 @@ export class SafeRepository implements ISafeRepository {
     return page;
   }
 
+  async clearCollectibleTransfers(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<void> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(chainId);
+
+    return transactionService.clearTransfers(safeAddress);
+  }
+
   async getIncomingTransfers(
     chainId: string,
     safeAddress: string,

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -517,4 +517,53 @@ describe('Post Hook Events (Unit)', () => {
 
     await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
   });
+
+  it.each([
+    {
+      type: 'EXECUTED_MULTISIG_TRANSACTION',
+      safeTxHash: faker.datatype.hexadecimal(32),
+      txHash: faker.datatype.hexadecimal(32),
+    },
+    {
+      type: 'INCOMING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.datatype.hexadecimal(32),
+    },
+    {
+      type: 'OUTGOING_TOKEN',
+      tokenAddress: faker.finance.ethereumAddress(),
+      txHash: faker.datatype.hexadecimal(32),
+    },
+  ])('$type clears safe collectible transfers', async (payload) => {
+    const safeAddress = faker.finance.ethereumAddress();
+    const chainId = faker.random.numeric();
+    const cacheDir = new CacheDir(
+      `${chainId}_transfers_${safeAddress}`,
+      faker.random.alpha(),
+    );
+    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    const data = {
+      address: safeAddress,
+      chainId: chainId,
+      ...payload,
+    };
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+          return Promise.resolve({
+            data: chainBuilder().with('chainId', chainId).build(),
+          });
+        default:
+          return Promise.reject(new Error(`Could not match ${url}`));
+      }
+    });
+
+    await request(app.getHttpServer())
+      .post(`/chains/${chainId}/hooks/events`)
+      .set('Authorization', `Basic ${authToken}`)
+      .send(data)
+      .expect(200);
+
+    await expect(fakeCacheService.get(cacheDir)).resolves.toBeUndefined();
+  });
 });

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -48,21 +48,23 @@ export class CacheHooksService {
         );
         break;
       // A new executed multisig transaction affects:
+      // - the collectibles that the safe has
       // - the balance of the safe - clear safe balance
-      // - the safe configuration - clear safe info
+      // - the collectible transfers for that safe
       // - queued transactions and history – clear multisig transactions
       // - the transaction executed – clear multisig transaction
-      // - the collectibles that the safe has
+      // - the safe configuration - clear safe info
       case EventType.EXECUTED_MULTISIG_TRANSACTION:
         promises.push(
+          this.collectiblesRepository.clearCollectibles(chainId, event.address),
           this.balancesRepository.clearLocalBalances(chainId, event.address),
-          this.safeRepository.clearSafe(chainId, event.address),
+          this.safeRepository.clearCollectibleTransfers(chainId, event.address),
           this.safeRepository.clearMultisigTransactions(chainId, event.address),
           this.safeRepository.clearMultisigTransaction(
             chainId,
             event.safeTxHash,
           ),
-          this.collectiblesRepository.clearCollectibles(chainId, event.address),
+          this.safeRepository.clearSafe(chainId, event.address),
         );
         break;
       // A new confirmation for a pending transaction affects:
@@ -88,11 +90,13 @@ export class CacheHooksService {
       // An incoming/outgoing token affects:
       // - the balance of the safe - clear safe balance
       // - the collectibles that the safe has
+      // - the collectible transfers for that safe
       case EventType.INCOMING_TOKEN:
       case EventType.OUTGOING_TOKEN:
         promises.push(
           this.balancesRepository.clearLocalBalances(chainId, event.address),
           this.collectiblesRepository.clearCollectibles(chainId, event.address),
+          this.safeRepository.clearCollectibleTransfers(chainId, event.address),
         );
         break;
     }


### PR DESCRIPTION
Clears locally stored collectible transfers on `EXECUTED_MULTISIG_TRANSACTION`, `INCOMING_TOKEN` and `OUTGOING_TOKEN`