### PR TITLE
Set EXPIRATION_TIME_DEFAULT_SECONDS for tests

### DIFF
--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -1,1 +1,2 @@
 process.env.SAFE_CONFIG_BASE_URI = 'https://safe-config.staging.5afe.dev';
+process.env.EXPIRATION_TIME_DEFAULT_SECONDS = `${60}`; // long enough timeout for cache state assertions


### PR DESCRIPTION
The default `EXPIRATION_TIME_DEFAULT_SECONDS` in the service configuration is 60 seconds. By setting the default timeout in `e2e-setup.ts` we decouple the development default from the test setup.