### PR TITLE
Add configuration to set request timeout

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -29,4 +29,5 @@ export default (): ReturnType<typeof configuration> => ({
   expirationTimeInSeconds: {
     default: faker.number.int(),
   },
+  httpClient: { requestTimeout: faker.number.int() },
 });

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -31,4 +31,11 @@ export default () => ({
   expirationTimeInSeconds: {
     default: parseInt(process.env.EXPIRATION_TIME_DEFAULT_SECONDS ?? `${60}`),
   },
+  httpClient: {
+    // Timeout in milliseconds to be used for the HTTP client.
+    // A value of 0 disables the timeout.
+    requestTimeout: parseInt(
+      process.env.HTTP_CLIENT_REQUEST_TIMEOUT_MILLISECONDS ?? `${5_000}`,
+    ),
+  },
 });

--- a/src/datasources/network/network.module.spec.ts
+++ b/src/datasources/network/network.module.spec.ts
@@ -2,9 +2,12 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NetworkModule } from './network.module';
 import { RequestScopedLoggingModule } from '../../logging/logging.module';
 import { ClsModule } from 'nestjs-cls';
+import { ConfigurationModule } from '../../config/configuration.module';
+import configuration from '../../config/entities/__tests__/configuration';
+import { IConfigurationService } from '../../config/configuration.service.interface';
 
 describe('NetworkModule', () => {
-  it(`NetworkModule is successfully created`, async () => {
+  it(`axios client is created with timeout`, async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         NetworkModule,
@@ -12,11 +15,19 @@ describe('NetworkModule', () => {
         // and should be provided in the production app for it to work
         ClsModule.forRoot({ global: true }),
         RequestScopedLoggingModule,
+        ConfigurationModule.register(configuration),
       ],
     }).compile();
-
     const app = moduleFixture.createNestApplication();
+    const axios = moduleFixture.get('AxiosClient');
+    const configurationService = moduleFixture.get(IConfigurationService);
+    const httpClientTimeout = configurationService.get(
+      'httpClient.requestTimeout',
+    );
     await app.init();
+
+    expect(axios.defaults.timeout).toBe(httpClientTimeout);
+
     await app.close();
   });
 });

--- a/src/datasources/network/network.module.ts
+++ b/src/datasources/network/network.module.ts
@@ -2,13 +2,17 @@ import { Global, Module } from '@nestjs/common';
 import { AxiosNetworkService } from './axios.network.service';
 import { NetworkService } from './network.service.interface';
 import axios, { Axios } from 'axios';
+import { IConfigurationService } from '../../config/configuration.service.interface';
 
 /**
  * Use this factory to add any default parameter to the
  * {@link Axios} instance
  */
-function axiosFactory(): Axios {
-  return axios.create();
+function axiosFactory(configurationService: IConfigurationService): Axios {
+  const requestTimeout = configurationService.getOrThrow<number>(
+    'httpClient.requestTimeout',
+  );
+  return axios.create({ timeout: requestTimeout });
 }
 
 /**
@@ -21,7 +25,11 @@ function axiosFactory(): Axios {
 @Global()
 @Module({
   providers: [
-    { provide: 'AxiosClient', useFactory: axiosFactory },
+    {
+      provide: 'AxiosClient',
+      useFactory: axiosFactory,
+      inject: [IConfigurationService],
+    },
     { provide: NetworkService, useClass: AxiosNetworkService },
   ],
   exports: [NetworkService],


### PR DESCRIPTION
Closes #501

- The Axios client used in the service can now be configured with a request timeout by setting the environment variable. `HTTP_CLIENT_REQUEST_TIMEOUT_MILLISECONDS` to the desired value.
- The default value for the timeout is 5000ms (5 seconds).
- Setting the value to 0 disables the request timeout.