### PR TITLE
Add missing unit tests for data mappers 

### DIFF
--- a/src/routes/common/__tests__/entities/address-info.builder.ts
+++ b/src/routes/common/__tests__/entities/address-info.builder.ts
@@ -1,0 +1,10 @@
+import { faker } from '@faker-js/faker';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { AddressInfo } from '../../entities/address-info.entity';
+
+export function addressInfoBuilder(): IBuilder<AddressInfo> {
+  return Builder.new<AddressInfo>()
+    .with('value', faker.finance.ethereumAddress())
+    .with('name', faker.word.words())
+    .with('logoUri', faker.internet.url({ appendSlash: false }));
+}

--- a/src/routes/transactions/entities/__tests__/safe-app-info.builder.ts
+++ b/src/routes/transactions/entities/__tests__/safe-app-info.builder.ts
@@ -1,0 +1,10 @@
+import { faker } from '@faker-js/faker';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { SafeAppInfo } from '../safe-app-info.entity';
+
+export function safeAppInfoBuilder(): IBuilder<SafeAppInfo> {
+  return Builder.new<SafeAppInfo>()
+    .with('name', faker.word.words())
+    .with('url', faker.internet.url({ appendSlash: false }))
+    .with('logoUri', faker.internet.url({ appendSlash: false }));
+}

--- a/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
+++ b/src/routes/transactions/entities/__tests__/transfer-transaction-info.builder.ts
@@ -1,0 +1,23 @@
+import { sample } from 'lodash';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { erc20TransferBuilder } from '../../../../domain/safe/entities/__tests__/erc20-transfer.builder';
+import { addressInfoBuilder } from '../../../common/__tests__/entities/address-info.builder';
+import {
+  TransferDirection,
+  TransferTransactionInfo,
+} from '../transfer-transaction-info.entity';
+
+export function transferTransactionInfoBuilder(): IBuilder<TransferTransactionInfo> {
+  return Builder.new<TransferTransactionInfo>()
+    .with('type', 'Transfer')
+    .with('sender', addressInfoBuilder().build())
+    .with('recipient', addressInfoBuilder().build())
+    .with(
+      'direction',
+      sample(Object.values(TransferDirection)) ?? TransferDirection.Incoming,
+    )
+    .with('transferInfo', {
+      ...erc20TransferBuilder().build(),
+      type: 'ERC20_TRANSFER',
+    });
+}

--- a/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
+++ b/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
@@ -1,0 +1,41 @@
+import { faker } from '@faker-js/faker';
+import { random, range, sampleSize } from 'lodash';
+import { Builder, IBuilder } from '../../../../__tests__/builder';
+import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
+import { addressInfoBuilder } from '../../../common/__tests__/entities/address-info.builder';
+import {
+  MultisigConfirmationDetails,
+  MultisigExecutionDetails,
+} from '../../entities/transaction-details/multisig-execution-details.entity';
+
+function multisigConfirmationDetailsBuilder(): IBuilder<MultisigConfirmationDetails> {
+  return Builder.new<MultisigConfirmationDetails>()
+    .with('signer', addressInfoBuilder().build())
+    .with('signature', faker.string.sample())
+    .with('submittedAt', faker.number.int());
+}
+
+export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDetails> {
+  const signers = range(random(2, 5)).map(() => addressInfoBuilder().build());
+  const confirmations = range(random(2, 5)).map(() =>
+    multisigConfirmationDetailsBuilder().build(),
+  );
+
+  return Builder.new<MultisigExecutionDetails>()
+    .with('type', 'MULTISIG')
+    .with('submittedAt', faker.number.int())
+    .with('nonce', faker.number.int())
+    .with('safeTxGas', faker.string.numeric())
+    .with('baseGas', faker.string.numeric())
+    .with('gasPrice', faker.string.numeric())
+    .with('gasToken', faker.finance.ethereumAddress())
+    .with('refundReceiver', addressInfoBuilder().build())
+    .with('safeTxHash', faker.string.sample())
+    .with('executor', addressInfoBuilder().build())
+    .with('signers', signers)
+    .with('confirmationsRequired', faker.number.int())
+    .with('confirmations', confirmations)
+    .with('rejectors', sampleSize(signers, 2))
+    .with('gasTokenInfo', tokenBuilder().build())
+    .with('trusted', faker.datatype.boolean());
+}

--- a/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
+++ b/src/routes/transactions/mappers/__tests__/multisig-execution-details.builder.ts
@@ -8,6 +8,9 @@ import {
   MultisigExecutionDetails,
 } from '../../entities/transaction-details/multisig-execution-details.entity';
 
