### PR TITLE
Do not clear balance on EXECUTED_MULTISIG_TRANSACTION

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -277,11 +277,6 @@ describe('Post Hook Events (Unit)', () => {
 
   it.each([
     {
-      type: 'EXECUTED_MULTISIG_TRANSACTION',
-      safeTxHash: faker.datatype.hexadecimal(32),
-      txHash: faker.datatype.hexadecimal(32),
-    },
-    {
       type: 'INCOMING_TOKEN',
       tokenAddress: faker.finance.ethereumAddress(),
       txHash: faker.datatype.hexadecimal(32),

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -49,7 +49,6 @@ export class CacheHooksService {
         break;
       // A new executed multisig transaction affects:
       // - the collectibles that the safe has
-      // - the balance of the safe - clear safe balance
       // - the collectible transfers for that safe
       // - queued transactions and history – clear multisig transactions
       // - the transaction executed – clear multisig transaction
@@ -57,7 +56,6 @@ export class CacheHooksService {
       case EventType.EXECUTED_MULTISIG_TRANSACTION:
         promises.push(
           this.collectiblesRepository.clearCollectibles(chainId, event.address),
-          this.balancesRepository.clearLocalBalances(chainId, event.address),
           this.safeRepository.clearCollectibleTransfers(chainId, event.address),
           this.safeRepository.clearMultisigTransactions(chainId, event.address),
           this.safeRepository.clearMultisigTransaction(


### PR DESCRIPTION
The `EXECUTED_MULTISIG_TRANSACTION` might affect the balance of the safe (native token or otherwise). We already handle the events for incoming and outgoing tokens, so we should rely on those to invalidate the balance instead.