### PR TITLE
Specify cache timeout per endpoint

### DIFF
--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -27,12 +27,17 @@ const mockHttpErrorFactory = jest.mocked(httpErrorFactory);
 
 describe('ConfigApi', () => {
   const baseUri = faker.internet.url();
+  const expirationTimeInSeconds = faker.datatype.number();
   let fakeConfigurationService;
   let service: ConfigApi;
 
   beforeAll(async () => {
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('safeConfig.baseUri', baseUri);
+    fakeConfigurationService.set(
+      'expirationTimeInSeconds.default',
+      expirationTimeInSeconds,
+    );
   });
 
   beforeEach(async () => {
@@ -71,6 +76,7 @@ describe('ConfigApi', () => {
       new CacheDir('chains', 'undefined_undefined'),
       `${baseUri}/api/v1/chains`,
       { params: { limit: undefined, offset: undefined } },
+      expirationTimeInSeconds,
     );
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
@@ -86,6 +92,8 @@ describe('ConfigApi', () => {
     expect(mockDataSource.get).toBeCalledWith(
       new CacheDir(`${data.chainId}_chain`, ''),
       `${baseUri}/api/v1/chains/${data.chainId}`,
+      undefined,
+      expirationTimeInSeconds,
     );
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
@@ -103,6 +111,7 @@ describe('ConfigApi', () => {
       new CacheDir(`${chainId}_safe_apps`, 'undefined_undefined'),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl: undefined, url: undefined } },
+      expirationTimeInSeconds,
     );
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
@@ -121,6 +130,7 @@ describe('ConfigApi', () => {
       new CacheDir(`${chainId}_safe_apps`, `undefined_${url}`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl: undefined, url } },
+      expirationTimeInSeconds,
     );
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });
@@ -139,6 +149,7 @@ describe('ConfigApi', () => {
       new CacheDir(`${chainId}_safe_apps`, `${clientUrl}_undefined`),
       `${baseUri}/api/v1/safe-apps/`,
       { params: { chainId, clientUrl, url: undefined } },
+      expirationTimeInSeconds,
     );
     expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
   });

--- a/src/datasources/transaction-api/transaction-api.manager.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.ts
@@ -42,6 +42,7 @@ export class TransactionApiManager implements ITransactionApiManager {
       this.useVpcUrl ? chain.vpcTransactionService : chain.transactionService,
       this.dataSource,
       this.cacheService,
+      this.configurationService,
       this.httpErrorFactory,
       this.networkService,
     );

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -27,8 +27,7 @@ describe('Get contract e2e test', () => {
     await redisClient.flushAll();
   });
 
-  // TODO: test relies on the value being cached. Default cache timeout was removed.
-  it.skip('GET /contracts/<address>', async () => {
+  it('GET /contracts/<address>', async () => {
     const contractAddress = '0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4';
     const expectedResponse: Contract = JSON.parse(
       readFileSync(

--- a/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
+++ b/src/routes/owners/__tests__/get-safes-by-owner.e2e-spec.ts
@@ -24,8 +24,7 @@ describe('Get safes by owner e2e test', () => {
     await redisClient.flushAll();
   });
 
-  // TODO: test relies on the value being cached. Default cache timeout was removed.
-  it.skip('GET /owners/<owner_address>/safes', async () => {
+  it('GET /owners/<owner_address>/safes', async () => {
     const ownerAddress = '0xf10E2042ec19747401E5EA174EfB63A0058265E6';
     const ownerCacheKey = `${chainId}_owner_safes_${ownerAddress}`;
 

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -25,8 +25,7 @@ describe('Get Safe Apps e2e test', () => {
     await redisClient.flushAll();
   });
 
-  // TODO: test relies on the value being cached. Default cache timeout was removed.
-  it.skip('GET /chains/<chainId>/safe-apps', async () => {
+  it('GET /chains/<chainId>/safe-apps', async () => {
     const safeAppsCacheKey = `${chainId}_safe_apps`;
     const safeAppsCacheField = 'undefined_undefined';
 
@@ -62,8 +61,7 @@ describe('Get Safe Apps e2e test', () => {
     expect(cacheContent).not.toBeNull();
   });
 
-  // TODO: test relies on the value being cached. Default cache timeout was removed.
-  it.skip('GET /chains/<chainId>/safe-apps?url=${transactionBuilderUrl}', async () => {
+  it('GET /chains/<chainId>/safe-apps?url=${transactionBuilderUrl}', async () => {
     const safeAppsCacheKey = `${chainId}_safe_apps`;
     const transactionBuilderUrl = 'https://safe-apps.dev.5afe.dev/tx-builder';
     const safeAppsCacheField = `undefined_${transactionBuilderUrl}`;


### PR DESCRIPTION
The following endpoints now use the value set in `expirationTimeInSeconds.default`:

Configuration Service:
- `/api/v1/chains`
- `/api/v1/chains/${chainId}`
- `/api/v1/safe-apps/`

Transaction Service:
- `/api/v1/safes/${safeAddress}/balances/usd/`
- `/api/v2/safes/${safeAddress}/collectibles/`
- `/api/v1/about` *
- `/api/v1/about/master-copies` *
- `/api/v1/safes/${safeAddress}`
- `/api/v1/contracts/${contractAddress}` *
- `/api/v1/transfer/${transferId}` *
- `/api/v1/safes/${safeAddress}/transfers`
- `/api/v1/safes/${safeAddress}/incoming-transfers`
- `/api/v1/module-transaction/${moduleTransactionId}` *
- `/api/v1/safes/${safeAddress}/module-transactions`
- `/api/v1/safes/${safeAddress}/multisig-transactions`
- `/api/v1/multisig-transactions/${safeTransactionHash}`
- `/api/v1/safes/${safeAddress}/creation` *
- `/api/v1/safes/${safeAddress}/all-transactions`
- `/api/v1/tokens/${address}` *
- `/api/v1/tokens` *
- `/api/v1/owners/${ownerAddress}/safes` *

Endpoints with `*` are not invalidated by web hooks