### PR TITLE
Use latest git tag for service version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "safe-client-gateway",
-  "version": "0.0.1",
   "description": "",
   "private": true,
   "license": "MIT",

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -1,6 +1,22 @@
 import * as child_process from 'child_process';
 
 /**
+ * Returns the version number using the local git client.
+ *
+ * If git is not available or there is an error, returns null
+ */
+function getVersion(): null | string {
+  try {
+    return child_process
+      .execSync('git describe --tags --abbrev=0')
+      .toString()
+      .trim();
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
  * Returns the build number using the local git client.
  *
  * If git is not available or there is an error, returns null
@@ -19,7 +35,7 @@ function getBuildNumber(): null | string {
 export default () => ({
   about: {
     name: 'safe-client-gateway',
-    version: process.env.npm_package_version || '',
+    version: getVersion(),
     buildNumber: getBuildNumber(),
   },
   applicationPort: process.env.APPLICATION_PORT || '3000',

--- a/src/routes/about/__tests__/get-about.e2e-spec.ts
+++ b/src/routes/about/__tests__/get-about.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('Get about e2e test', () => {
         expect(body).toEqual(
           expect.objectContaining({
             name: expect.any(String),
-            version: expect.any(String),
+            version: expect.anyStringOrNull(),
             buildNumber: expect.anyStringOrNull(),
           }),
         );


### PR DESCRIPTION
Depends on #513 

Spawns a sub process to read the available git tags and sets it as the service version. If git is not available or an error is returned, the service version is set to null.