### PR TITLE
Fix docker compose web container requirement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       REDIS_HOST: redis
       EXCHANGE_API_KEY: ${EXCHANGE_API_KEY-example_api_key}
       APPLICATION_PORT: ${APPLICATION_PORT-3000}
+      AUTH_TOKEN: ${AUTH_TOKEN-example_auth_token}
     depends_on:
       - redis
 


### PR DESCRIPTION
Adds `AUTH_TOKEN` to the web container in docker-compose.yml. The web container cannot start if the `AUTH_TOKEN` is not set.