### PR TITLE
fix: retrieve transactions by `safeTxHash`

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -70,10 +70,11 @@ describe('Get by id - Transactions Controller (Unit)', () => {
 
   it('Failure: client-side validation error', async () => {
     const chainId = faker.random.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
     const id = faker.datatype.uuid();
 
     await request(app.getHttpServer())
-      .get(`/v1/chains/${chainId}/transactions/${id}_${id}`)
+      .get(`/v1/chains/${chainId}/transactions/unknown_${safeAddress}_${id}`)
       .expect(400)
       .expect({
         message: 'Invalid transaction type',

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -67,21 +67,6 @@ describe('Get by id - Transactions Controller (Unit)', () => {
   afterAll(async () => {
     await app.close();
   });
-
-  it('Failure: client-side validation error', async () => {
-    const chainId = faker.random.numeric();
-    const safeAddress = faker.finance.ethereumAddress();
-    const id = faker.datatype.uuid();
-
-    await request(app.getHttpServer())
-      .get(`/v1/chains/${chainId}/transactions/unknown_${safeAddress}_${id}`)
-      .expect(400)
-      .expect({
-        message: 'Invalid transaction type',
-        code: 400,
-      });
-  });
-
   it('Failure: Config API fails', async () => {
     const chainId = faker.random.numeric();
     const id = `module_${faker.datatype.uuid()}`;

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -54,6 +54,21 @@ export class TransactionsService {
   ) {}
 
   async getById(chainId: string, txId: string): Promise<TransactionDetails> {
+    const isSafeTxHash = !txId.includes(TRANSACTION_ID_SEPARATOR);
+
+    if (isSafeTxHash) {
+      const tx = await this.safeRepository.getMultiSigTransaction(
+        chainId,
+        txId,
+      );
+      const safe = await this.safeRepository.getSafe(chainId, tx.safe);
+      return this.multisigTransactionDetailsMapper.mapDetails(
+        chainId,
+        tx,
+        safe,
+      );
+    }
+
     const [txType, safeAddress, id] = txId.split(TRANSACTION_ID_SEPARATOR);
 
     if (txType === MODULE_TRANSACTION_PREFIX) {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { head, last } from 'lodash';
 import { MultisigTransaction as DomainMultisigTransaction } from '../../domain/safe/entities/multisig-transaction.entity';
 import { SafeRepository } from '../../domain/safe/safe.repository';
@@ -54,53 +54,55 @@ export class TransactionsService {
   ) {}
 
   async getById(chainId: string, txId: string): Promise<TransactionDetails> {
-    const isSafeTxHash = !txId.includes(TRANSACTION_ID_SEPARATOR);
-
-    if (isSafeTxHash) {
-      const tx = await this.safeRepository.getMultiSigTransaction(
-        chainId,
-        txId,
-      );
-      const safe = await this.safeRepository.getSafe(chainId, tx.safe);
-      return this.multisigTransactionDetailsMapper.mapDetails(
-        chainId,
-        tx,
-        safe,
-      );
-    }
-
     const [txType, safeAddress, id] = txId.split(TRANSACTION_ID_SEPARATOR);
 
-    if (txType === MODULE_TRANSACTION_PREFIX) {
-      const [tx, safe] = await Promise.all([
-        this.safeRepository.getModuleTransaction(chainId, id),
-        this.safeRepository.getSafe(chainId, safeAddress),
-      ]);
-      return this.moduleTransactionDetailsMapper.mapDetails(chainId, tx, safe);
-    }
-    if (txType === TRANSFER_PREFIX) {
-      const [transfer, safe] = await Promise.all([
-        this.safeRepository.getTransfer(chainId, id),
-        this.safeRepository.getSafe(chainId, safeAddress),
-      ]);
-      return this.transferDetailsMapper.mapDetails(chainId, transfer, safe);
-    }
-    if (txType === MULTISIG_TRANSACTION_PREFIX) {
-      const [tx, safe] = await Promise.all([
-        this.safeRepository.getMultiSigTransaction(chainId, id),
-        this.safeRepository.getSafe(chainId, safeAddress),
-      ]);
-      return this.multisigTransactionDetailsMapper.mapDetails(
-        chainId,
-        tx,
-        safe,
-      );
-    }
+    switch (txType) {
+      case MODULE_TRANSACTION_PREFIX: {
+        const [tx, safe] = await Promise.all([
+          this.safeRepository.getModuleTransaction(chainId, id),
+          this.safeRepository.getSafe(chainId, safeAddress),
+        ]);
+        return this.moduleTransactionDetailsMapper.mapDetails(
+          chainId,
+          tx,
+          safe,
+        );
+      }
 
-    throw new BadRequestException({
-      message: 'Invalid transaction type',
-      code: 400,
-    });
+      case TRANSFER_PREFIX: {
+        const [transfer, safe] = await Promise.all([
+          this.safeRepository.getTransfer(chainId, id),
+          this.safeRepository.getSafe(chainId, safeAddress),
+        ]);
+        return this.transferDetailsMapper.mapDetails(chainId, transfer, safe);
+      }
+
+      case MULTISIG_TRANSACTION_PREFIX: {
+        const [tx, safe] = await Promise.all([
+          this.safeRepository.getMultiSigTransaction(chainId, id),
+          this.safeRepository.getSafe(chainId, safeAddress),
+        ]);
+        return this.multisigTransactionDetailsMapper.mapDetails(
+          chainId,
+          tx,
+          safe,
+        );
+      }
+
+      // txId is safeTxHash
+      default: {
+        const tx = await this.safeRepository.getMultiSigTransaction(
+          chainId,
+          txId,
+        );
+        const safe = await this.safeRepository.getSafe(chainId, tx.safe);
+        return this.multisigTransactionDetailsMapper.mapDetails(
+          chainId,
+          tx,
+          safe,
+        );
+      }
+    }
   }
 
   async getMultisigTransactions(


### PR DESCRIPTION
Resolves #446

If an the `safeTxHash` is used to retrieve a transaction, it fetches a multisig transaction with it.

[Reference](https://github.com/safe-global/safe-client-gateway/blob/main/src/routes/transactions/handlers/details.rs#L198) from the previous gateway.