### PR TITLE
Remove created messages validation

### DIFF
--- a/src/domain/messages/messages.repository.interface.ts
+++ b/src/domain/messages/messages.repository.interface.ts
@@ -19,7 +19,7 @@ export interface IMessagesRepository {
     message: unknown,
     safeAppId: number,
     signature: string,
-  ): Promise<Message>;
+  ): Promise<unknown>;
 
   updateMessageSignature(
     chainId: string,

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -46,16 +46,16 @@ export class MessagesRepository implements IMessagesRepository {
     message: unknown,
     safeAppId: number | null,
     signature: string,
-  ): Promise<Message> {
+  ): Promise<unknown> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(chainId);
-    const createdMessage = await transactionService.postMessage(
+
+    return transactionService.postMessage(
       safeAddress,
       message,
       safeAppId,
       signature,
     );
-    return this.messageValidator.validate(createdMessage);
   }
 
   async updateMessageSignature(


### PR DESCRIPTION
Closes #439

As I commented in https://github.com/safe-global/safe-client-gateway-nest/issues/439#issuecomment-1597423163, we were validating the Transaction Service response when a message gets created. Based on the OpenAPI definition, we assumed a body containing a `Message` entity would be returned by the Transaction Service but that's not the case. 

This change removes the validation for the payload coming from the Transaction Service when creating a new message. 