### PR TITLE
Remove contributors from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,24 +2,6 @@
   "name": "safe-client-gateway",
   "version": "0.0.1",
   "description": "",
-  "contributors": [
-    {
-      "name": "Frederico Sabino",
-      "url": "https://github.com/fmrsabino"
-    },
-    {
-      "name": "Héctor Gómez",
-      "url": "https://github.com/hectorgomezv"
-    },
-    {
-      "name": "Uxío Fuentefría",
-      "url": "https://github.com/uxio0"
-    },
-    {
-      "name": "Moisés Fernández",
-      "url": "https://github.com/moisses89"
-    }
-  ],
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
- Removes `contributors` field from `package.json`
- As the project evolves (and we get more contributions from different accounts), this field becomes harder to maintain. We can also track contributions via Git itself