### PR TITLE
fix: solve `faker` deprecations

### DIFF
--- a/src/__tests__/faker.ts
+++ b/src/__tests__/faker.ts
@@ -1,0 +1,20 @@
+import { faker } from '@faker-js/faker';
+
+/**
+ * `faker.datatype.json` will be deprecated from version 9.0
+ * The following is the implementation taken from version 8.0.2
+ * @see https://github.com/faker-js/faker/blob/651d1a8cd11b2d562c7a6473b8a544b81d5fbb95/src/modules/datatype/index.ts#LL415C5-L424C41
+ */
+
+export function fakeJson(): string {
+  const properties = ['foo', 'bar', 'bike', 'a', 'b', 'name', 'prop'];
+  const returnObject: Record<string, string | number> = {};
+
+  properties.forEach((prop) => {
+    returnObject[prop] = faker.datatype.boolean()
+      ? faker.string.sample()
+      : faker.number.int();
+  });
+
+  return JSON.stringify(returnObject);
+}

--- a/src/__tests__/faker.ts
+++ b/src/__tests__/faker.ts
@@ -1,8 +1,20 @@
+/**
+ * Faker v8.0.2
+ * https://fakerjs.dev/
+ *
+ * Copyright 2022-2023 Faker and other contributors
+ *
+ * Released under the MIT license
+ * https://github.com/faker-js/faker/blob/bbda1d7e2ce0b0bd33a3cc78458a73cd79e3eca0/LICENSE
+ *
+ * Date: 2021-06-21
+ */
+
 import { faker } from '@faker-js/faker';
 
 /**
- * `faker.datatype.json` will be deprecated from version 9.0
- * The following is the implementation taken from version 8.0.2
+ * `faker.datatype.json` will be deprecated from version v9.0
+ * The following is the implementation taken from version v8.0.2
  * @see https://github.com/faker-js/faker/blob/651d1a8cd11b2d562c7a6473b8a544b81d5fbb95/src/modules/datatype/index.ts#LL415C5-L424C41
  */
 

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -1,17 +1,18 @@
 import { faker } from '@faker-js/faker';
 import { validate } from './configuration.validator';
