### PR TITLE
Add anyStringOrNull matcher

### DIFF
--- a/src/__tests__/matchers/to-be-string-or-null.ts
+++ b/src/__tests__/matchers/to-be-string-or-null.ts
@@ -1,0 +1,31 @@
+import { expect } from '@jest/globals';
+import type { MatcherFunction } from 'expect';
+
+const anyStringOrNull: MatcherFunction = function (actual) {
+  const pass = actual === null || typeof actual === 'string';
+  if (pass) {
+    return {
+      message: () => `expected ${actual} to be string or null`,
+      pass: true,
+    };
+  } else {
+    return {
+      message: () => `expected ${actual} to be string or null`,
+      pass: false,
+    };
+  }
+};
+
+expect.extend({
+  anyStringOrNull,
+});
+
+declare module 'expect' {
+  interface AsymmetricMatchers {
+    anyStringOrNull(): void;
+  }
+
+  interface Matchers<R> {
+    anyStringOrNull(): R;
+  }
+}


### PR DESCRIPTION
Extends Jest with a matcher to test if a field is `null` or `string`

For example use-cases see #512 #514 