### PR TITLE
Fix malformed URL when adding confirmations

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -422,7 +422,7 @@ export class TransactionApi implements ITransactionApi {
     addConfirmationDto: AddConfirmationDto,
   ): Promise<unknown> {
     try {
-      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations`;
+      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       return await this.networkService.post(url, {
         signature: addConfirmationDto.signedSafeTxHash,
       });

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -121,7 +121,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
       }
     });
     mockNetworkService.post.mockImplementation((url) => {
-      const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/confirmations`;
+      const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       switch (url) {
         case postConfirmationUrl:
           return Promise.resolve();


### PR DESCRIPTION
Closes #493 

This PR:
- Fixes an incorrect URL when calling the Transaction Service. `/` is mandatory at the end of the URL. 