### PR TITLE
fix: return `TransactionDetails` from `/propose`

### DIFF
--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -221,7 +221,7 @@ export class TransactionsController {
     @Param('safeAddress') safeAddress: string,
     @Body(ProposeTransactionDtoValidationPipe)
     proposeTransactionDto: ProposeTransactionDto,
-  ): Promise<Transaction> {
+  ): Promise<TransactionDetails> {
     return this.transactionsService.proposeTransaction(
       chainId,
       safeAddress,

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -368,7 +368,7 @@ export class TransactionsService {
     chainId: string,
     safeAddress: string,
     proposeTransactionDto: ProposeTransactionDto,
-  ): Promise<Transaction> {
+  ): Promise<TransactionDetails> {
     await this.safeRepository.proposeTransaction(
       chainId,
       safeAddress,
@@ -381,7 +381,7 @@ export class TransactionsService {
       proposeTransactionDto.safeTxHash,
     );
 
-    return this.multisigTransactionMapper.mapTransaction(
+    return this.multisigTransactionDetailsMapper.mapDetails(
       chainId,
       domainTransaction,
       safe,


### PR DESCRIPTION
Resolves #360, #433, #434, #435, #436, #437 and #438

The `ReturnType` of the `/propose` endpoint has been changed from a `Transaction` to `TransactionDetails`. The associated tests have been updated accordingly.