### PR TITLE
Add LOG_LEVEL environment variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,3 +26,6 @@
 # Authorization token to use privileged endpoints.
 # The AUTH_TOKEN should always be set
 #AUTH_TOKEN=
+
+# Log level for the service.
+#LOG_LEVEL=

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -18,7 +18,6 @@ describe('Configuration validator', () => {
   });
 
   it('should an invalid LOG_LEVEL configuration in production environment', () => {
-    process.env.NODE_ENV = 'production';
     expect(() =>
       validate({
         ...JSON.parse(fakeJson()),

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -10,11 +10,23 @@ describe('Configuration validator', () => {
     expect(validated).toBe(expected);
   });
 
-  it('should detect a malformed configuration in production environment', () => {
+  it('should detect missing mandatory configuration in production environment', () => {
     process.env.NODE_ENV = 'production';
     expect(() => validate(JSON.parse(fakeJson()))).toThrow(
-      /Mandatory configuration is missing: .*AUTH_TOKEN.*EXCHANGE_API_KEY/,
+      /must have required property 'AUTH_TOKEN'.*must have required property 'EXCHANGE_API_KEY'/,
     );
+  });
+
+  it('should an invalid LOG_LEVEL configuration in production environment', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() =>
+      validate({
+        ...JSON.parse(fakeJson()),
+        AUTH_TOKEN: faker.string.uuid(),
+        EXCHANGE_API_KEY: faker.string.uuid(),
+        LOG_LEVEL: faker.word.words(),
+      }),
+    ).toThrow(/LOG_LEVEL must be equal to one of the allowed values/);
   });
 
   it('should return the input configuration if validated in production environment', () => {

--- a/src/config/configuration.validator.ts
+++ b/src/config/configuration.validator.ts
@@ -5,6 +5,10 @@ const configurationSchema: Schema = {
   properties: {
     AUTH_TOKEN: { type: 'string' },
     EXCHANGE_API_KEY: { type: 'string' },
+    LOG_LEVEL: {
+      type: 'string',
+      enum: ['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'],
+    },
   },
   required: ['AUTH_TOKEN', 'EXCHANGE_API_KEY'],
 };
@@ -15,8 +19,10 @@ export function validate(
   if (process.env.NODE_ENV !== 'test') {
     const ajv = new Ajv({ allErrors: true });
     if (!ajv.validate(configurationSchema, configuration)) {
-      const errors = ajv.errors?.map((error) => error.message)?.join(', ');
-      throw Error(`Mandatory configuration is missing: ${errors}`);
+      const errors = ajv.errors
+        ?.map((error) => `${error.instancePath} ${error.message}`)
+        ?.join(', ');
+      throw Error(`Configuration is invalid: ${errors}`);
     }
   }
   return configuration;

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker';
-import { sample } from 'lodash';
 import configuration from '../../entities/configuration';
 
 export default (): ReturnType<typeof configuration> => ({
@@ -21,9 +20,7 @@ export default (): ReturnType<typeof configuration> => ({
     default: faker.number.int(),
   },
   httpClient: { requestTimeout: faker.number.int() },
-  log: {
-    level: sample(['error', 'warn', 'info', 'debug']) ?? 'debug',
-  },
+  log: { level: 'debug' },
   redis: {
     host: faker.internet.domainName(),
     port: faker.internet.port().toString(),

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker';
+import { sample } from 'lodash';
 import configuration from '../../entities/configuration';
 
 export default (): ReturnType<typeof configuration> => ({
@@ -20,6 +21,9 @@ export default (): ReturnType<typeof configuration> => ({
     default: faker.number.int(),
   },
   httpClient: { requestTimeout: faker.number.int() },
+  log: {
+    level: sample(['error', 'warn', 'info', 'debug']) ?? 'debug',
+  },
   redis: {
     host: faker.internet.domainName(),
     port: faker.internet.port().toString(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -61,6 +61,9 @@ export default () => ({
       process.env.HTTP_CLIENT_REQUEST_TIMEOUT_MILLISECONDS ?? `${5_000}`,
     ),
   },
+  log: {
+    level: process.env.LOG_LEVEL || 'debug',
+  },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',

--- a/src/logging/logging.module.ts
+++ b/src/logging/logging.module.ts
@@ -3,6 +3,7 @@ import { LoggingService } from './logging.interface';
 import { RequestScopedLoggingService } from './logging.service';
 import * as winston from 'winston';
 import * as Transport from 'winston-transport';
+import { IConfigurationService } from '../config/configuration.service.interface';
 
 /**
  * Provides a new instance of a Winston logger using the provided {@link transports}
@@ -19,9 +20,11 @@ const LoggerTransports = Symbol('LoggerTransports');
  * Factory which provides a collection of transports to be used by the
  * logger instance
  */
-function winstonTransportsFactory(): Transport[] | Transport {
+function winstonTransportsFactory(
+  configurationService: IConfigurationService,
+): Transport[] | Transport {
   return new winston.transports.Console({
-    level: 'debug',
+    level: configurationService.getOrThrow<string>('log.level'),
     format: winston.format.json(),
   });
 }
@@ -35,7 +38,11 @@ function winstonTransportsFactory(): Transport[] | Transport {
 @Module({
   providers: [
     { provide: LoggingService, useClass: RequestScopedLoggingService },
-    { provide: LoggerTransports, useFactory: winstonTransportsFactory },
+    {
+      provide: LoggerTransports,
+      useFactory: winstonTransportsFactory,
+      inject: [IConfigurationService],
+    },
     {
       provide: 'Logger',
       useFactory: winstonFactory,


### PR DESCRIPTION
Closes #313 

This PR:
- Adds the `LOG_LEVEL` environment variable to the expected configuration.
- Adds this `log.level` parameter to the configuration entity (and to the test entity). 
- Adds the `LOG_LEVEL` environment variable to the `.env.template` file.
- Injects the log level value into the `Logger` build configuration.