+const MIN_SIGNERS = 2;
+const MAX_SIGNERS = 5;
+
 function multisigConfirmationDetailsBuilder(): IBuilder<MultisigConfirmationDetails> {
   return Builder.new<MultisigConfirmationDetails>()
     .with('signer', addressInfoBuilder().build())
@@ -16,8 +19,10 @@ function multisigConfirmationDetailsBuilder(): IBuilder<MultisigConfirmationDeta
 }
 
 export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDetails> {
-  const signers = range(random(2, 5)).map(() => addressInfoBuilder().build());
-  const confirmations = range(random(2, 5)).map(() =>
+  const signers = range(random(MIN_SIGNERS, MAX_SIGNERS)).map(() =>
+    addressInfoBuilder().build(),
+  );
+  const confirmations = range(random(MIN_SIGNERS, MAX_SIGNERS)).map(() =>
     multisigConfirmationDetailsBuilder().build(),
   );
 
@@ -33,9 +38,9 @@ export function multisigExecutionDetailsBuilder(): IBuilder<MultisigExecutionDet
     .with('safeTxHash', faker.string.sample())
     .with('executor', addressInfoBuilder().build())
     .with('signers', signers)
-    .with('confirmationsRequired', faker.number.int())
+    .with('confirmationsRequired', faker.number.int({ max: signers.length }))
     .with('confirmations', confirmations)
-    .with('rejectors', sampleSize(signers, 2))
+    .with('rejectors', sampleSize(signers, MIN_SIGNERS))
     .with('gasTokenInfo', tokenBuilder().build())
     .with('trusted', faker.datatype.boolean());
 }

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
@@ -1,0 +1,130 @@
+import { faker } from '@faker-js/faker';
+import { sample } from 'lodash';
+import { moduleTransactionBuilder } from '../../../../domain/safe/entities/__tests__/module-transaction.builder';
+import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import { addressInfoBuilder } from '../../../common/__tests__/entities/address-info.builder';
+import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
+import { transferTransactionInfoBuilder } from '../../entities/__tests__/transfer-transaction-info.builder';
+import { ModuleExecutionDetails } from '../../entities/transaction-details/module-execution-details.entity';
+import { TransactionStatus } from '../../entities/transaction-status.entity';
+import { TransactionDataMapper } from '../common/transaction-data.mapper';
+import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper';
+import { ModuleTransactionDetailsMapper } from './module-transaction-details.mapper';
+import { ModuleTransactionStatusMapper } from './module-transaction-status.mapper';
+
+describe('ModuleTransactionDetails mapper (Unit)', () => {
+  let mapper: ModuleTransactionDetailsMapper;
+
+  const addressInfoHelper = jest.mocked({
+    getOrDefault: jest.fn(),
+  } as unknown as AddressInfoHelper);
+
+  const statusMapper = jest.mocked({
+    mapTransactionStatus: jest.fn(),
+  } as unknown as ModuleTransactionStatusMapper);
+
+  const transactionInfoMapper = jest.mocked({
+    mapTransactionInfo: jest.fn(),
+  } as unknown as MultisigTransactionInfoMapper);
+
+  const transactionDataMapper = jest.mocked({
+    isTrustedDelegateCall: jest.fn(),
+    buildAddressInfoIndex: jest.fn(),
+  } as unknown as TransactionDataMapper);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mapper = new ModuleTransactionDetailsMapper(
+      addressInfoHelper,
+      statusMapper,
+      transactionInfoMapper,
+      transactionDataMapper,
+    );
+  });
+
+  it('should return a TransactionDetails object with an empty addressInfoIndex', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = moduleTransactionBuilder().build();
+    const safe = safeBuilder().build();
+    const txStatus =
+      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
+    const txInfo = transferTransactionInfoBuilder().build();
+    transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    transactionDataMapper.buildAddressInfoIndex.mockResolvedValue({});
+    const trustedDelegateCallTarget = faker.datatype.boolean();
+    transactionDataMapper.isTrustedDelegateCall.mockResolvedValue(
+      trustedDelegateCallTarget,
+    );
+
+    const actual = await mapper.mapDetails(chainId, transaction, safe);
+
+    expect(actual).toEqual({
+      safeAddress: safe.address,
+      txId: `module_${safe.address}_${transaction.moduleTransactionId}`,
+      executedAt: transaction.executionDate?.getTime(),
+      txStatus,
+      txInfo,
+      txData: expect.objectContaining({
+        hexData: transaction.data,
+        dataDecoded: transaction.dataDecoded,
+        to: addressInfo,
+        value: transaction.value,
+        operation: transaction.operation,
+        trustedDelegateCallTarget,
+        addressInfoIndex: null,
+      }),
+      txHash: transaction.transactionHash,
+      detailedExecutionInfo: new ModuleExecutionDetails(addressInfo),
+      safeAppInfo: null,
+    });
+  });
+
+  it('should return a TransactionDetails object with an non-empty addressInfoIndex', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = moduleTransactionBuilder().build();
+    const safe = safeBuilder().build();
+    const txStatus =
+      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
+    const txInfo = transferTransactionInfoBuilder().build();
+    transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    const addressInfoIndex = {
+      [faker.string.sample()]: addressInfoBuilder().build(),
+      [faker.string.sample()]: addressInfoBuilder().build(),
+    };
+    transactionDataMapper.buildAddressInfoIndex.mockResolvedValue(
+      addressInfoIndex,
+    );
+    const trustedDelegateCallTarget = faker.datatype.boolean();
+    transactionDataMapper.isTrustedDelegateCall.mockResolvedValue(
+      trustedDelegateCallTarget,
+    );
+
+    const actual = await mapper.mapDetails(chainId, transaction, safe);
+
+    expect(actual).toEqual({
+      safeAddress: safe.address,
+      txId: `module_${safe.address}_${transaction.moduleTransactionId}`,
+      executedAt: transaction.executionDate?.getTime(),
+      txStatus,
+      txInfo,
+      txData: expect.objectContaining({
+        hexData: transaction.data,
+        dataDecoded: transaction.dataDecoded,
+        to: addressInfo,
+        value: transaction.value,
+        operation: transaction.operation,
+        trustedDelegateCallTarget,
+        addressInfoIndex,
+      }),
+      txHash: transaction.transactionHash,
+      detailedExecutionInfo: new ModuleExecutionDetails(addressInfo),
+      safeAppInfo: null,
+    });
+  });
+});

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -41,7 +41,7 @@ export class ModuleTransactionMapper {
       txStatus,
       txInfo,
       executionInfo,
-      null, // TODO: include safeAppInfo retrieval logic where needed
+      null,
     );
   }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -1,0 +1,82 @@
