### PR TITLE
Return TransactionDetails on addConfirmation endpoint

### DIFF
--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -25,6 +25,8 @@ import { addConfirmationDtoBuilder } from '../entities/add-confirmation.dto.buil
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
+import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
+import { pageBuilder } from '../../../../domain/entities/__tests__/page.builder';
 
 describe('Add transaction confirmations - Transactions Controller (Unit)', () => {
   let app: INestApplication;
@@ -76,23 +78,44 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       multisigTransactionBuilder().build(),
     ) as MultisigTransaction;
     const safe = safeBuilder().with('address', transaction.safe).build();
+    const gasToken = tokenBuilder().build();
+    const token = tokenBuilder().build();
+    const safeAppsResponse = [
+      safeAppBuilder()
+        .with('url', faker.internet.url({ appendSlash: false }))
+        .with('iconUrl', faker.internet.url({ appendSlash: false }))
+        .with('name', faker.word.words())
+        .build(),
+    ];
+    const replacementTxsPage = pageBuilder().with('results', []).build();
     mockNetworkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/`;
+      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${transaction.safe}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
-      const getContractUrl = `${chain.transactionService}/api/v1/contracts/${transaction.to}`;
+      const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${transaction.gasToken}`;
+      const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${transaction.to}`;
+      const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${transaction.to}`;
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
         case getMultisigTransactionUrl:
           return Promise.resolve({ data: transaction });
+        case getMultisigTransactionsUrl:
+          return Promise.resolve({ data: replacementTxsPage });
         case getSafeUrl:
           return Promise.resolve({ data: safe });
         case getSafeAppsUrl:
           return Promise.resolve({ data: safeApps });
-        case getContractUrl:
+        case getGasTokenContractUrl:
+          return Promise.resolve({ data: gasToken });
+        case getToContractUrl:
           return Promise.resolve({ data: contract });
+        case getToTokenUrl:
+          return Promise.resolve({ data: token });
+        case getSafeAppsUrl:
+          return Promise.resolve({ data: safeAppsResponse });
         default:
           return Promise.reject(new Error(`Could not match ${url}`));
       }
@@ -114,19 +137,17 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       .send(addConfirmationDto)
       .expect(200)
       .expect(({ body }) =>
-        expect(body).toEqual(
-          expect.objectContaining({
-            id: `multisig_${transaction.safe}_${transaction.safeTxHash}`,
-            timestamp: expect.any(Number),
-            txStatus: expect.any(String),
-            txInfo: expect.any(Object),
-            executionInfo: expect.objectContaining({
-              type: 'MULTISIG',
-              nonce: transaction.nonce,
-            }),
-            safeAppInfo: expect.any(Object),
-          }),
-        ),
+        expect(body).toMatchObject({
+          safeAddress: safe.address,
+          txId: `multisig_${transaction.safe}_${transaction.safeTxHash}`,
+          executedAt: expect.any(Number),
+          txStatus: expect.any(String),
+          txInfo: expect.any(Object),
+          txData: expect.any(Object),
+          txHash: transaction.transactionHash,
+          detailedExecutionInfo: expect.any(Object),
+          safeAppInfo: expect.any(Object),
+        }),
       );
   });
 });

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -117,7 +117,7 @@ export class TransactionsController {
     @Param('safeTxHash') safeTxHash: string,
     @Body(AddConfirmationDtoValidationPipe)
     addConfirmationDto: AddConfirmationDto,
-  ): Promise<Transaction> {
+  ): Promise<TransactionDetails> {
     return this.transactionsService.addConfirmation(
       chainId,
       safeTxHash,

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -19,7 +19,6 @@ import { PreviewTransactionDto } from './entities/preview-transaction.dto.entity
 import { QueuedItem } from './entities/queued-item.entity';
 import { TransactionItemPage } from './entities/transaction-item-page.entity';
 import { TransactionPreview } from './entities/transaction-preview.entity';
-import { Transaction } from './entities/transaction.entity';
 import { ModuleTransactionMapper } from './mappers/module-transactions/module-transaction.mapper';
 import { MultisigTransactionMapper } from './mappers/multisig-transactions/multisig-transaction.mapper';
 import { QueuedItemsMapper } from './mappers/queued-items/queued-items.mapper';
@@ -166,7 +165,7 @@ export class TransactionsService {
     chainId: string,
     safeTxHash: string,
     addConfirmationDto: AddConfirmationDto,
-  ): Promise<Transaction> {
+  ): Promise<TransactionDetails> {
     await this.safeRepository.addConfirmation(
       chainId,
       safeTxHash,
@@ -178,7 +177,7 @@ export class TransactionsService {
     );
     const safe = await this.safeRepository.getSafe(chainId, transaction.safe);
 
-    return this.multisigTransactionMapper.mapTransaction(
+    return this.multisigTransactionDetailsMapper.mapDetails(
       chainId,
       transaction,
       safe,


### PR DESCRIPTION
Closes #458 

This PR:
- Fixes the return type for POST method to `/chains/:chainId/transactions/:safeTxHash/confirmations`, since the expected return type is `TransactionDetails` but `Transaction` was being returned by mistake.