### PR TITLE
Do not return promises' result in hooks/events

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -40,7 +40,7 @@ export class CacheHooksController {
       | OutgoingToken
       | OutgoingEther
       | PendingTransaction,
-  ): Promise<void[]> {
-    return await this.service.onEvent(chainId, eventPayload);
+  ): Promise<void> {
+    await this.service.onEvent(chainId, eventPayload);
   }
 }


### PR DESCRIPTION
The route `POST /chains/:chainId/hooks/events` was returning an array with the length of promises resolved. It should return an empty body instead.