### PR TITLE
Return false on null data decoded

### DIFF
--- a/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.spec.ts
@@ -11,6 +11,7 @@ import { AddressInfo } from '../../../common/entities/address-info.entity';
 import { MULTI_SEND_METHOD_NAME } from '../../constants';
 import { DataDecodedParamHelper } from './data-decoded-param.helper';
 import { TransactionDataMapper } from './transaction-data.mapper';
+import { DELEGATE_OPERATION } from '../../../../domain/safe/entities/operation.entity';
 
 const addressInfoHelper = jest.mocked({
   get: jest.fn(),
@@ -45,6 +46,20 @@ describe('Transaction Data Mapper (Unit)', () => {
         dataDecodedBuilder().build(),
       );
       expect(actual).toBeNull();
+    });
+
+    it('should return false if data decoded is null', async () => {
+      const contract = contractBuilder().build();
+      contractsRepository.getContract.mockResolvedValue(contract);
+
+      const actual = await mapper.isTrustedDelegateCall(
+        faker.random.numeric(),
+        DELEGATE_OPERATION,
+        faker.finance.ethereumAddress(),
+        null,
+      );
+
+      expect(actual).toBe(false);
     });
 
     it('should mark as non-trusted for delegate call if the contract cannot be retrieved', async () => {

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -71,7 +71,7 @@ export class TransactionDataMapper {
    * If the transaction operation is DELEGATE, and the target {@link Contract}
    * is trusted, and the {@link DataDecoded} received contains a nested
    * DELEGATE operation, then true is returned.
-   * Otherwise the function will return false.
+   * Otherwise, the function will return false.
    */
   async isTrustedDelegateCall(
     chainId: string,
@@ -79,7 +79,7 @@ export class TransactionDataMapper {
     to: string,
     dataDecoded: DataDecoded | null,
   ): Promise<boolean | null> {
-    if (dataDecoded === null || operation !== DELEGATE_OPERATION) return null;
+    if (operation !== DELEGATE_OPERATION) return null;
 
     let contract: Contract;
     try {
@@ -88,10 +88,11 @@ export class TransactionDataMapper {
       return false;
     }
 
-    return (
-      contract.trustedForDelegateCall &&
-      this.dataDecodedParamHelper.hasNestedDelegate(dataDecoded)
-    );
+    const hasNestedDelegate = dataDecoded
+      ? this.dataDecodedParamHelper.hasNestedDelegate(dataDecoded)
+      : false;
+
+    return contract.trustedForDelegateCall && hasNestedDelegate;
   }
 
   /**


### PR DESCRIPTION
Closes #444

- Sets `isTrustedDelegateCall` to return `false` if `dataDecoded` is `null`
- It was previously returning `null` which should only be returned if the respective operation is not a `DELEGATE_OPERATION`