### PR TITLE
Remove chain id from the hook route path

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -57,7 +57,7 @@ describe('Post Hook Events (Unit)', () => {
 
   it('should throw an error if authorization is not sent in the request headers', async () => {
     await request(app.getHttpServer())
-      .post(`/chains/1/hooks/events`)
+      .post(`/hooks/events`)
       .send({})
       .expect(403);
   });
@@ -121,7 +121,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -144,7 +144,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/1/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(400);
@@ -196,7 +196,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -244,7 +244,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -292,7 +292,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -331,7 +331,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -380,7 +380,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -429,7 +429,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -473,7 +473,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -512,7 +512,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);
@@ -576,7 +576,7 @@ describe('Post Hook Events (Unit)', () => {
     });
 
     await request(app.getHttpServer())
-      .post(`/chains/${chainId}/hooks/events`)
+      .post(`/hooks/events`)
       .set('Authorization', `Basic ${authToken}`)
       .send(data)
       .expect(200);

--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Body,
-  Controller,
-  HttpCode,
-  Param,
-  Post,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { EventValidationPipe } from './pipes/event-validation.pipe';
 import { CacheHooksService } from './cache-hooks.service';
 import { BasicAuthGuard } from '../common/auth/basic-auth.guard';
@@ -26,10 +19,9 @@ export class CacheHooksController {
   constructor(private readonly service: CacheHooksService) {}
 
   @UseGuards(BasicAuthGuard)
-  @Post('/chains/:chainId/hooks/events')
+  @Post('/hooks/events')
   @HttpCode(200)
   async postEvent(
-    @Param('chainId') chainId: string,
     @Body(EventValidationPipe)
     eventPayload:
       | ExecutedTransaction
@@ -41,6 +33,6 @@ export class CacheHooksController {
       | OutgoingEther
       | PendingTransaction,
   ): Promise<void> {
-    await this.service.onEvent(chainId, eventPayload);
+    await this.service.onEvent(eventPayload);
   }
 }

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -24,7 +24,6 @@ export class CacheHooksService {
   ) {}
 
   async onEvent(
-    chainId: string,
     event:
       | ExecutedTransaction
       | IncomingEther
@@ -42,9 +41,12 @@ export class CacheHooksService {
       // the pending transaction – clear multisig transaction
       case EventType.PENDING_MULTISIG_TRANSACTION:
         promises.push(
-          this.safeRepository.clearMultisigTransactions(chainId, event.address),
+          this.safeRepository.clearMultisigTransactions(
+            event.chainId,
+            event.address,
+          ),
           this.safeRepository.clearMultisigTransaction(
-            chainId,
+            event.chainId,
             event.safeTxHash,
           ),
         );
@@ -55,10 +57,13 @@ export class CacheHooksService {
       case EventType.MODULE_TRANSACTION:
         promises.push(
           this.safeRepository.clearAllExecutedTransactions(
-            chainId,
+            event.chainId,
             event.address,
           ),
-          this.safeRepository.clearModuleTransactions(chainId, event.address),
+          this.safeRepository.clearModuleTransactions(
+            event.chainId,
+            event.address,
+          ),
         );
         break;
       // A new executed multisig transaction affects:
@@ -70,18 +75,27 @@ export class CacheHooksService {
       // - the safe configuration - clear safe info
       case EventType.EXECUTED_MULTISIG_TRANSACTION:
         promises.push(
-          this.collectiblesRepository.clearCollectibles(chainId, event.address),
-          this.safeRepository.clearAllExecutedTransactions(
-            chainId,
+          this.collectiblesRepository.clearCollectibles(
+            event.chainId,
             event.address,
           ),
-          this.safeRepository.clearCollectibleTransfers(chainId, event.address),
-          this.safeRepository.clearMultisigTransactions(chainId, event.address),
+          this.safeRepository.clearAllExecutedTransactions(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearCollectibleTransfers(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearMultisigTransactions(
+            event.chainId,
+            event.address,
+          ),
           this.safeRepository.clearMultisigTransaction(
-            chainId,
+            event.chainId,
             event.safeTxHash,
           ),
-          this.safeRepository.clearSafe(chainId, event.address),
+          this.safeRepository.clearSafe(event.chainId, event.address),
         );
         break;
       // A new confirmation for a pending transaction affects:
@@ -89,9 +103,12 @@ export class CacheHooksService {
       // - the pending transaction – clear multisig transaction
       case EventType.NEW_CONFIRMATION:
         promises.push(
-          this.safeRepository.clearMultisigTransactions(chainId, event.address),
+          this.safeRepository.clearMultisigTransactions(
+            event.chainId,
+            event.address,
+          ),
           this.safeRepository.clearMultisigTransaction(
-            chainId,
+            event.chainId,
             event.safeTxHash,
           ),
         );
@@ -102,12 +119,18 @@ export class CacheHooksService {
       // - the incoming transfers for that safe
       case EventType.INCOMING_ETHER:
         promises.push(
-          this.balancesRepository.clearLocalBalances(chainId, event.address),
-          this.safeRepository.clearAllExecutedTransactions(
-            chainId,
+          this.balancesRepository.clearLocalBalances(
+            event.chainId,
             event.address,
           ),
-          this.safeRepository.clearIncomingTransfers(chainId, event.address),
+          this.safeRepository.clearAllExecutedTransactions(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearIncomingTransfers(
+            event.chainId,
+            event.address,
+          ),
         );
         break;
       // Outgoing ether affects:
@@ -115,9 +138,12 @@ export class CacheHooksService {
       // - the list of all executed transactions (including transfers) for the safe
       case EventType.OUTGOING_ETHER:
         promises.push(
-          this.balancesRepository.clearLocalBalances(chainId, event.address),
+          this.balancesRepository.clearLocalBalances(
+            event.chainId,
+            event.address,
+          ),
           this.safeRepository.clearAllExecutedTransactions(
-            chainId,
+            event.chainId,
             event.address,
           ),
         );
@@ -130,14 +156,26 @@ export class CacheHooksService {
       // - the incoming transfers for that safe
       case EventType.INCOMING_TOKEN:
         promises.push(
-          this.balancesRepository.clearLocalBalances(chainId, event.address),
-          this.collectiblesRepository.clearCollectibles(chainId, event.address),
-          this.safeRepository.clearAllExecutedTransactions(
-            chainId,
+          this.balancesRepository.clearLocalBalances(
+            event.chainId,
             event.address,
           ),
-          this.safeRepository.clearCollectibleTransfers(chainId, event.address),
-          this.safeRepository.clearIncomingTransfers(chainId, event.address),
+          this.collectiblesRepository.clearCollectibles(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearAllExecutedTransactions(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearCollectibleTransfers(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearIncomingTransfers(
+            event.chainId,
+            event.address,
+          ),
         );
         break;
       // An outgoing token affects:
@@ -147,13 +185,22 @@ export class CacheHooksService {
       // - the collectible transfers for that safe
       case EventType.OUTGOING_TOKEN:
         promises.push(
-          this.balancesRepository.clearLocalBalances(chainId, event.address),
-          this.collectiblesRepository.clearCollectibles(chainId, event.address),
-          this.safeRepository.clearAllExecutedTransactions(
-            chainId,
+          this.balancesRepository.clearLocalBalances(
+            event.chainId,
             event.address,
           ),
-          this.safeRepository.clearCollectibleTransfers(chainId, event.address),
+          this.collectiblesRepository.clearCollectibles(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearAllExecutedTransactions(
+            event.chainId,
+            event.address,
+          ),
+          this.safeRepository.clearCollectibleTransfers(
+            event.chainId,
+            event.address,
+          ),
         );
         break;
     }


### PR DESCRIPTION
Closes #495 

- Removes the `chainId` from the route path i.e. `/chains/:chainId/hooks/events` is now `/hooks/events`.
- The chain id is available on every webhook payload that we currently handle, so we can use it instead (making the route chain agnostic).