### PR TITLE
Fix bad request and response in TransactionApi.postDelegate

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -251,11 +251,11 @@ export class TransactionApi implements ITransactionApi {
     delegator?: string,
     signature?: string,
     label?: string,
-  ): Promise<unknown> {
+  ): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/delegates/`;
-      return await this.networkService.post(url, {
-        safe: safeAddress,
+      await this.networkService.post(url, {
+        safe: safeAddress ?? null, // TODO: this is a workaround while https://github.com/safe-global/safe-transaction-service/issues/1521 is not fixed.
         delegate: delegate,
         delegator: delegator,
         signature: signature,

--- a/src/domain/delegate/delegate.repository.interface.ts
+++ b/src/domain/delegate/delegate.repository.interface.ts
@@ -21,7 +21,7 @@ export interface IDelegateRepository {
     delegator?: string,
     signature?: string,
     label?: string,
-  ): Promise<unknown>;
+  ): Promise<void>;
 
   deleteDelegate(
     chainId: string,

--- a/src/domain/delegate/delegate.repository.ts
+++ b/src/domain/delegate/delegate.repository.ts
@@ -44,17 +44,16 @@ export class DelegateRepository implements IDelegateRepository {
     delegator?: string,
     signature?: string,
     label?: string,
-  ): Promise<unknown> {
+  ): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(chainId);
-    const result = await transactionService.postDelegate(
+    await transactionService.postDelegate(
       safeAddress,
       delegate,
       delegator,
       signature,
       label,
     );
-    return result;
   }
 
   async deleteDelegate(

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -67,7 +67,7 @@ export interface ITransactionApi {
     delegator?: string,
     signature?: string,
     label?: string,
-  ): Promise<unknown>;
+  ): Promise<void>;
 
   deleteDelegate(
     delegate: string,

--- a/src/routes/delegates/delegates.controller.ts
+++ b/src/routes/delegates/delegates.controller.ts
@@ -79,8 +79,8 @@ export class DelegatesController {
   async postDelegate(
     @Param('chainId') chainId: string,
     @Body(CreateDelegateDtoValidationPipe) createDelegateDto: CreateDelegateDto,
-  ): Promise<unknown> {
-    return this.service.postDelegate(chainId, createDelegateDto);
+  ): Promise<void> {
+    await this.service.postDelegate(chainId, createDelegateDto);
   }
 
   @Delete('chains/:chainId/delegates/:delegateAddress')

--- a/src/routes/delegates/delegates.service.ts
+++ b/src/routes/delegates/delegates.service.ts
@@ -51,8 +51,8 @@ export class DelegatesService {
   async postDelegate(
     chainId: string,
     createDelegateDto: CreateDelegateDto,
-  ): Promise<unknown> {
-    return await this.repository.postDelegate(
+  ): Promise<void> {
+    await this.repository.postDelegate(
       chainId,
       createDelegateDto.safe,
       createDelegateDto.delegate,


### PR DESCRIPTION
Closes #457 

This PR fixes two things related with the `TransactionApi.postDelegate` function:

- The function was returning the whole `NetworkResponse` object, which was generating a 500 status error while trying to serialize the whole object to JSON before sending the response to the client. In fact, this endpoint is expected to return no data so I just removed the return statement.
- The function was also sending `safe: undefined` in the payload, which is correct, but it seems the Transaction Service has a bug in my opinion related to this, since passing `undefined` generates a 500 status error in the Transaction Service, but passing `null` doesn't. So `safe: safeAddress ?? null` is now used as a workaround. A TODO comment is added to change this back when the Transaction Service bug gets fixed (I have opened a ticket here: https://github.com/safe-global/safe-transaction-service/issues/1521)