### PR TITLE
Set Coveralls step as optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           REDIS_PORT: 6379
           SAFE_CONFIG_BASE_URI: ${{ secrets.SAFE_CONFIG_BASE_URI }}
       - name: Coveralls Parallel
+        continue-on-error: true
         uses: coverallsapp/github-action@v2.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets the coverage upload step (using coveralls) as optional. If Coveralls is down, or we face issues with the coverage upload (Coveralls job closed for a specific commit hash), we should not block the deployment pipeline because of it.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error