### PR TITLE
Revert "Change dependabot PR limit (#476)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 20
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 20


### PR DESCRIPTION
This reverts commit a87973d6ed16d64147163729ca930d58d8bc76ec.

Most of the dependencies were updated so we should fallback to the default limit of open pull requests open by Dependabot (5).