+import { faker } from '@faker-js/faker';
+import { sample } from 'lodash';
+import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
+import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
+import { safeAppInfoBuilder } from '../../entities/__tests__/safe-app-info.builder';
+import { transferTransactionInfoBuilder } from '../../entities/__tests__/transfer-transaction-info.builder';
+import { TransactionStatus } from '../../entities/transaction-status.entity';
+import { SafeAppInfoMapper } from '../common/safe-app-info.mapper';
+import { TransactionDataMapper } from '../common/transaction-data.mapper';
+import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper';
+import { MultisigTransactionDetailsMapper } from './multisig-transaction-details.mapper';
+import { MultisigTransactionExecutionDetailsMapper } from './multisig-transaction-execution-details.mapper';
+import { MultisigTransactionStatusMapper } from './multisig-transaction-status.mapper';
+
+const addressInfoHelper = jest.mocked({
+  getOrDefault: jest.fn(),
+} as unknown as AddressInfoHelper);
+
+const statusMapper = jest.mocked({
+  mapTransactionStatus: jest.fn(),
+} as unknown as MultisigTransactionStatusMapper);
+
+const transactionInfoMapper = jest.mocked({
+  mapTransactionInfo: jest.fn(),
+} as unknown as MultisigTransactionInfoMapper);
+
+const transactionDataMapper = jest.mocked({
+  isTrustedDelegateCall: jest.fn(),
+  buildAddressInfoIndex: jest.fn(),
+} as unknown as TransactionDataMapper);
+
+const safeAppInfoMapper = jest.mocked({
+  mapSafeAppInfo: jest.fn(),
+} as unknown as SafeAppInfoMapper);
+
+const multisigTransactionExecutionDetailsMapper = jest.mocked({
+  mapMultisigExecutionDetails: jest.fn(),
+} as unknown as MultisigTransactionExecutionDetailsMapper);
+
+describe.skip('MultisigTransactionDetails mapper (Unit)', () => {
+  let mapper: MultisigTransactionDetailsMapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mapper = new MultisigTransactionDetailsMapper(
+      addressInfoHelper,
+      statusMapper,
+      transactionInfoMapper,
+      transactionDataMapper,
+      safeAppInfoMapper,
+      multisigTransactionExecutionDetailsMapper,
+    );
+  });
+
+  it('should return a TransactionDetails object', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().build();
+    const safe = safeBuilder().build();
+    const txStatus =
+      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
+    const txInfo = transferTransactionInfoBuilder().build();
+    transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
+    const safeAppInfo = safeAppInfoBuilder().build();
+    safeAppInfoMapper.mapSafeAppInfo.mockResolvedValue(safeAppInfo);
+
+    const actual = await mapper.mapDetails(chainId, transaction, safe);
+
+    expect(actual).toEqual({
+      safeAddress: safe.address,
+      txId: `multisig_${safe.address}_${transaction.safeTxHash}`,
+      executedAt: transaction.executionDate?.getTime(),
+      txStatus,
+      txInfo,
+      // txData,
+      txHash: transaction.transactionHash,
+      // detailedExecutionInfo,
+      safeAppInfo,
+    });
+  });
+});

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.spec.ts
@@ -2,10 +2,12 @@ import { faker } from '@faker-js/faker';
 import { sample } from 'lodash';
 import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import { addressInfoBuilder } from '../../../common/__tests__/entities/address-info.builder';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { safeAppInfoBuilder } from '../../entities/__tests__/safe-app-info.builder';
 import { transferTransactionInfoBuilder } from '../../entities/__tests__/transfer-transaction-info.builder';
 import { TransactionStatus } from '../../entities/transaction-status.entity';
+import { multisigExecutionDetailsBuilder } from '../__tests__/multisig-execution-details.builder';
 import { SafeAppInfoMapper } from '../common/safe-app-info.mapper';
 import { TransactionDataMapper } from '../common/transaction-data.mapper';
 import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper';
@@ -34,11 +36,11 @@ const safeAppInfoMapper = jest.mocked({
   mapSafeAppInfo: jest.fn(),
 } as unknown as SafeAppInfoMapper);
 
