### PR TITLE
fix: return `null` if fallback handler is a "null address"

### DIFF
--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -40,6 +40,8 @@ export class SafesService {
 
     const [
       masterCopyInfo,
+      fallbackHandlerInfo,
+      guardInfo,
       collectiblesTag,
       queuedTransactionTag,
       transactionHistoryTag,
@@ -47,29 +49,20 @@ export class SafesService {
       this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy, [
         'CONTRACT',
       ]),
-
+      safe.fallbackHandler === NULL_ADDRESS
+        ? Promise.resolve(null)
+        : this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler, [
+            'CONTRACT',
+          ]),
+      safe.guard === NULL_ADDRESS
+        ? Promise.resolve(null)
+        : this.addressInfoHelper.getOrDefault(chainId, safe.guard, [
+            'CONTRACT',
+          ]),
       this.getCollectiblesTag(chainId, safeAddress),
       this.getQueuedTransactionTag(chainId, safe),
       this.executedTransactionTag(chainId, safeAddress),
     ]);
-
-    let fallbackHandlerInfo: AddressInfo | null = null;
-    if (safe.fallbackHandler !== NULL_ADDRESS) {
-      fallbackHandlerInfo = await this.addressInfoHelper.getOrDefault(
-        chainId,
-        safe.fallbackHandler,
-        ['CONTRACT'],
-      );
-    }
-
-    let guardInfo: AddressInfo | null = null;
-    if (safe.guard !== NULL_ADDRESS) {
-      guardInfo = await this.addressInfoHelper.getOrDefault(
-        chainId,
-        safe.guard,
-        ['CONTRACT'],
-      );
-    }
 
     let moduleAddressesInfo: AddressInfo[] | null = null;
     if (safe.modules) {

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -40,7 +40,6 @@ export class SafesService {
 
     const [
       masterCopyInfo,
-      fallbackHandlerInfo,
       collectiblesTag,
       queuedTransactionTag,
       transactionHistoryTag,
@@ -48,14 +47,20 @@ export class SafesService {
       this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy, [
         'CONTRACT',
       ]),
-      this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler, [
-        'CONTRACT',
-      ]),
 
       this.getCollectiblesTag(chainId, safeAddress),
       this.getQueuedTransactionTag(chainId, safe),
       this.executedTransactionTag(chainId, safeAddress),
     ]);
+
+    let fallbackHandlerInfo: AddressInfo | null = null;
+    if (safe.fallbackHandler !== NULL_ADDRESS) {
+      fallbackHandlerInfo = await this.addressInfoHelper.getOrDefault(
+        chainId,
+        safe.fallbackHandler,
+        ['CONTRACT'],
+      );
+    }
 
     let guardInfo: AddressInfo | null = null;
     if (safe.guard !== NULL_ADDRESS) {


### PR DESCRIPTION
Partially resolves #347

`SafeState['fallbackHandler']` now returns `null` if the Safe's fallback handler is a "null address" (`0x0000000000000000000000000000000000000000`). It was previously serialising it instead. Test coverage for this has been added.