### PR TITLE
Parse configuration default expiration time as a number

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -29,6 +29,6 @@ export default () => ({
     port: process.env.REDIS_PORT || '6379',
   },
   expirationTimeInSeconds: {
-    default: process.env.EXPIRATION_TIME_DEFAULT_SECONDS || 60,
+    default: parseInt(process.env.EXPIRATION_TIME_DEFAULT_SECONDS ?? `${60}`),
   },
 });


### PR DESCRIPTION
Parses `EXPIRATION_TIME_DEFAULT_SECONDS` as a number.