### PR TITLE
feat: add types to Swagger query parameters

### DIFF
--- a/src/routes/messages/messages.controller.ts
+++ b/src/routes/messages/messages.controller.ts
@@ -33,7 +33,7 @@ export class MessagesController {
 
   @ApiOkResponse({ type: MessagePage })
   @Get('chains/:chainId/safes/:safeAddress/messages')
-  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
   async getMessagesBySafe(
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,

--- a/src/routes/safe-apps/safe-apps.controller.ts
+++ b/src/routes/safe-apps/safe-apps.controller.ts
@@ -13,8 +13,8 @@ export class SafeAppsController {
 
   @ApiOkResponse({ type: SafeApp, isArray: true })
   @Get('chains/:chainId/safe-apps')
-  @ApiQuery({ name: 'clientUrl', required: false })
-  @ApiQuery({ name: 'url', required: false })
+  @ApiQuery({ name: 'clientUrl', required: false, type: String })
+  @ApiQuery({ name: 'url', required: false, type: String })
   async getSafeApps(
     @Param('chainId') chainId: string,
     @Query('clientUrl') clientUrl?: string,

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -58,7 +58,7 @@ export class TransactionsController {
   @ApiQuery({ name: 'to', required: false, type: String })
   @ApiQuery({ name: 'value', required: false, type: String })
   @ApiQuery({ name: 'nonce', required: false, type: String })
-  @ApiQuery({ name: 'executed', required: false, type: String })
+  @ApiQuery({ name: 'executed', required: false, type: Boolean })
   @ApiQuery({ name: 'cursor', required: false, type: String })
   async getMultisigTransactions(
     @Param('chainId') chainId: string,

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -53,13 +53,13 @@ export class TransactionsController {
 
   @ApiOkResponse({ type: MultisigTransactionPage })
   @Get('chains/:chainId/safes/:safeAddress/multisig-transactions')
-  @ApiQuery({ name: 'execution_date__gte', required: false })
-  @ApiQuery({ name: 'execution_date__lte', required: false })
-  @ApiQuery({ name: 'to', required: false })
-  @ApiQuery({ name: 'value', required: false })
-  @ApiQuery({ name: 'nonce', required: false })
-  @ApiQuery({ name: 'executed', required: false })
-  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'execution_date__gte', required: false, type: String })
+  @ApiQuery({ name: 'execution_date__lte', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
+  @ApiQuery({ name: 'value', required: false, type: String })
+  @ApiQuery({ name: 'nonce', required: false, type: String })
+  @ApiQuery({ name: 'executed', required: false, type: String })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
   async getMultisigTransactions(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
@@ -88,9 +88,9 @@ export class TransactionsController {
 
   @ApiOkResponse({ type: ModuleTransactionPage })
   @Get('chains/:chainId/safes/:safeAddress/module-transactions')
-  @ApiQuery({ name: 'to', required: false })
-  @ApiQuery({ name: 'module', required: false })
-  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'to', required: false, type: String })
+  @ApiQuery({ name: 'module', required: false, type: String })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
   async getModuleTransactions(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
@@ -127,12 +127,12 @@ export class TransactionsController {
 
   @ApiOkResponse({ type: IncomingTransferPage })
   @Get('chains/:chainId/safes/:safeAddress/incoming-transfers')
-  @ApiQuery({ name: 'execution_date__gte', required: false })
-  @ApiQuery({ name: 'execution_date__lte', required: false })
-  @ApiQuery({ name: 'to', required: false })
-  @ApiQuery({ name: 'value', required: false })
-  @ApiQuery({ name: 'token_address', required: false })
-  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'execution_date__gte', required: false, type: String })
+  @ApiQuery({ name: 'execution_date__lte', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
+  @ApiQuery({ name: 'value', required: false, type: String })
+  @ApiQuery({ name: 'token_address', required: false, type: String })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
   async getIncomingTransfers(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
@@ -175,9 +175,9 @@ export class TransactionsController {
 
   @ApiOkResponse({ type: QueuedItemPage })
   @Get('chains/:chainId/safes/:safeAddress/transactions/queued')
-  @ApiQuery({ name: 'cursor', required: false })
-  @ApiQuery({ name: 'timezone_offset', required: false })
-  @ApiQuery({ name: 'trusted', required: false })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
+  @ApiQuery({ name: 'timezone_offset', required: false, type: String })
+  @ApiQuery({ name: 'trusted', required: false, type: Boolean })
   async getTransactionQueue(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,
@@ -194,8 +194,8 @@ export class TransactionsController {
 
   @ApiOkResponse({ type: TransactionItemPage })
   @Get('chains/:chainId/safes/:safeAddress/transactions/history')
-  @ApiQuery({ name: 'timezone_offset', required: false })
-  @ApiQuery({ name: 'cursor', required: false })
+  @ApiQuery({ name: 'timezone_offset', required: false, type: String })
+  @ApiQuery({ name: 'cursor', required: false, type: String })
   async getTransactionsHistory(
     @Param('chainId') chainId: string,
     @RouteUrlDecorator() routeUrl: URL,


### PR DESCRIPTION
Resolves #337 

This add types to Swagger parameters, e.g. `trusted`, `timezone_offset` and `cursor`:

![image](https://github.com/safe-global/safe-client-gateway-nest/assets/20442784/d56bded9-1b22-4129-927b-a1700ffd9d70)