### PR TITLE
Remove global mockNetworkService

### DIFF
--- a/src/datasources/cache/cache.first.data.source.spec.ts
+++ b/src/datasources/cache/cache.first.data.source.spec.ts
@@ -1,12 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { ILoggingService } from '../../logging/logging.interface';
 import { NetworkResponseError } from '../network/entities/network.error.entity';
-import { mockNetworkService } from '../network/__tests__/test.network.module';
 import { CacheFirstDataSource } from './cache.first.data.source';
 import { ICacheService } from './cache.service.interface';
 import { CacheDir } from './entities/cache-dir.entity';
 import { FakeCacheService } from './__tests__/fake.cache.service';
 import { fakeJson } from '../../__tests__/faker';
+import { INetworkService } from '../network/network.service.interface';
 
 const mockLoggingService = {
   info: jest.fn(),
@@ -14,6 +14,12 @@ const mockLoggingService = {
   error: jest.fn(),
   warn: jest.fn(),
 } as unknown as ILoggingService;
+
+const networkService = {
+  get: jest.fn(),
+} as unknown as INetworkService;
+
+const mockNetworkService = jest.mocked(networkService);
 
 describe('CacheFirstDataSource', () => {
   let cacheFirstDataSource: CacheFirstDataSource;

--- a/src/datasources/network/__tests__/test.network.module.ts
+++ b/src/datasources/network/__tests__/test.network.module.ts
@@ -1,19 +1,11 @@
 import { Global, Module } from '@nestjs/common';
-import { NetworkService, INetworkService } from '../network.service.interface';
+import { INetworkService, NetworkService } from '../network.service.interface';
 
 const networkService: INetworkService = {
   get: jest.fn(),
   post: jest.fn(),
   delete: jest.fn(),
 };
-
-/**
- * Mocked Network interface which can be used in a testing scenario
- * to mock any external HTTP call made as long as it is done with
- * the {@link NetworkService}
- * @type {jest.Mocked}
- */
-export const mockNetworkService = jest.mocked(networkService);
 
 /**
  * The {@link TestNetworkModule} should be used whenever a mocked HTTP client
@@ -23,11 +15,18 @@ export const mockNetworkService = jest.mocked(networkService);
  * Test.createTestingModule({ imports: [ModuleA, TestNetworkModule]}).compile();
  *
  * This will create a TestModule which uses the implementation of ModuleA but
- * overrides the real HTTP client with a mocked one – {@link mockNetworkService}
+ * overrides the real HTTP client with a mocked one
  */
 @Global()
 @Module({
-  providers: [{ provide: NetworkService, useValue: mockNetworkService }],
+  providers: [
+    {
+      provide: NetworkService,
+      useFactory: () => {
+        return jest.mocked(networkService);
+      },
+    },
+  ],
   exports: [NetworkService],
 })
 export class TestNetworkModule {}

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -3,10 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { ValidationModule } from '../../validation/validation.module';
@@ -18,12 +15,14 @@ import { IConfigurationService } from '../../config/configuration.service.interf
 import { CacheDir } from '../../datasources/cache/entities/cache-dir.entity';
 import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
 import { CacheService } from '../../datasources/cache/cache.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Post Hook Events (Unit)', () => {
   let app: INestApplication;
   let authToken;
   let safeConfigUrl;
   let fakeCacheService: FakeCacheService;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -47,6 +46,7 @@ describe('Post Hook Events (Unit)', () => {
     const configurationService = moduleFixture.get(IConfigurationService);
     authToken = configurationService.get('auth.token');
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     await app.init();
   });
@@ -109,7 +109,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -132,7 +132,7 @@ describe('Post Hook Events (Unit)', () => {
       type: 'SOME_TEST_TYPE_THAT_WE_DO_NOT_SUPPORT',
       safeTxHash: 'some-safe-tx-hash',
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/1`:
           return Promise.resolve({
@@ -184,7 +184,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -232,7 +232,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -280,7 +280,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -319,7 +319,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -368,7 +368,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -417,7 +417,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -461,7 +461,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -500,7 +500,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({
@@ -564,7 +564,7 @@ describe('Post Hook Events (Unit)', () => {
       chainId: chainId,
       ...payload,
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chainId}`:
           return Promise.resolve({

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -1,10 +1,7 @@
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DomainModule } from '../../domain.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { INestApplication } from '@nestjs/common';
 import { CollectiblesModule } from './collectibles.module';
 import * as request from 'supertest';
@@ -27,10 +24,12 @@ import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Collectibles Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -51,6 +50,7 @@ describe('Collectibles Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -76,7 +76,7 @@ describe('Collectibles Controller (Unit)', () => {
         ])
         .build();
 
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse });
@@ -119,7 +119,7 @@ describe('Collectibles Controller (Unit)', () => {
         ])
         .build();
 
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse });
@@ -136,7 +136,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
         params: {
           limit: 10,
           offset: 20,
@@ -163,7 +163,7 @@ describe('Collectibles Controller (Unit)', () => {
         ])
         .build();
 
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse });
@@ -180,7 +180,7 @@ describe('Collectibles Controller (Unit)', () => {
         )
         .expect(200);
 
-      expect(mockNetworkService.get.mock.calls[1][1]).toStrictEqual({
+      expect(networkService.get.mock.calls[1][1]).toStrictEqual({
         params: {
           limit: PaginationData.DEFAULT_LIMIT,
           offset: PaginationData.DEFAULT_OFFSET,
@@ -197,7 +197,7 @@ describe('Collectibles Controller (Unit)', () => {
       const transactionServiceError = new NetworkResponseError(400, {
         message: 'some collectibles error',
       });
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse });
@@ -222,7 +222,7 @@ describe('Collectibles Controller (Unit)', () => {
       const safeAddress = faker.finance.ethereumAddress();
       const chainResponse = chainBuilder().with('chainId', chainId).build();
       const transactionServiceError = new NetworkRequestError({});
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chainId}`:
             return Promise.resolve({ data: chainResponse });

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -3,10 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../domain/contracts/entities/__tests__/contract.builder';
@@ -16,10 +13,12 @@ import { ContractsModule } from './contracts.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Contracts controller', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -40,6 +39,7 @@ describe('Contracts controller', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -53,7 +53,7 @@ describe('Contracts controller', () => {
     it('Success', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -73,7 +73,7 @@ describe('Contracts controller', () => {
     it('Failure: Config API fails', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.reject(new Error());
@@ -90,7 +90,7 @@ describe('Contracts controller', () => {
     it('Failure: Transaction API fails', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -109,7 +109,7 @@ describe('Contracts controller', () => {
     it('should get a validation error', async () => {
       const chain = chainBuilder().build();
       const contract = contractBuilder().build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -5,10 +5,7 @@ import { omit } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { delegateBuilder } from '../../domain/delegate/entities/__tests__/delegate.builder';
@@ -22,10 +19,12 @@ import { deleteSafeDelegateDtoBuilder } from './entities/__tests__/delete-safe-d
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Delegates controller', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -46,6 +45,7 @@ describe('Delegates controller', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -64,7 +64,7 @@ describe('Delegates controller', () => {
           delegateBuilder().with('safe', safe).build(),
         ])
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: chain });
         }
@@ -92,7 +92,7 @@ describe('Delegates controller', () => {
           { ...delegateBuilder().with('safe', safe).build(), label: true },
         ])
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: chain });
         }
@@ -121,7 +121,7 @@ describe('Delegates controller', () => {
         .with('previous', null)
         .with('results', [])
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         if (url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`) {
           return Promise.resolve({ data: chain });
         }
@@ -151,12 +151,12 @@ describe('Delegates controller', () => {
     it('Success', async () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url === `${chain.transactionService}/api/v1/delegates/`
           ? Promise.resolve({ status: 201 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -182,12 +182,12 @@ describe('Delegates controller', () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       createDelegateDto.safe = undefined;
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url === `${chain.transactionService}/api/v1/delegates/`
           ? Promise.resolve({ status: 201 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -202,12 +202,12 @@ describe('Delegates controller', () => {
     it('Should return the tx-service error message', async () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url === `${chain.transactionService}/api/v1/delegates/`
           ? Promise.reject({
               data: { message: 'Malformed body', status: 400 },
@@ -229,12 +229,12 @@ describe('Delegates controller', () => {
     it('Should fail with An error occurred', async () => {
       const createDelegateDto = createDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url === `${chain.transactionService}/api/v1/delegates/`
           ? Promise.reject({ status: 503 })
           : Promise.reject(`No matching rule for url: ${url}`),
@@ -255,12 +255,12 @@ describe('Delegates controller', () => {
     it('Success', async () => {
       const deleteDelegateDto = deleteDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`
           ? Promise.resolve({ data: {}, status: 204 })
@@ -278,12 +278,12 @@ describe('Delegates controller', () => {
     it('Should return the tx-service error message', async () => {
       const deleteDelegateDto = deleteDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`
           ? Promise.reject({
@@ -308,12 +308,12 @@ describe('Delegates controller', () => {
     it('Should fail with An error occurred', async () => {
       const deleteDelegateDto = deleteDelegateDtoBuilder().build();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/delegates/${deleteDelegateDto.delegate}`
           ? Promise.reject({ status: 503 })
@@ -350,12 +350,12 @@ describe('Delegates controller', () => {
     it('Success', async () => {
       const chain = chainBuilder().build();
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${deleteSafeDelegateDto.safe}/delegates/${deleteSafeDelegateDto.delegate}`
           ? Promise.resolve({ data: {}, status: 204 })
@@ -373,12 +373,12 @@ describe('Delegates controller', () => {
     it('Should return errors from provider', async () => {
       const chain = chainBuilder().build();
       const deleteSafeDelegateDto = deleteSafeDelegateDtoBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${deleteSafeDelegateDto.safe}/delegates/${deleteSafeDelegateDto.delegate}`
           ? Promise.reject({

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -5,10 +5,7 @@ import { omit } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
@@ -25,10 +22,12 @@ import { EstimationsModule } from './estimations.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Estimations Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -49,6 +48,7 @@ describe('Estimations Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -64,7 +64,7 @@ describe('Estimations Controller (Unit)', () => {
       const safe = safeBuilder().build();
       const estimation = estimationBuilder().build();
       const lastTransaction = multisigTransactionBuilder().build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
         const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
         const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -84,7 +84,7 @@ describe('Estimations Controller (Unit)', () => {
         }
         return Promise.reject(`No matching rule for url: ${url}`);
       });
-      mockNetworkService.post.mockImplementation((url) => {
+      networkService.post.mockImplementation((url) => {
         const estimationsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/estimations/`;
         return url === estimationsUrl
           ? Promise.resolve({ data: estimation })
@@ -138,7 +138,7 @@ describe('Estimations Controller (Unit)', () => {
     const lastTransaction = multisigTransactionBuilder()
       .with('nonce', faker.number.int({ min: 51 }))
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
@@ -158,7 +158,7 @@ describe('Estimations Controller (Unit)', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation })
@@ -190,7 +190,7 @@ describe('Estimations Controller (Unit)', () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().with('nonce', faker.number.int()).build();
     const estimation = estimationBuilder().build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
@@ -207,7 +207,7 @@ describe('Estimations Controller (Unit)', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation })
@@ -242,7 +242,7 @@ describe('Estimations Controller (Unit)', () => {
     const lastTransaction = multisigTransactionBuilder()
       .with('nonce', faker.number.int({ max: safe.nonce }))
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const chainsUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${address}`;
       const multisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/`;
@@ -262,7 +262,7 @@ describe('Estimations Controller (Unit)', () => {
       }
       return Promise.reject(`No matching rule for url: ${url}`);
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const estimationsUrl = `${chain.transactionService}/api/v1/safes/${address}/multisig-transactions/estimations/`;
       return url === estimationsUrl
         ? Promise.resolve({ data: estimation })

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -3,10 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
@@ -22,12 +19,14 @@ import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
 import { CacheService } from '../../datasources/cache/cache.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Flush Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
   let authToken;
   let fakeCacheService: FakeCacheService;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -53,6 +52,7 @@ describe('Flush Controller (Unit)', () => {
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
     authToken = configurationService.get('auth.token');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -79,7 +79,7 @@ describe('Flush Controller (Unit)', () => {
       chainBuilder().with('chainId', '1').build(),
       chainBuilder().with('chainId', '2').build(),
     ];
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains`:
           return Promise.resolve({

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -5,10 +5,7 @@ import { random, range } from 'lodash';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
@@ -28,10 +25,12 @@ import { MessagesModule } from './messages.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Messages controller', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -52,6 +51,7 @@ describe('Messages controller', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -73,7 +73,7 @@ describe('Messages controller', () => {
           faker.number.int({ max: messageConfirmations.length }),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -134,7 +134,7 @@ describe('Messages controller', () => {
           faker.number.int({ max: messageConfirmations.length }),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -194,7 +194,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -255,7 +255,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -315,7 +315,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -375,7 +375,7 @@ describe('Messages controller', () => {
           faker.number.int({ min: messageConfirmations.length + 1 }),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -442,7 +442,7 @@ describe('Messages controller', () => {
         .with('count', 1)
         .with('results', [messageToJson(message)])
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -526,7 +526,7 @@ describe('Messages controller', () => {
           messages.map((m) => messageToJson(m)),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -625,7 +625,7 @@ describe('Messages controller', () => {
           messages.map((m) => messageToJson(m)),
         )
         .build();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         switch (url) {
           case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
             return Promise.resolve({ data: chain });
@@ -688,12 +688,12 @@ describe('Messages controller', () => {
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
       const message = messageBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`
           ? Promise.resolve({ data: messageToJson(message) })
@@ -711,12 +711,12 @@ describe('Messages controller', () => {
       const chain = chainBuilder().build();
       const safe = safeBuilder().build();
       const errorMessage = faker.word.words();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/safes/${safe.address}/messages/`
           ? Promise.reject({
@@ -764,12 +764,12 @@ describe('Messages controller', () => {
       const expectedResponse = {
         data: { signature: faker.string.hexadecimal() },
       };
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/messages/${message.messageHash}/signatures/`
           ? Promise.resolve(expectedResponse)
@@ -792,12 +792,12 @@ describe('Messages controller', () => {
         .with('created', faker.date.recent())
         .build();
       const errorMessage = faker.word.words();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : Promise.reject(`No matching rule for url: ${url}`),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/messages/${message.messageHash}/signatures/`
           ? Promise.reject({

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -6,10 +6,7 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { ValidationModule } from '../../validation/validation.module';
@@ -20,10 +17,12 @@ import { NotificationsModule } from './notifications.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Notifications Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -44,6 +43,7 @@ describe('Notifications Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -67,12 +67,12 @@ describe('Notifications Controller (Unit)', () => {
   describe('POST /register/notifications', () => {
     it('Success', async () => {
       const registerDeviceDto = buildInputDto();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build() })
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve()
           : rejectForUrl(url),
@@ -87,12 +87,12 @@ describe('Notifications Controller (Unit)', () => {
 
     it('Client errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build() })
           : rejectForUrl(url);
       });
-      mockNetworkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce((url) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -101,7 +101,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve()
           : rejectForUrl(url),
@@ -122,12 +122,12 @@ describe('Notifications Controller (Unit)', () => {
 
     it('Server errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build() })
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce((url) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -136,7 +136,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve()
           : rejectForUrl(url),
@@ -155,12 +155,12 @@ describe('Notifications Controller (Unit)', () => {
 
     it('Both client and server errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         return url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build() })
           : rejectForUrl(url);
       });
-      mockNetworkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce((url) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -169,7 +169,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce((url) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(
               new NetworkResponseError(
@@ -178,7 +178,7 @@ describe('Notifications Controller (Unit)', () => {
             )
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve()
           : rejectForUrl(url),
@@ -200,22 +200,22 @@ describe('Notifications Controller (Unit)', () => {
 
     it('No status code errors returned from provider', async () => {
       const registerDeviceDto = buildInputDto();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url.includes(`${safeConfigUrl}/api/v1/chains/`)
           ? Promise.resolve({ data: chainBuilder().build() })
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce((url) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve()
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementationOnce((url) =>
+      networkService.post.mockImplementationOnce((url) =>
         url.includes(`/api/v1/notifications/devices`)
           ? Promise.reject(new Error())
           : rejectForUrl(url),
       );
-      mockNetworkService.post.mockImplementation((url) =>
+      networkService.post.mockImplementation((url) =>
         url.includes('/api/v1/notifications/devices/')
           ? Promise.resolve()
           : rejectForUrl(url),
@@ -239,12 +239,12 @@ describe('Notifications Controller (Unit)', () => {
       const safeAddress = faker.finance.ethereumAddress();
       const chain = chainBuilder().build();
       const expectedProviderURL = `${chain.transactionService}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : rejectForUrl(url),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url === expectedProviderURL ? Promise.resolve() : rejectForUrl(url),
       );
 
@@ -254,15 +254,15 @@ describe('Notifications Controller (Unit)', () => {
         )
         .expect(200)
         .expect({});
-      expect(mockNetworkService.delete).toBeCalledTimes(1);
-      expect(mockNetworkService.delete).toBeCalledWith(expectedProviderURL);
+      expect(networkService.delete).toBeCalledTimes(1);
+      expect(networkService.delete).toBeCalledWith(expectedProviderURL);
     });
 
     it('Failure: Config API fails', async () => {
       const uuid = faker.string.uuid();
       const safeAddress = faker.finance.ethereumAddress();
       const chainId = faker.string.numeric();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chainId}`
           ? Promise.reject(new Error())
           : rejectForUrl(url),
@@ -273,19 +273,19 @@ describe('Notifications Controller (Unit)', () => {
           `/v1/chains/${chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(503);
-      expect(mockNetworkService.delete).toBeCalledTimes(0);
+      expect(networkService.delete).toBeCalledTimes(0);
     });
 
     it('Failure: Transaction API fails', async () => {
       const uuid = faker.string.uuid();
       const safeAddress = faker.finance.ethereumAddress();
       const chain = chainBuilder().build();
-      mockNetworkService.get.mockImplementation((url) =>
+      networkService.get.mockImplementation((url) =>
         url === `${safeConfigUrl}/api/v1/chains/${chain.chainId}`
           ? Promise.resolve({ data: chain })
           : rejectForUrl(url),
       );
-      mockNetworkService.delete.mockImplementation((url) =>
+      networkService.delete.mockImplementation((url) =>
         url ===
         `${chain.transactionService}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`
           ? Promise.reject(new Error())
@@ -297,7 +297,7 @@ describe('Notifications Controller (Unit)', () => {
           `/v1/chains/${chain.chainId}/notifications/devices/${uuid}/safes/${safeAddress}`,
         )
         .expect(503);
-      expect(mockNetworkService.delete).toBeCalledTimes(1);
+      expect(networkService.delete).toBeCalledTimes(1);
     });
   });
 });

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { ValidationModule } from '../../validation/validation.module';
@@ -16,10 +13,12 @@ import { OwnersModule } from './owners.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -40,6 +39,7 @@ describe('Owners Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -61,8 +61,8 @@ describe('Owners Controller (Unit)', () => {
           faker.finance.ethereumAddress(),
         ],
       };
-      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-      mockNetworkService.get.mockResolvedValueOnce({
+      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
         data: transactionApiSafeListResponse,
       });
 
@@ -75,7 +75,7 @@ describe('Owners Controller (Unit)', () => {
     it('Failure: Config API fails', async () => {
       const chainId = faker.string.numeric();
       const ownerAddress = faker.finance.ethereumAddress();
-      mockNetworkService.get.mockRejectedValueOnce({
+      networkService.get.mockRejectedValueOnce({
         status: 500,
       });
 
@@ -87,8 +87,8 @@ describe('Owners Controller (Unit)', () => {
           code: 500,
         });
 
-      expect(mockNetworkService.get).toBeCalledTimes(1);
-      expect(mockNetworkService.get).toBeCalledWith(
+      expect(networkService.get).toBeCalledTimes(1);
+      expect(networkService.get).toBeCalledWith(
         `${safeConfigUrl}/api/v1/chains/${chainId}`,
         undefined,
       );
@@ -98,8 +98,8 @@ describe('Owners Controller (Unit)', () => {
       const chainId = faker.string.numeric();
       const ownerAddress = faker.finance.ethereumAddress();
       const chainResponse = chainBuilder().with('chainId', chainId).build();
-      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-      mockNetworkService.get.mockRejectedValueOnce({
+      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockRejectedValueOnce({
         status: 500,
       });
 
@@ -111,12 +111,12 @@ describe('Owners Controller (Unit)', () => {
           code: 500,
         });
 
-      expect(mockNetworkService.get).toBeCalledTimes(2);
-      expect(mockNetworkService.get).toBeCalledWith(
+      expect(networkService.get).toBeCalledTimes(2);
+      expect(networkService.get).toBeCalledWith(
         `${safeConfigUrl}/api/v1/chains/${chainId}`,
         undefined,
       );
-      expect(mockNetworkService.get).toBeCalledWith(
+      expect(networkService.get).toBeCalledWith(
         `${chainResponse.transactionService}/api/v1/owners/${ownerAddress}/safes/`,
         undefined,
       );
@@ -133,8 +133,8 @@ describe('Owners Controller (Unit)', () => {
           faker.finance.ethereumAddress(),
         ],
       };
-      mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-      mockNetworkService.get.mockResolvedValueOnce({
+      networkService.get.mockResolvedValueOnce({ data: chainResponse });
+      networkService.get.mockResolvedValueOnce({
         data: transactionApiSafeListResponse,
       });
 

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { SafeAppAccessControlPolicies } from '../../domain/safe-apps/entities/safe-app-access-control.entity';
@@ -19,10 +16,12 @@ import { SafeAppsModule } from './safe-apps.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Safe Apps Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -43,6 +42,7 @@ describe('Safe Apps Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -73,7 +73,7 @@ describe('Safe Apps Controller (Unit)', () => {
           )
           .build(),
       ];
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({ data: safeAppsResponse });
@@ -122,7 +122,7 @@ describe('Safe Apps Controller (Unit)', () => {
     it('Success with UNKNOWN accessControl', async () => {
       const chain = chainBuilder().build();
       const safeAppsResponse = [safeAppBuilder().build()];
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({
@@ -179,7 +179,7 @@ describe('Safe Apps Controller (Unit)', () => {
           .build(),
       ];
 
-      mockNetworkService.get.mockImplementation((url) => {
+      networkService.get.mockImplementation((url) => {
         const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
         if (url === getSafeAppsUrl) {
           return Promise.resolve({ data: safeAppsResponse });

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -2,10 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DomainModule } from '../../domain.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { SafesModule } from './safes.module';
 import * as request from 'supertest';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
@@ -38,13 +35,15 @@ import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { NULL_ADDRESS } from '../common/constants';
 import {
-  toJson as messageToJson,
   messageBuilder,
+  toJson as messageToJson,
 } from '../../domain/messages/entities/__tests__/message.builder';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Safes Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -65,6 +64,7 @@ describe('Safes Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -132,7 +132,7 @@ describe('Safes Controller (Unit)', () => {
       ])
       .build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -219,7 +219,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -273,7 +273,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -328,7 +328,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -386,7 +386,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -456,7 +456,7 @@ describe('Safes Controller (Unit)', () => {
       .build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -529,7 +529,7 @@ describe('Safes Controller (Unit)', () => {
       .build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -601,7 +601,7 @@ describe('Safes Controller (Unit)', () => {
       .build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -673,7 +673,7 @@ describe('Safes Controller (Unit)', () => {
       .build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -744,7 +744,7 @@ describe('Safes Controller (Unit)', () => {
       ])
       .build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -803,7 +803,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -878,7 +878,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -930,7 +930,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -977,7 +977,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -1030,7 +1030,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });
@@ -1078,7 +1078,7 @@ describe('Safes Controller (Unit)', () => {
     const allTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
           return Promise.resolve({ data: chain });

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
@@ -27,10 +24,12 @@ import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
 import { pageBuilder } from '../../../../domain/entities/__tests__/page.builder';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('Add transaction confirmations - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -51,6 +50,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -88,7 +88,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         .build(),
     ];
     const replacementTxsPage = pageBuilder().with('results', []).build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -120,7 +120,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const postConfirmationUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
       switch (url) {
         case postConfirmationUrl:

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
@@ -35,10 +32,12 @@ import { TransactionsModule } from '../../transactions.module';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('Get by id - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -59,6 +58,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -71,7 +71,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const chainId = faker.string.numeric();
     const id = `module_${faker.string.uuid()}`;
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       if (url === getChainUrl) {
         return Promise.reject({ status: 500 });
       }
@@ -86,8 +86,8 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(2);
-    expect(mockNetworkService.get).toBeCalledWith(getChainUrl, undefined);
+    expect(networkService.get).toBeCalledTimes(2);
+    expect(networkService.get).toBeCalledWith(getChainUrl, undefined);
   });
 
   it('Failure: Transaction API fails', async () => {
@@ -96,7 +96,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const moduleTransactionId = faker.string.uuid();
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${moduleTransactionId}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -117,9 +117,9 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(4);
-    expect(mockNetworkService.get).toBeCalledWith(getChainUrl, undefined);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(4);
+    expect(networkService.get).toBeCalledWith(getChainUrl, undefined);
+    expect(networkService.get).toBeCalledWith(
       getModuleTransactionUrl,
       undefined,
     );
@@ -133,7 +133,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${id}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -177,7 +177,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getModuleTransactionUrl = `${chain.transactionService}/api/v1/module-transaction/${moduleTransactionId}`;
     const getContractUrl = `${chain.transactionService}/api/v1/contracts/${moduleTransaction.to}`;
     const getModuleContractUrl = `${chain.transactionService}/api/v1/contracts/${moduleTransaction.module}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -244,7 +244,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getTransferUrl = `${chain.transactionService}/api/v1/transfer/${id}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -283,7 +283,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getTransferUrl = `${chain.transactionService}/api/v1/transfer/${transferId}`;
     const getFromContractUrl = `${chain.transactionService}/api/v1/contracts/${transfer.from}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${transfer.to}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -339,7 +339,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
     const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
     const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${txHash}/`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -415,7 +415,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
     const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${tx.to}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -582,7 +582,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
     const getToTokenUrl = `${chain.transactionService}/api/v1/tokens/${tx.to}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });
@@ -749,7 +749,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
     const getGasTokenContractUrl = `${chain.transactionService}/api/v1/tokens/${tx.gasToken}`;
     const getToContractUrl = `${chain.transactionService}/api/v1/contracts/${tx.to}`;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       switch (url) {
         case getChainUrl:
           return Promise.resolve({ data: chain });

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -7,10 +7,7 @@ import { ConfigurationModule } from '../../../../config/configuration.module';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../../../domain/entities/__tests__/page.builder';
@@ -32,10 +29,12 @@ import { TokenType } from '../../../../domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '../../../../logging/__tests__/test.logging.module';
 import { ValidationModule } from '../../../../validation/validation.module';
 import { TransactionsModule } from '../../transactions.module';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('List incoming transfers by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -56,6 +55,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -68,7 +68,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
   it('Failure: Config API fails', async () => {
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockRejectedValueOnce({
       status: 500,
     });
 
@@ -80,8 +80,8 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(1);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(1);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -93,8 +93,8 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     const limit = faker.number.int({ min: 0, max: 100 });
     const offset = faker.number.int({ min: 0, max: 100 });
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockRejectedValueOnce({
       status: 500,
     });
 
@@ -108,12 +108,12 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(2);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(2);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledWith(
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/incoming-transfers/`,
       expect.objectContaining({
         params: expect.objectContaining({ offset, limit }),
@@ -125,8 +125,8 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockResolvedValueOnce({
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
       data: { results: ['invalidData'] },
     });
 
@@ -154,7 +154,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('type', TokenType.Erc20)
       .with('address', erc20Transfer.tokenAddress)
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -233,7 +233,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('type', TokenType.Erc721)
       .with('address', erc721Transfer.tokenAddress)
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -306,7 +306,7 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       .with('value', faker.number.int({ min: 1 }).toString())
       .with('transferId', 'e1015fc690')
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getIncomingTransfersUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/incoming-transfers/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import {
@@ -21,10 +18,12 @@ import { TransactionsModule } from '../../transactions.module';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('List module transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -45,6 +44,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -57,7 +57,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
   it('Failure: Config API fails', async () => {
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockRejectedValueOnce({
       status: 500,
     });
 
@@ -69,8 +69,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(1);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(1);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -80,8 +80,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockRejectedValueOnce({
       status: 500,
     });
 
@@ -93,8 +93,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(2);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(2);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -104,9 +104,9 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockResolvedValueOnce({ data: { results: [] } });
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({ data: { results: [] } });
+    networkService.get.mockRejectedValueOnce({
       status: 404,
     });
 
@@ -118,8 +118,8 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 404,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(3);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(3);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -140,9 +140,9 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     };
 
     const safe = safeBuilder().build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockResolvedValueOnce({ data: moduleTransaction });
-    mockNetworkService.get.mockResolvedValueOnce({ data: safe });
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({ data: moduleTransaction });
+    networkService.get.mockResolvedValueOnce({ data: safe });
 
     await request(app.getHttpServer())
       .get(`/v1/chains/${chainId}/safes/${safeAddress}/module-transactions`)

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -7,10 +7,7 @@ import { ConfigurationModule } from '../../../../config/configuration.module';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  TestNetworkModule,
-  mockNetworkService,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
@@ -31,10 +28,12 @@ import { TokenType } from '../../../../domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '../../../../logging/__tests__/test.logging.module';
 import { ValidationModule } from '../../../../validation/validation.module';
 import { TransactionsModule } from '../../transactions.module';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('List multisig transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -55,6 +54,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -67,7 +67,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
   it('Failure: Config API fails', async () => {
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockRejectedValueOnce({
       status: 500,
     });
 
@@ -79,8 +79,8 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(1);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(1);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
@@ -90,8 +90,8 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockRejectedValueOnce({
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockRejectedValueOnce({
       status: 500,
     });
 
@@ -103,12 +103,12 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         code: 500,
       });
 
-    expect(mockNetworkService.get).toBeCalledTimes(2);
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledTimes(2);
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledWith(
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`,
       expect.objectContaining({
         params: expect.objectContaining({
@@ -124,8 +124,8 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
-    mockNetworkService.get.mockResolvedValueOnce({ data: chainResponse });
-    mockNetworkService.get.mockResolvedValueOnce({
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
       data: { results: ['invalidData'] },
     });
 
@@ -179,7 +179,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .with('type', TokenType.Erc20)
       .with('address', multisigTransaction.to)
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -301,7 +301,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
         confirmationBuilder().build(),
       ])
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -397,7 +397,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
           .build(),
       )
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${domainTransaction.safe}/multisig-transactions/`;

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
@@ -24,10 +21,12 @@ import { TransactionsModule } from '../../transactions.module';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('List queued transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -48,6 +47,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -130,7 +130,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       ) as MultisigTransaction,
     ];
 
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
@@ -323,7 +323,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
           .build(),
       ) as MultisigTransaction,
     ];
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
       const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
@@ -27,10 +24,12 @@ import { TransactionsModule } from '../../transactions.module';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('Preview transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -51,6 +50,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -82,7 +82,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const chainResponse = chainBuilder().build();
     const dataDecodedResponse = dataDecodedBuilder().build();
     const contractResponse = contractBuilder().build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -97,7 +97,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.resolve({ data: dataDecodedResponse });
@@ -147,7 +147,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const safeResponse = safeBuilder().with('address', safeAddress).build();
     const chainResponse = chainBuilder().build();
     const dataDecodedResponse = dataDecodedBuilder().build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -162,7 +162,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.resolve({ data: dataDecodedResponse });
@@ -211,7 +211,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const safeResponse = safeBuilder().with('address', safeAddress).build();
     const chainResponse = chainBuilder().build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -226,7 +226,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.reject({ error: 'Data cannot be decoded' });
@@ -290,7 +290,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
     const contractResponse = contractBuilder()
       .with('trustedForDelegateCall', true)
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
       const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
@@ -305,7 +305,7 @@ describe('Preview transaction - Transactions Controller (Unit)', () => {
       }
       return Promise.reject(new Error(`Could not match ${url}`));
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const getDataDecodedUrl = `${chainResponse.transactionService}/api/v1/data-decoder/`;
       if (url === getDataDecodedUrl) {
         return Promise.resolve({ data: dataDecodedResponse });

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -4,10 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestAppProvider } from '../../../../app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
-import {
-  mockNetworkService,
-  TestNetworkModule,
-} from '../../../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
@@ -26,10 +23,12 @@ import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
+import { NetworkService } from '../../../../datasources/network/network.service.interface';
 
 describe('Propose transaction - Transactions Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -50,6 +49,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -81,7 +81,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
     const transactions = pageBuilder().build();
     const token = tokenBuilder().build();
     const gasToken = tokenBuilder().build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${proposeTransactionDto.safeTxHash}/`;
       const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
@@ -111,7 +111,7 @@ describe('Propose transaction - Transactions Controller (Unit)', () => {
           return Promise.reject(new Error(`Could not match ${url}`));
       }
     });
-    mockNetworkService.post.mockImplementation((url) => {
+    networkService.post.mockImplementation((url) => {
       const proposeTransactionUrl = `${chain.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
       switch (url) {
         case proposeTransactionUrl:

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -7,10 +7,7 @@ import { ConfigurationModule } from '../../config/configuration.module';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import configuration from '../../config/entities/__tests__/configuration';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
-import {
-  TestNetworkModule,
-  mockNetworkService,
-} from '../../datasources/network/__tests__/test.network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import {
@@ -46,10 +43,12 @@ import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { ValidationModule } from '../../validation/validation.module';
 import { TransactionsModule } from './transactions.module';
 import { Transfer } from '../../domain/safe/entities/transfer.entity';
+import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
+  let networkService;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -70,6 +69,7 @@ describe('Transactions History Controller (Unit)', () => {
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
@@ -82,7 +82,7 @@ describe('Transactions History Controller (Unit)', () => {
   it('Failure: Config API fails', async () => {
     const chainId = faker.string.numeric();
     const safeAddress = faker.finance.ethereumAddress();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       if (url === getChainUrl) {
         return Promise.reject({ status: 500 });
@@ -103,7 +103,7 @@ describe('Transactions History Controller (Unit)', () => {
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       if (url === getChainUrl) {
@@ -136,7 +136,7 @@ describe('Transactions History Controller (Unit)', () => {
       results: [],
     };
     const creationTransaction = creationTransactionBuilder().build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -218,7 +218,7 @@ describe('Transactions History Controller (Unit)', () => {
       previous: null,
       results: [moduleTransaction, multisigTransaction, incomingTransaction],
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -273,7 +273,7 @@ describe('Transactions History Controller (Unit)', () => {
       previous: null,
       results: [moduleTransaction],
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -366,7 +366,7 @@ describe('Transactions History Controller (Unit)', () => {
       .with('type', TokenType.Erc20)
       .with('address', multisigTransaction.to)
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getAllTransactions = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
@@ -513,7 +513,7 @@ describe('Transactions History Controller (Unit)', () => {
     const creationTransaction = creationTransactionBuilder()
       .with('created', new Date(moduleTransaction.executionDate))
       .build();
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -586,7 +586,7 @@ describe('Transactions History Controller (Unit)', () => {
       previous: `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/?executed=false&limit=6&queued=true&trusted=true`,
       results: [moduleTransaction],
     };
-    mockNetworkService.get.mockImplementation((url) => {
+    networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
       const getAllTransactions = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`;
       const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
@@ -612,11 +612,11 @@ describe('Transactions History Controller (Unit)', () => {
         expect(body.previous).toContain(clientPreviousCursor);
       });
 
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,
     );
-    expect(mockNetworkService.get).toBeCalledWith(
+    expect(networkService.get).toBeCalledWith(
       `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/all-transactions/`,
       {
         params: {


### PR DESCRIPTION
- Removes the global reference to `mockNetworkService`
- Creates a new mocked instance per module creation (using a factory)
- Retrieves mocked instance via the module fixture