-const multisigTransactionExecutionDetailsMapper = jest.mocked({
+const multisigExecutionDetailsMapper = jest.mocked({
   mapMultisigExecutionDetails: jest.fn(),
 } as unknown as MultisigTransactionExecutionDetailsMapper);
 
-describe.skip('MultisigTransactionDetails mapper (Unit)', () => {
+describe('MultisigTransactionDetails mapper (Unit)', () => {
   let mapper: MultisigTransactionDetailsMapper;
 
   beforeEach(() => {
@@ -49,11 +51,11 @@ describe.skip('MultisigTransactionDetails mapper (Unit)', () => {
       transactionInfoMapper,
       transactionDataMapper,
       safeAppInfoMapper,
-      multisigTransactionExecutionDetailsMapper,
+      multisigExecutionDetailsMapper,
     );
   });
 
-  it('should return a TransactionDetails object', async () => {
+  it('should return a TransactionDetails object with null addressInfoIndex', async () => {
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder().build();
     const safe = safeBuilder().build();
@@ -64,6 +66,14 @@ describe.skip('MultisigTransactionDetails mapper (Unit)', () => {
     transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
     const safeAppInfo = safeAppInfoBuilder().build();
     safeAppInfoMapper.mapSafeAppInfo.mockResolvedValue(safeAppInfo);
+    const multisigExecutionDetails = multisigExecutionDetailsBuilder().build();
+    multisigExecutionDetailsMapper.mapMultisigExecutionDetails.mockResolvedValue(
+      multisigExecutionDetails,
+    );
+    transactionDataMapper.isTrustedDelegateCall.mockResolvedValue(true);
+    transactionDataMapper.buildAddressInfoIndex.mockResolvedValue({});
+    const to = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(to);
 
     const actual = await mapper.mapDetails(chainId, transaction, safe);
 
@@ -73,9 +83,66 @@ describe.skip('MultisigTransactionDetails mapper (Unit)', () => {
       executedAt: transaction.executionDate?.getTime(),
       txStatus,
       txInfo,
-      // txData,
+      txData: expect.objectContaining({
+        hexData: transaction.data,
+        dataDecoded: transaction.dataDecoded,
+        to,
+        value: transaction.value,
+        operation: transaction.operation,
+        trustedDelegateCallTarget: true,
+        addressInfoIndex: null,
+      }),
       txHash: transaction.transactionHash,
-      // detailedExecutionInfo,
+      detailedExecutionInfo: multisigExecutionDetails,
+      safeAppInfo,
+    });
+  });
+
+  it('should return a TransactionDetails object with non-null addressInfoIndex', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().build();
+    const safe = safeBuilder().build();
+    const txStatus =
+      sample(Object.values(TransactionStatus)) ?? TransactionStatus.Success;
+    statusMapper.mapTransactionStatus.mockReturnValue(txStatus);
+    const txInfo = transferTransactionInfoBuilder().build();
+    transactionInfoMapper.mapTransactionInfo.mockResolvedValue(txInfo);
+    const safeAppInfo = safeAppInfoBuilder().build();
+    safeAppInfoMapper.mapSafeAppInfo.mockResolvedValue(safeAppInfo);
+    const multisigExecutionDetails = multisigExecutionDetailsBuilder().build();
+    multisigExecutionDetailsMapper.mapMultisigExecutionDetails.mockResolvedValue(
+      multisigExecutionDetails,
+    );
+    transactionDataMapper.isTrustedDelegateCall.mockResolvedValue(true);
+    const addressInfoIndex = {
+      [faker.string.sample()]: addressInfoBuilder().build(),
+      [faker.string.sample()]: addressInfoBuilder().build(),
+    };
+    transactionDataMapper.buildAddressInfoIndex.mockResolvedValue(
+      addressInfoIndex,
+    );
+    const to = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(to);
+
+    const actual = await mapper.mapDetails(chainId, transaction, safe);
+
+    expect(actual).toEqual({
+      safeAddress: safe.address,
+      txId: `multisig_${safe.address}_${transaction.safeTxHash}`,
+      executedAt: transaction.executionDate?.getTime(),
+      txStatus,
+      txInfo,
+      txData: expect.objectContaining({
+        hexData: transaction.data,
+        dataDecoded: transaction.dataDecoded,
+        to,
+        value: transaction.value,
+        operation: transaction.operation,
+        trustedDelegateCallTarget: true,
+        addressInfoIndex,
+      }),
+      txHash: transaction.transactionHash,
+      detailedExecutionInfo: multisigExecutionDetails,
       safeAppInfo,
     });
   });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -1,31 +1,19 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { isEmpty } from 'lodash';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import { Safe } from '../../../../domain/safe/entities/safe.entity';
-import { SafeRepository } from '../../../../domain/safe/safe.repository';
-import { ISafeRepository } from '../../../../domain/safe/safe.repository.interface';
-import { TokenRepository } from '../../../../domain/tokens/token.repository';
-import { ITokenRepository } from '../../../../domain/tokens/token.repository.interface';
-import {
-  ILoggingService,
-  LoggingService,
-} from '../../../../logging/logging.interface';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
-import { NULL_ADDRESS } from '../../../common/constants';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
 import {
   MULTISIG_TRANSACTION_PREFIX,
   TRANSACTION_ID_SEPARATOR,
 } from '../../constants';
 import { TransactionData } from '../../entities/transaction-data.entity';
-import {
-  MultisigConfirmationDetails,
-  MultisigExecutionDetails,
-} from '../../entities/transaction-details/multisig-execution-details.entity';
 import { TransactionDetails } from '../../entities/transaction-details/transaction-details.entity';
 import { SafeAppInfoMapper } from '../common/safe-app-info.mapper';
 import { TransactionDataMapper } from '../common/transaction-data.mapper';
 import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper';
+import { MultisigTransactionExecutionDetailsMapper } from './multisig-transaction-execution-details.mapper';
 import { MultisigTransactionStatusMapper } from './multisig-transaction-status.mapper';
 
 @Injectable()
@@ -36,9 +24,7 @@ export class MultisigTransactionDetailsMapper {
     private readonly transactionInfoMapper: MultisigTransactionInfoMapper,
     private readonly transactionDataMapper: TransactionDataMapper,
     private readonly safeAppInfoMapper: SafeAppInfoMapper,
-    @Inject(ITokenRepository) private readonly tokenRepository: TokenRepository,
-    @Inject(ISafeRepository) private readonly safeRepository: SafeRepository,
-    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    private readonly multisigTransactionExecutionDetailsMapper: MultisigTransactionExecutionDetailsMapper,
   ) {}
 
   async mapDetails(
@@ -67,7 +53,11 @@ export class MultisigTransactionDetailsMapper {
       ),
       this.safeAppInfoMapper.mapSafeAppInfo(chainId, transaction),
       this.transactionInfoMapper.mapTransactionInfo(chainId, transaction, safe),
-      this._mapMultisigExecutionDetails(chainId, transaction, safe),
+      this.multisigTransactionExecutionDetailsMapper.mapMultisigExecutionDetails(
+        chainId,
+        transaction,
+        safe,
+      ),
       this._getRecipientAddressInfo(chainId, transaction.to),
     ]);
 
@@ -92,63 +82,6 @@ export class MultisigTransactionDetailsMapper {
     };
   }
 
-  private async _mapMultisigExecutionDetails(
-    chainId: string,
-    transaction: MultisigTransaction,
-    safe: Safe,
-  ): Promise<MultisigExecutionDetails> {
-    const signers = safe.owners.map((owner) => new AddressInfo(owner));
-    const gasToken = transaction.gasToken ?? NULL_ADDRESS;
-    const confirmationsRequired =
-      transaction.confirmationsRequired ?? safe.threshold;
-    const confirmations = !transaction.confirmations
-      ? []
-      : transaction.confirmations.map(
-          (confirmation) =>
-            new MultisigConfirmationDetails(
-              new AddressInfo(confirmation.owner),
-              confirmation.signature,
-              confirmation.submissionDate.getTime(),
-            ),
-        );
-
-    const [gasTokenInfo, executor, refundReceiver, rejectors] =
-      await Promise.all([
-        gasToken != NULL_ADDRESS
-          ? this.tokenRepository.getToken(chainId, gasToken)
-          : Promise.resolve(null),
-        transaction.executor
-          ? this.addressInfoHelper.getOrDefault(chainId, transaction.executor, [
-              'CONTRACT',
-            ])
-          : Promise.resolve(null),
-        this.addressInfoHelper.getOrDefault(
-          chainId,
-          transaction.refundReceiver ?? NULL_ADDRESS,
-          ['CONTRACT'],
-        ),
-        this._getRejectors(chainId, transaction, safe),
-      ]);
-
-    return new MultisigExecutionDetails(
-      transaction.submissionDate.getTime(),
-      transaction.nonce,
-      transaction.safeTxGas?.toString() ?? '0',
-      transaction.baseGas?.toString() ?? '0',
-      transaction.gasPrice?.toString() ?? '0',
-      gasToken,
-      refundReceiver,
-      transaction.safeTxHash,
-      executor,
-      signers,
-      confirmationsRequired,
-      confirmations,
-      rejectors,
-      gasTokenInfo,
-      transaction.trusted,
-    );
-  }
-
   /**
    * Tries to get the {@link AddressInfo} related to the address from a Token, and
    * fallbacks to a Contract. If none can be found, a default {@link AddressInfo}
@@ -166,48 +99,5 @@ export class MultisigTransactionDetailsMapper {
       'TOKEN',
       'CONTRACT',
     ]);
-  }
-
-  /**
-   * Gets an array of {@link AddressInfo} representing the confirmations of the replacement
-   * transaction for the {@link Transaction} passed in.
-   *
-   * When a transaction is cancelled, another transaction replaces it, having the same nonce
-   * and isExecuted attribute set to true. This function retrieves that transaction, and
-   * collects its confirmations as rejectors.
-   *
-   * @param chainId - chain id to use
-   * @param transaction - transaction to use
-   * @param safe - safe to use
-   * @returns confirmations for the replacement transaction
-   */
-  private async _getRejectors(
-    chainId: string,
-    transaction: MultisigTransaction,
-    safe: Safe,
-  ): Promise<AddressInfo[] | null> {
-    const replacementTxsPage =
-      await this.safeRepository.getMultisigTransactions(
-        chainId,
-        safe.address,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        transaction.nonce.toString(),
-      );
-
-    if (isEmpty(replacementTxsPage.results)) {
-      this.loggingService.debug(
-        `Replacement transaction with nonce ${transaction.nonce} not found for cancelled transaction ${transaction.transactionHash}`,
-      );
-      return null;
-    }
-
-    const replacementTx = replacementTxsPage.results[0];
-    return replacementTx.confirmations
-      ? replacementTx.confirmations.map((c) => new AddressInfo(c.owner))
-      : null;
   }
 }

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -1,10 +1,18 @@
 import { faker } from '@faker-js/faker';
+import { pageBuilder } from '../../../../domain/entities/__tests__/page.builder';
+import { confirmationBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction-confirmation.builder';
 import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import { SafeRepository } from '../../../../domain/safe/safe.repository';
+import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
 import { TokenRepository } from '../../../../domain/tokens/token.repository';
 import { ILoggingService } from '../../../../logging/logging.interface';
+import { addressInfoBuilder } from '../../../common/__tests__/entities/address-info.builder';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
+import { NULL_ADDRESS } from '../../../common/constants';
+import { AddressInfo } from '../../../common/entities/address-info.entity';
+import { MultisigConfirmationDetails } from '../../entities/transaction-details/multisig-execution-details.entity';
 import { MultisigTransactionExecutionDetailsMapper } from './multisig-transaction-execution-details.mapper';
 
 const addressInfoHelper = jest.mocked({
@@ -23,7 +31,7 @@ const loggingService = jest.mocked({
   debug: jest.fn(),
 } as unknown as ILoggingService);
 
-describe.skip('MultisigTransactionExecutionDetails mapper (Unit)', () => {
+describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
   let mapper: MultisigTransactionExecutionDetailsMapper;
 
   beforeEach(() => {
@@ -36,10 +44,111 @@ describe.skip('MultisigTransactionExecutionDetails mapper (Unit)', () => {
     );
   });
 
-  it('should return a MultisigExecutionDetails object', async () => {
+  it('should return a MultisigExecutionDetails object with gasToken, empty confirmations and empty rejections', async () => {
     const chainId = faker.string.numeric();
-    const transaction = multisigTransactionBuilder().build();
+    const transaction = multisigTransactionBuilder()
+      .with('confirmations', [])
+      .build();
     const safe = safeBuilder().build();
-    await mapper.mapMultisigExecutionDetails(chainId, transaction, safe);
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    safeRepository.getMultisigTransactions.mockResolvedValue(
+      pageBuilder<MultisigTransaction>().with('results', []).build(),
+    );
+    const gasTokenInfo = tokenBuilder().build();
+    tokenRepository.getToken.mockResolvedValue(gasTokenInfo);
+
+    const actual = await mapper.mapMultisigExecutionDetails(
+      chainId,
+      transaction,
+      safe,
+    );
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        type: 'MULTISIG',
+        submittedAt: transaction.submissionDate.getTime(),
+        nonce: transaction.nonce,
+        safeTxGas: transaction.safeTxGas?.toString(),
+        baseGas: transaction.baseGas?.toString(),
+        gasPrice: transaction.gasPrice?.toString(),
+        gasToken: transaction.gasToken,
+        refundReceiver: addressInfo,
+        safeTxHash: transaction.safeTxHash,
+        executor: addressInfo,
+        signers: safe.owners.map((owner) => new AddressInfo(owner)),
+        confirmationsRequired: transaction.confirmationsRequired,
+        confirmations: [],
+        rejectors: null,
+        gasTokenInfo,
+        trusted: transaction.trusted,
+      }),
+    );
+  });
+
+  it('should return a MultisigExecutionDetails object with NULL_ADDRESS gasToken, confirmations and rejections', async () => {
+    const chainId = faker.string.numeric();
+    const transactionConfirmations = [
+      confirmationBuilder().build(),
+      confirmationBuilder().build(),
+    ];
+    const transaction = multisigTransactionBuilder()
+      .with('gasToken', NULL_ADDRESS)
+      .with('confirmations', transactionConfirmations)
+      .build();
+    const safe = safeBuilder().build();
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    const replacementTxConfirmation = confirmationBuilder().build();
+    const replacementTx = multisigTransactionBuilder()
+      .with('confirmations', [replacementTxConfirmation])
+      .build();
+    safeRepository.getMultisigTransactions.mockResolvedValue(
+      pageBuilder<MultisigTransaction>()
+        .with('results', [replacementTx])
+        .build(),
+    );
+    const expectedConfirmationsDetails = [
+      new MultisigConfirmationDetails(
+        new AddressInfo(transactionConfirmations[0].owner),
+        transactionConfirmations[0].signature,
+        transactionConfirmations[0].submissionDate.getTime(),
+      ),
+      new MultisigConfirmationDetails(
+        new AddressInfo(transactionConfirmations[1].owner),
+        transactionConfirmations[1].signature,
+        transactionConfirmations[1].submissionDate.getTime(),
+      ),
+    ];
+    const expectedRejectors = [
+      new AddressInfo(replacementTxConfirmation.owner),
+    ];
+
+    const actual = await mapper.mapMultisigExecutionDetails(
+      chainId,
+      transaction,
+      safe,
+    );
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        type: 'MULTISIG',
+        submittedAt: transaction.submissionDate.getTime(),
+        nonce: transaction.nonce,
+        safeTxGas: transaction.safeTxGas?.toString(),
+        baseGas: transaction.baseGas?.toString(),
+        gasPrice: transaction.gasPrice?.toString(),
+        gasToken: NULL_ADDRESS,
+        refundReceiver: addressInfo,
+        safeTxHash: transaction.safeTxHash,
+        executor: addressInfo,
+        signers: safe.owners.map((owner) => new AddressInfo(owner)),
+        confirmationsRequired: transaction.confirmationsRequired,
+        confirmations: expectedConfirmationsDetails,
+        rejectors: expectedRejectors,
+        gasTokenInfo: null,
+        trusted: transaction.trusted,
+      }),
+    );
   });
 });

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -1,0 +1,45 @@
+import { faker } from '@faker-js/faker';
+import { multisigTransactionBuilder } from '../../../../domain/safe/entities/__tests__/multisig-transaction.builder';
+import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import { SafeRepository } from '../../../../domain/safe/safe.repository';
+import { TokenRepository } from '../../../../domain/tokens/token.repository';
+import { ILoggingService } from '../../../../logging/logging.interface';
+import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
+import { MultisigTransactionExecutionDetailsMapper } from './multisig-transaction-execution-details.mapper';
+
+const addressInfoHelper = jest.mocked({
+  getOrDefault: jest.fn(),
+} as unknown as AddressInfoHelper);
+
+const tokenRepository = jest.mocked({
+  getToken: jest.fn(),
+} as unknown as TokenRepository);
+
+const safeRepository = jest.mocked({
+  getMultisigTransactions: jest.fn(),
+} as unknown as SafeRepository);
+
+const loggingService = jest.mocked({
+  debug: jest.fn(),
+} as unknown as ILoggingService);
+
+describe.skip('MultisigTransactionExecutionDetails mapper (Unit)', () => {
+  let mapper: MultisigTransactionExecutionDetailsMapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mapper = new MultisigTransactionExecutionDetailsMapper(
+      addressInfoHelper,
+      tokenRepository,
+      safeRepository,
+      loggingService,
+    );
+  });
+
+  it('should return a MultisigExecutionDetails object', async () => {
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder().build();
+    const safe = safeBuilder().build();
+    await mapper.mapMultisigExecutionDetails(chainId, transaction, safe);
+  });
+});

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -1,0 +1,131 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { isEmpty } from 'lodash';
+import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
+import { Safe } from '../../../../domain/safe/entities/safe.entity';
+import { SafeRepository } from '../../../../domain/safe/safe.repository';
+import { ISafeRepository } from '../../../../domain/safe/safe.repository.interface';
+import { TokenRepository } from '../../../../domain/tokens/token.repository';
+import { ITokenRepository } from '../../../../domain/tokens/token.repository.interface';
+import {
+  ILoggingService,
+  LoggingService,
+} from '../../../../logging/logging.interface';
+import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
+import { NULL_ADDRESS } from '../../../common/constants';
+import { AddressInfo } from '../../../common/entities/address-info.entity';
+import {
+  MultisigConfirmationDetails,
+  MultisigExecutionDetails,
+} from '../../entities/transaction-details/multisig-execution-details.entity';
+
+// TODO: unit tests are missing for this mapper.
+// multisig-transaction-execution-details.mapper.spec
+@Injectable()
+export class MultisigTransactionExecutionDetailsMapper {
+  constructor(
+    private readonly addressInfoHelper: AddressInfoHelper,
+    @Inject(ITokenRepository) private readonly tokenRepository: TokenRepository,
+    @Inject(ISafeRepository) private readonly safeRepository: SafeRepository,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async mapMultisigExecutionDetails(
+    chainId: string,
+    transaction: MultisigTransaction,
+    safe: Safe,
+  ): Promise<MultisigExecutionDetails> {
+    const signers = safe.owners.map((owner) => new AddressInfo(owner));
+    const gasToken = transaction.gasToken ?? NULL_ADDRESS;
+    const confirmationsRequired =
+      transaction.confirmationsRequired ?? safe.threshold;
+    const confirmations = !transaction.confirmations
+      ? []
+      : transaction.confirmations.map(
+          (confirmation) =>
+            new MultisigConfirmationDetails(
+              new AddressInfo(confirmation.owner),
+              confirmation.signature,
+              confirmation.submissionDate.getTime(),
+            ),
+        );
+
+    const [gasTokenInfo, executor, refundReceiver, rejectors] =
+      await Promise.all([
+        gasToken != NULL_ADDRESS
+          ? this.tokenRepository.getToken(chainId, gasToken)
+          : Promise.resolve(null),
+        transaction.executor
+          ? this.addressInfoHelper.getOrDefault(chainId, transaction.executor, [
+              'CONTRACT',
+            ])
+          : Promise.resolve(null),
+        this.addressInfoHelper.getOrDefault(
+          chainId,
+          transaction.refundReceiver ?? NULL_ADDRESS,
+          ['CONTRACT'],
+        ),
+        this._getRejectors(chainId, transaction, safe),
+      ]);
+
+    return new MultisigExecutionDetails(
+      transaction.submissionDate.getTime(),
+      transaction.nonce,
+      transaction.safeTxGas?.toString() ?? '0',
+      transaction.baseGas?.toString() ?? '0',
+      transaction.gasPrice?.toString() ?? '0',
+      gasToken,
+      refundReceiver,
+      transaction.safeTxHash,
+      executor,
+      signers,
+      confirmationsRequired,
+      confirmations,
+      rejectors,
+      gasTokenInfo,
+      transaction.trusted,
+    );
+  }
+
+  /**
+   * Gets an array of {@link AddressInfo} representing the confirmations of the replacement
+   * transaction for the {@link Transaction} passed in.
+   *
+   * When a transaction is cancelled, another transaction replaces it, having the same nonce
+   * and isExecuted attribute set to true. This function retrieves that transaction, and
+   * collects its confirmations as rejectors.
+   *
+   * @param chainId - chain id to use
+   * @param transaction - transaction to use
+   * @param safe - safe to use
+   * @returns confirmations for the replacement transaction
+   */
+  private async _getRejectors(
+    chainId: string,
+    transaction: MultisigTransaction,
+    safe: Safe,
+  ): Promise<AddressInfo[] | null> {
+    const replacementTxsPage =
+      await this.safeRepository.getMultisigTransactions(
+        chainId,
+        safe.address,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        transaction.nonce.toString(),
+      );
+
+    if (isEmpty(replacementTxsPage.results)) {
+      this.loggingService.debug(
+        `Replacement transaction with nonce ${transaction.nonce} not found for cancelled transaction ${transaction.transactionHash}`,
+      );
+      return null;
+    }
+
+    const replacementTx = replacementTxsPage.results[0];
+    return replacementTx.confirmations
+      ? replacementTx.confirmations.map((c) => new AddressInfo(c.owner))
+      : null;
+  }
+}

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -18,8 +18,6 @@ import {
   MultisigExecutionDetails,
 } from '../../entities/transaction-details/multisig-execution-details.entity';
 
-// TODO: unit tests are missing for this mapper.
-// multisig-transaction-execution-details.mapper.spec
 @Injectable()
 export class MultisigTransactionExecutionDetailsMapper {
   constructor(

--- a/src/routes/transactions/mappers/transfers/transfer-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-details.mapper.spec.ts
@@ -1,0 +1,41 @@
+import { faker } from '@faker-js/faker';
+import { erc20TransferBuilder } from '../../../../domain/safe/entities/__tests__/erc20-transfer.builder';
+import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
+import { transferTransactionInfoBuilder } from '../../entities/__tests__/transfer-transaction-info.builder';
+import { TransferDetailsMapper } from './transfer-details.mapper';
+import { TransferInfoMapper } from './transfer-info.mapper';
+
+const transferInfoMapper = jest.mocked({
+  mapTransferInfo: jest.fn(),
+} as unknown as TransferInfoMapper);
+
+describe('TransferDetails mapper (Unit)', () => {
+  let mapper: TransferDetailsMapper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mapper = new TransferDetailsMapper(transferInfoMapper);
+  });
+
+  it('should return a TransactionDetails object', async () => {
+    const chainId = faker.string.numeric();
+    const transfer = erc20TransferBuilder().build();
+    const safe = safeBuilder().build();
+    const transferInfo = transferTransactionInfoBuilder().build();
+    transferInfoMapper.mapTransferInfo.mockResolvedValue(transferInfo);
+
+    const actual = await mapper.mapDetails(chainId, transfer, safe);
+
+    expect(actual).toEqual({
+      safeAddress: safe.address,
+      txId: `transfer_${safe.address}_${transfer.transferId}`,
+      executedAt: transfer.executionDate.getTime(),
+      txStatus: 'SUCCESS',
+      txInfo: transferInfo,
+      txData: null,
+      detailedExecutionInfo: null,
+      txHash: transfer.transactionHash,
+      safeAppInfo: null,
+    });
+  });
+});

--- a/src/routes/transactions/transactions.module.ts
+++ b/src/routes/transactions/transactions.module.ts
@@ -26,6 +26,7 @@ import { TransferInfoMapper } from './mappers/transfers/transfer-info.mapper';
 import { IncomingTransferMapper } from './mappers/transfers/transfer.mapper';
 import { TransactionsController } from './transactions.controller';
 import { TransactionsService } from './transactions.service';
+import { MultisigTransactionExecutionDetailsMapper } from './mappers/multisig-transactions/multisig-transaction-execution-details.mapper';
 
 @Module({
   controllers: [TransactionsController],
@@ -41,6 +42,7 @@ import { TransactionsService } from './transactions.service';
     ModuleTransactionMapper,
     ModuleTransactionStatusMapper,
     MultisigTransactionDetailsMapper,
+    MultisigTransactionExecutionDetailsMapper,
     MultisigTransactionExecutionInfoMapper,
     MultisigTransactionInfoMapper,
     MultisigTransactionMapper,


### PR DESCRIPTION
Closes #368 

This PR:
- Adds unit tests for `MultisigTransactionDetailsMapper`.
- Adds unit tests for `ModuleTransactionDetailsMapper`.
- Adds unit tests for `TransferDetailsMapper`.

Additionally:
- `MultisigTransactionExecutionDetailsMapper.detailedExecutionInfo` is now refactored to be placed in a separate mapper, in order to favor encapsulation and testability. `detailedExecutionInfo` was previously generated by a private function within `MultisigTransactionExecutionDetailsMapper`.
- Some additional builders were introduced, in particular, `addressInfoBuilder` seems to be a good candidate to be used in other tests, but that change was considered out of the scope of this PR, to avoid too much noise when reviewing.