### PR TITLE
Add support for disabling logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           REDIS_HOST: localhost
           REDIS_PORT: 6379
           SAFE_CONFIG_BASE_URI: ${{ secrets.SAFE_CONFIG_BASE_URI }}
+          LOG_SILENT: true
       - name: Coveralls Parallel
         continue-on-error: true
         uses: coverallsapp/github-action@v2.2.0

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -20,7 +20,10 @@ export default (): ReturnType<typeof configuration> => ({
     default: faker.number.int(),
   },
   httpClient: { requestTimeout: faker.number.int() },
-  log: { level: 'debug' },
+  log: {
+    level: 'debug',
+    silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
+  },
   redis: {
     host: faker.internet.domainName(),
     port: faker.internet.port().toString(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -29,6 +29,7 @@ export default () => ({
   },
   log: {
     level: process.env.LOG_LEVEL || 'debug',
+    silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',

--- a/src/logging/logging.module.ts
+++ b/src/logging/logging.module.ts
@@ -9,9 +9,16 @@ import { IConfigurationService } from '../config/configuration.service.interface
  * Provides a new instance of a Winston logger using the provided {@link transports}
  *
  * @param transports - the logger transports to be used in the winston instance
+ * @param configurationService - the configuration service to retrieve service-level settings
  */
-function winstonFactory(transports: Transport[] | Transport): winston.Logger {
-  return winston.createLogger({ transports: transports });
+function winstonFactory(
+  transports: Transport[] | Transport,
+  configurationService: IConfigurationService,
+): winston.Logger {
+  return winston.createLogger({
+    transports: transports,
+    silent: configurationService.getOrThrow<boolean>('log.silent'),
+  });
 }
 
 const LoggerTransports = Symbol('LoggerTransports');
@@ -46,7 +53,7 @@ function winstonTransportsFactory(
     {
       provide: 'Logger',
       useFactory: winstonFactory,
-      inject: [LoggerTransports],
+      inject: [LoggerTransports, IConfigurationService],
     },
   ],
   exports: [LoggingService],


### PR DESCRIPTION
- Adds a new configuration `log.silent` which, if set to `true` disables logging (default is `false`).
- This configuration can be set using the environment variable `LOG_SILENT`.
- Sets CI `LOG_SILENT` value to `true` (no test logs by default)