### PR TITLE
fix: add types to test configuration

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -1,19 +1,20 @@
 import { faker } from '@faker-js/faker';
+import configuration from '../../entities/configuration';
 
-export default () => ({
+export default (): ReturnType<typeof configuration> => ({
   about: {
     name: faker.random.words(),
     version: faker.system.semver(),
     buildNumber: faker.random.numeric(),
   },
-  applicationPort: faker.internet.port(),
+  applicationPort: faker.internet.port().toString(),
   auth: {
     token: faker.datatype.hexadecimal(32),
   },
   exchange: {
     baseUri: faker.internet.url(),
     apiKey: faker.datatype.hexadecimal(32),
-    cacheTtlSeconds: faker.random.numeric(),
+    cacheTtlSeconds: faker.datatype.number(),
   },
   safeConfig: {
     baseUri: faker.internet.url(),
@@ -23,9 +24,9 @@ export default () => ({
   },
   redis: {
     host: faker.internet.domainName(),
-    port: faker.internet.port(),
+    port: faker.internet.port().toString(),
   },
   expirationTimeInSeconds: {
-    default: faker.random.numeric(),
+    default: faker.datatype.number(),
   },
 });


### PR DESCRIPTION
This adds types to our test configuration (added in https://github.com/safe-global/safe-client-gateway-nest/commit/2a2168f37dd4b2c79ddd6fe92ad4942c4c870f0e), updating incorrect values accordingly.