### PR TITLE
Remove uri validation from collectible schema

### DIFF
--- a/src/domain/collectibles/entities/schemas/collectible.schema.ts
+++ b/src/domain/collectibles/entities/schemas/collectible.schema.ts
@@ -10,10 +10,12 @@ export const collectibleSchema: JSONSchemaType<Collectible> = {
     tokenSymbol: { type: 'string' },
     logoUri: { type: 'string' },
     id: { type: 'string' },
-    uri: { type: 'string', nullable: true, default: null, format: 'uri' },
+    // Do not use format: 'uri' as it fails on some payloads that should be considered valid
+    uri: { type: 'string', nullable: true, default: null },
     name: { type: 'string', nullable: true, default: null },
     description: { type: 'string', nullable: true, default: null },
-    imageUri: { type: 'string', nullable: true, default: null, format: 'uri' },
+    // Do not use format: 'uri' as it fails on some payloads that should be considered valid
+    imageUri: { type: 'string', nullable: true, default: null },
     metadata: { type: 'object', nullable: true, default: null },
   },
   required: ['address', 'tokenName', 'tokenSymbol', 'logoUri', 'id'],


### PR DESCRIPTION
Closes #356

The uri validation provided by AJV set for `uri` and `imageUri` fails on some payloads that should be considered valid

See `uri` and `imageUri` fields of the following request https://safe-client.safe.global/v2/chains/5/safes/0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C/collectibles

