### PR TITLE
feat: add `SafeState['messagesTag']`

### DIFF
--- a/src/routes/safes/entities/safe-info.entity.ts
+++ b/src/routes/safes/entities/safe-info.entity.ts
@@ -36,6 +36,8 @@ export class SafeState {
   readonly txQueuedTag: string;
   @ApiProperty()
   readonly txHistoryTag: string;
+  @ApiProperty()
+  readonly messagesTag: string;
 
   constructor(
     address: AddressInfo,
@@ -48,6 +50,7 @@ export class SafeState {
     collectiblesTag: string,
     txQueuedTag: string,
     txHistoryTag: string,
+    messagesTag: string,
     modules: AddressInfo[] | null,
     fallbackHandler: AddressInfo | null,
     guard: AddressInfo | null,
@@ -63,6 +66,7 @@ export class SafeState {
     this.collectiblesTag = collectiblesTag;
     this.txQueuedTag = txQueuedTag;
     this.txHistoryTag = txHistoryTag;
+    this.messagesTag = messagesTag;
     this.modules = modules;
     this.fallbackHandler = fallbackHandler;
     this.guard = guard;

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -37,6 +37,10 @@ import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { NULL_ADDRESS } from '../common/constants';
+import {
+  toJson as messageToJson,
+  messageBuilder,
+} from '../../domain/messages/entities/__tests__/message.builder';
 
 describe('Safes Controller (Unit)', () => {
   let app: INestApplication;
@@ -117,6 +121,17 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
+
+    const messages = pageBuilder()
+      .with('results', [
+        messageToJson(
+          messageBuilder()
+            .with('modified', new Date('2023-03-12T12:29:06Z'))
+            .build(),
+        ),
+      ])
+      .build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -137,6 +152,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -169,6 +186,7 @@ describe('Safes Controller (Unit)', () => {
         collectiblesTag: '1474253704',
         txQueuedTag: '2495629387',
         txHistoryTag: '3256547346',
+        messagesTag: '1678624146',
         modules: null,
         fallbackHandler: {
           value: fallbackHandlerInfo.address,
@@ -199,6 +217,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -219,6 +239,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -249,6 +271,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -269,6 +293,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -300,6 +326,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -320,6 +348,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -354,6 +384,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -374,6 +406,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -420,6 +454,8 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -440,6 +476,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -489,6 +527,8 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -509,6 +549,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -557,6 +599,8 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -577,6 +621,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -625,6 +671,8 @@ describe('Safes Controller (Unit)', () => {
         ),
       ])
       .build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -645,6 +693,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -655,6 +705,77 @@ describe('Safes Controller (Unit)', () => {
       .expect((response) =>
         expect(response.body).toMatchObject({
           txHistoryTag: '1600314722',
+        }),
+      );
+  });
+
+  it('messagesTag is the latest modified timestamp', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+
+    const messages = pageBuilder()
+      .with('results', [
+        messageToJson(
+          messageBuilder()
+            .with('modified', new Date('2023-03-12T12:29:06Z'))
+            .build(),
+        ),
+        messageToJson(
+          messageBuilder()
+            .with('modified', new Date('2023-07-12T12:29:06Z'))
+            .build(),
+        ),
+        messageToJson(
+          messageBuilder()
+            .with('modified', new Date('2023-02-12T12:29:06Z'))
+            .build(),
+        ),
+      ])
+      .build();
+
+    mockNetworkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          messagesTag: '1689164946',
         }),
       );
   });
@@ -680,6 +801,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -706,6 +829,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -751,6 +876,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -771,6 +898,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -799,6 +928,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -819,6 +950,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -842,6 +975,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -863,6 +998,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -891,6 +1028,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -911,6 +1050,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
@@ -935,6 +1076,8 @@ describe('Safes Controller (Unit)', () => {
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
     const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
@@ -956,6 +1099,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: queuedTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
           return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -171,7 +171,7 @@ export class SafesService {
     }
 
     const sortedMessages = messages.results.sort((m1, m2) => {
-      return m2.modified > m1.modified ? 1 : -1;
+      return m2.modified.getTime() - m1.modified.getTime();
     });
 
     return sortedMessages[0].modified;

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -13,6 +13,8 @@ import {
 } from '../../domain/safe/entities/transaction.entity';
 import { AddressInfo } from '../common/entities/address-info.entity';
 import { NULL_ADDRESS } from '../common/constants';
+import { MessagesRepository } from '../../domain/messages/messages.repository';
+import { IMessagesRepository } from '../../domain/messages/messages.repository.interface';
 
 @Injectable()
 export class SafesService {
@@ -22,6 +24,8 @@ export class SafesService {
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
     private readonly addressInfoHelper: AddressInfoHelper,
+    @Inject(IMessagesRepository)
+    private readonly messagesRepository: MessagesRepository,
   ) {}
 
   async getSafeInfo(chainId: string, safeAddress: string): Promise<SafeState> {
@@ -45,6 +49,7 @@ export class SafesService {
       collectiblesTag,
       queuedTransactionTag,
       transactionHistoryTag,
+      messagesTag,
     ] = await Promise.all([
       this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy, [
         'CONTRACT',
@@ -62,6 +67,7 @@ export class SafesService {
       this.getCollectiblesTag(chainId, safeAddress),
       this.getQueuedTransactionTag(chainId, safe),
       this.executedTransactionTag(chainId, safeAddress),
+      this.modifiedMessageTag(chainId, safeAddress),
     ]);
 
     let moduleAddressesInfo: AddressInfo[] | null = null;
@@ -85,6 +91,7 @@ export class SafesService {
       this.toUnixTimestampInSecondsOrNow(collectiblesTag).toString(),
       this.toUnixTimestampInSecondsOrNow(queuedTransactionTag).toString(),
       this.toUnixTimestampInSecondsOrNow(transactionHistoryTag).toString(),
+      this.toUnixTimestampInSecondsOrNow(messagesTag).toString(),
       moduleAddressesInfo,
       fallbackHandlerInfo,
       guardInfo,
@@ -148,6 +155,26 @@ export class SafesService {
       // This should never happen as AJV would not allow an unknown transaction to get to this stage
       throw Error('Unrecognized transaction type');
     }
+  }
+
+  private async modifiedMessageTag(
+    chainId: string,
+    safeAddress: string,
+  ): Promise<Date | null> {
+    const messages = await this.messagesRepository.getMessagesBySafe(
+      chainId,
+      safeAddress,
+    );
+
+    if (messages.results.length === 0) {
+      return null;
+    }
+
+    const sortedMessages = messages.results.sort((m1, m2) => {
+      return m2.modified > m1.modified ? 1 : -1;
+    });
+
+    return sortedMessages[0].modified;
   }
 
   private computeVersionState(


### PR DESCRIPTION
Partially resolves #347

This adds `SafeState['messagesTag']`, returning the most recent message `modified` timestamp. Test coverage for this has been added.