+import { fakeJson } from '../__tests__/faker';
 
 describe('Configuration validator', () => {
   it('should bypass this validation on tests', () => {
     process.env.NODE_ENV = 'test';
-    const expected = JSON.parse(faker.datatype.json());
+    const expected = JSON.parse(fakeJson());
     const validated = validate(expected);
     expect(validated).toBe(expected);
   });
 
   it('should detect a malformed configuration in production environment', () => {
     process.env.NODE_ENV = 'production';
-    expect(() => validate(JSON.parse(faker.datatype.json()))).toThrow(
+    expect(() => validate(JSON.parse(fakeJson()))).toThrow(
       /Mandatory configuration is missing: .*AUTH_TOKEN.*EXCHANGE_API_KEY/,
     );
   });
@@ -19,7 +20,7 @@ describe('Configuration validator', () => {
   it('should return the input configuration if validated in production environment', () => {
     process.env.NODE_ENV = 'production';
     const expected = {
-      ...JSON.parse(faker.datatype.json()),
+      ...JSON.parse(fakeJson()),
       AUTH_TOKEN: faker.string.uuid(),
       EXCHANGE_API_KEY: faker.string.uuid(),
     };

--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -6,6 +6,7 @@ import { CacheFirstDataSource } from './cache.first.data.source';
 import { ICacheService } from './cache.service.interface';
 import { CacheDir } from './entities/cache-dir.entity';
 import { FakeCacheService } from './__tests__/fake.cache.service';
+import { fakeJson } from '../../__tests__/faker';
 
 const mockLoggingService = {
   info: jest.fn(),
@@ -31,7 +32,7 @@ describe('CacheFirstDataSource', () => {
   it('should return the data returned by the underlying network interface', async () => {
     const targetUrl = faker.internet.url({ appendSlash: false });
     const cacheDir = new CacheDir(faker.word.sample(), faker.word.sample());
-    const data = JSON.parse(faker.datatype.json());
+    const data = JSON.parse(fakeJson());
     mockNetworkService.get.mockImplementation((url) => {
       switch (url) {
         case targetUrl:
@@ -49,7 +50,7 @@ describe('CacheFirstDataSource', () => {
 
   it('should return the cached data without calling the underlying network interface', async () => {
     const cacheDir = new CacheDir(faker.word.sample(), faker.word.sample());
-    const rawJson = faker.datatype.json();
+    const rawJson = fakeJson();
     fakeCacheService.set(cacheDir, rawJson);
     mockNetworkService.get.mockImplementation((url) =>
       Promise.reject(`Unexpected request to ${url}`),

--- a/src/datasources/cache/redis.cache.service.spec.ts
+++ b/src/datasources/cache/redis.cache.service.spec.ts
@@ -5,6 +5,7 @@ import { CacheDir } from './entities/cache-dir.entity';
 import { RedisCacheService } from './redis.cache.service';
 import { FakeConfigurationService } from '../../config/__tests__/fake.configuration.service';
 import clearAllMocks = jest.clearAllMocks;
+import { fakeJson } from '../../__tests__/faker';
 
 const redisClientType = {
   hGet: jest.fn(),
@@ -42,7 +43,7 @@ describe('RedisCacheService', () => {
       faker.string.alphanumeric(),
       faker.string.sample(),
     );
-    const value = faker.datatype.json();
+    const value = fakeJson();
 
     await redisCacheService.set(cacheDir, value, undefined);
 
@@ -58,7 +59,7 @@ describe('RedisCacheService', () => {
       faker.string.alphanumeric(),
       faker.string.sample(),
     );
-    const value = faker.datatype.json();
+    const value = fakeJson();
     const expireTime = faker.number.int();
 
     await redisCacheService.set(cacheDir, value, expireTime);
@@ -81,7 +82,7 @@ describe('RedisCacheService', () => {
       faker.string.alphanumeric(),
       faker.string.sample(),
     );
-    const value = faker.datatype.json();
+    const value = fakeJson();
     const expireTimeSeconds = faker.number.int({ min: 5 });
     redisClientTypeMock.expire.mockRejectedValueOnce(new Error('cache error'));
 
@@ -113,7 +114,7 @@ describe('RedisCacheService', () => {
       faker.string.alphanumeric(),
       faker.string.sample(),
     );
-    const value = faker.datatype.json();
+    const value = fakeJson();
     redisClientTypeMock.hSet.mockRejectedValueOnce(new Error('cache error'));
 
     await expect(

--- a/src/domain/backbone/entities/__tests__/backbone.builder.ts
+++ b/src/domain/backbone/entities/__tests__/backbone.builder.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Backbone } from '../backbone.entity';
 import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { fakeJson } from '../../../../__tests__/faker';
 
 export function backboneBuilder(): IBuilder<Backbone> {
   return Builder.new<Backbone>()
@@ -15,5 +16,5 @@ export function backboneBuilder(): IBuilder<Backbone> {
         faker.word.sample(),
       ),
     )
-    .with('settings', JSON.parse(faker.datatype.json()));
+    .with('settings', JSON.parse(fakeJson()));
 }

--- a/src/domain/chains/entities/__tests__/chain.builder.ts
+++ b/src/domain/chains/entities/__tests__/chain.builder.ts
@@ -14,7 +14,7 @@ export function chainBuilder(): IBuilder<Chain> {
     .with('chainName', faker.company.name())
     .with('description', faker.word.words())
     .with('l2', faker.datatype.boolean())
-    .with('shortName', faker.company.companySuffix())
+    .with('shortName', faker.company.name())
     .with('rpcUri', rpcUriBuilder().build())
     .with('safeAppsRpcUri', rpcUriBuilder().build())
     .with('publicRpcUri', rpcUriBuilder().build())

--- a/src/domain/contracts/entities/__tests__/contract.builder.ts
+++ b/src/domain/contracts/entities/__tests__/contract.builder.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Contract } from '../contract.entity';
 import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { fakeJson } from '../../../../__tests__/faker';
 
 export function contractBuilder(): IBuilder<Contract> {
   return Builder.new<Contract>()
@@ -8,6 +9,6 @@ export function contractBuilder(): IBuilder<Contract> {
     .with('name', faker.word.sample())
     .with('displayName', faker.word.words())
     .with('logoUri', faker.internet.url({ appendSlash: false }))
-    .with('contractAbi', JSON.parse(faker.datatype.json()))
+    .with('contractAbi', JSON.parse(fakeJson()))
     .with('trustedForDelegateCall', faker.datatype.boolean());
 }

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -176,9 +176,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_balances_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -224,9 +224,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_multisig_transactions_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -272,9 +272,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_multisig_transaction_${payload.safeTxHash}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -311,9 +311,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_safe_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -360,9 +360,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_collectibles_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -409,9 +409,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_transfers_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -453,9 +453,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_incoming_transfers_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -492,9 +492,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_module_transactions_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,
@@ -556,9 +556,9 @@ describe('Post Hook Events (Unit)', () => {
     const chainId = faker.string.numeric();
     const cacheDir = new CacheDir(
       `${chainId}_all_transactions_${safeAddress}`,
-      faker.random.alpha(),
+      faker.string.alpha(),
     );
-    await fakeCacheService.set(cacheDir, faker.random.alpha());
+    await fakeCacheService.set(cacheDir, faker.string.alpha());
     const data = {
       address: safeAddress,
       chainId: chainId,

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -579,40 +579,40 @@ describe('Messages controller', () => {
           .with('safeAppId', null)
           .with(
             'created',
-            faker.date.between(
-              new Date(Date.UTC(2025, 0, 1, 16)).toISOString(),
-              new Date(Date.UTC(2025, 0, 1, 17)).toISOString(),
-            ),
+            faker.date.between({
+              from: new Date(Date.UTC(2025, 0, 1, 16)).toISOString(),
+              to: new Date(Date.UTC(2025, 0, 1, 17)).toISOString(),
+            }),
           )
           .build(),
         messageBuilder()
           .with('safeAppId', null)
           .with(
             'created',
-            faker.date.between(
-              new Date(Date.UTC(2025, 0, 2)).toISOString(),
-              new Date(Date.UTC(2025, 0, 3) - 1).toISOString(),
-            ),
+            faker.date.between({
+              from: new Date(Date.UTC(2025, 0, 2)).toISOString(),
+              to: new Date(Date.UTC(2025, 0, 3) - 1).toISOString(),
+            }),
           )
           .build(),
         messageBuilder()
           .with('safeAppId', null)
           .with(
             'created',
-            faker.date.between(
-              new Date(Date.UTC(2025, 0, 1, 10)).toISOString(),
-              new Date(Date.UTC(2025, 0, 1, 11)).toISOString(),
-            ),
+            faker.date.between({
+              from: new Date(Date.UTC(2025, 0, 1, 10)).toISOString(),
+              to: new Date(Date.UTC(2025, 0, 1, 11)).toISOString(),
+            }),
           )
           .build(),
         messageBuilder()
           .with('safeAppId', null)
           .with(
             'created',
-            faker.date.between(
-              new Date(Date.UTC(2025, 0, 3)).toISOString(),
-              new Date(Date.UTC(2025, 0, 4) - 1).toISOString(),
-            ),
+            faker.date.between({
+              from: new Date(Date.UTC(2025, 0, 3)).toISOString(),
+              to: new Date(Date.UTC(2025, 0, 4) - 1).toISOString(),
+            }),
           )
           .build(),
       ];

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -170,7 +170,10 @@ describe('Transactions History Controller (Unit)', () => {
         .with('dataDecoded', null)
         .with(
           'executionDate',
-          faker.date.between('2022-12-06T23:00:00Z', '2022-12-06T23:59:59Z'),
+          faker.date.between({
+            from: '2022-12-06T23:00:00Z',
+            to: '2022-12-06T23:59:59Z',
+          }),
         )
         .build(),
     );
@@ -180,7 +183,10 @@ describe('Transactions History Controller (Unit)', () => {
         .with('origin', null)
         .with(
           'executionDate',
-          faker.date.between('2022-12-25T00:00:00Z', '2022-12-25T00:59:59Z'),
+          faker.date.between({
+            from: '2022-12-25T00:00:00Z',
+            to: '2022-12-25T00:59:59Z',
+          }),
         )
         .build(),
     );
@@ -191,7 +197,10 @@ describe('Transactions History Controller (Unit)', () => {
       ethereumTransactionBuilder()
         .with(
           'executionDate',
-          faker.date.between('2022-12-31T00:00:00Z', '2022-12-31T23:59:59Z'),
+          faker.date.between({
+            from: '2022-12-31T00:00:00Z',
+            to: '2022-12-31T23:59:59Z',
+          }),
         )
         .with('transfers', [transfer])
         .build(),


### PR DESCRIPTION
Resolves `faker` deprecation warnings in console when testing according to official docs :

- [`faker.company.companySuffix`](https://fakerjs.dev/api/company.html#companysuffix) -> [`faker.company.name`](https://fakerjs.dev/api/company.html#name)
- `faker.date.between` -> [`faker.date.between` given boundaries](https://fakerjs.dev/api/date.html#between)
- [`faker.datatype.json`](https://fakerjs.dev/api/datatype.html#json) -> proprietary implementation based on [the current `faker.datatype.json` implementation](https://github.com/faker-js/faker/blob/651d1a8cd11b2d562c7a6473b8a544b81d5fbb95/src/modules/datatype/index.ts#LL415C5-L424C41)
- [`faker.random.alpha`](https://fakerjs.dev/api/random.html#alpha) -> [`faker.string.alpha`](https://fakerjs.dev/api/string.html#alpha)
