### PR TITLE
Read service version and build number from env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: |
+          BUILD_NUMBER=${{ github.sha }}
+          echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
       - uses: docker/setup-qemu-action@v2.2.0
         with:
           platforms: arm64
@@ -96,6 +99,9 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+            VERSION=${{ github.ref_name }}
           tags: ${{ env.DOCKER_IMAGE_TAG }}
           # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN yarn run build
 #
 FROM node:18.16-alpine as production
 USER node
+
+ARG VERSION
+ARG BUILD_NUMBER
+
+ENV APPLICATION_VERSION=${VERSION} \
+    APPLICATION_BUILD_NUMBER=${BUILD_NUMBER}
+
 COPY --chown=node:node --from=base /app/node_modules ./node_modules
 COPY --chown=node:node --from=base /app/dist ./dist
 CMD [ "node", "dist/main.js" ]

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -1,42 +1,8 @@
-import * as child_process from 'child_process';
-
-/**
- * Returns the version number using the local git client.
- *
- * If git is not available or there is an error, returns null
- */
-function getVersion(): null | string {
-  try {
-    return child_process
-      .execSync('git describe --tags --abbrev=0')
-      .toString()
-      .trim();
-  } catch (error) {
-    return null;
-  }
-}
-
-/**
- * Returns the build number using the local git client.
- *
- * If git is not available or there is an error, returns null
- */
-function getBuildNumber(): null | string {
-  try {
-    return child_process
-      .execSync('git rev-parse --short HEAD')
-      .toString()
-      .trim();
-  } catch (error) {
-    return null;
-  }
-}
-
 export default () => ({
   about: {
     name: 'safe-client-gateway',
-    version: getVersion(),
-    buildNumber: getBuildNumber(),
+    version: process.env.APPLICATION_VERSION,
+    buildNumber: process.env.APPLICATION_BUILD_NUMBER,
   },
   applicationPort: process.env.APPLICATION_PORT || '3000',
   auth: {

--- a/src/routes/about/about.service.ts
+++ b/src/routes/about/about.service.ts
@@ -12,9 +12,9 @@ export class AboutService {
   getAbout(): About {
     return {
       name: this.configurationService.getOrThrow<string>('about.name'),
-      version: this.configurationService.getOrThrow<string>('about.version'),
+      version: this.configurationService.get<string>('about.version') ?? null,
       buildNumber:
-        this.configurationService.getOrThrow<string>('about.buildNumber'),
+        this.configurationService.get<string>('about.buildNumber') ?? null,
     };
   }
 }

--- a/src/routes/about/entities/about.entity.ts
+++ b/src/routes/about/entities/about.entity.ts
@@ -1,10 +1,10 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class About {
   @ApiProperty()
   name: string;
-  @ApiProperty()
-  version: string;
-  @ApiProperty()
-  buildNumber: string;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  version: string | null;
+  @ApiPropertyOptional({ type: String, nullable: true })
+  buildNumber: string | null;
 }


### PR DESCRIPTION
- Reads the service version `APPLICATION_VERSION` and build number `APPLICATION_BUILD_NUMBER` from the environment.
- The Docker image now takes as an argument a `VERSION` and a `BUILD_NUMBER`. These arguments are mapped to `APPLICATION_VERSION` and `APPLICATION_BUILD_NUMBER` respectively.
- The `About` entity no longer requires a `version` and `buildNumber` to have a value. It was previously set to an empty-string but `null` is a better representation for the absence of a value.

**Note regarding the value of `VERSION`**

In our CI it reads from `github.ref_name` which is the branch name in case of a PR or the tag name in case of a tagged release. Examples:

```javascript
// For staging deployments
{
  ...
  "version": "main"
}
``` 

```javascript
// For a v1.0.0 tag
{
  ...
  "version": "v1.0.0"
}
``` 