### PR TITLE
Add new tag Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,13 +115,14 @@ jobs:
     needs: [ prettier, es-lint, tests-finish ]
     runs-on: ubuntu-latest
     env:
+      IMAGE_CACHE_SOURCE: staging
       IMAGE_REGISTRY: safeglobal
       IMAGE_NAME: safe-client-gateway-nest
     steps:
       - uses: actions/checkout@v3
       - name: Extract commit metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
       - run: |
@@ -143,7 +144,7 @@ jobs:
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_CACHE_SOURCE }}
           cache-to: type=inline
 
   autodeploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    tags:
-      - '*'
   pull_request:
+  release:
+    types: [ released ]
 
 jobs:
   prettier:
@@ -79,7 +79,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
-  docker-publish:
+  docker-publish-staging:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [ prettier, es-lint, tests-finish ]
     runs-on: ubuntu-latest
@@ -110,7 +110,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
           cache-to: type=inline
 
-  tag-publish:
+  docker-publish-release:
     if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/'))
     needs: [ prettier, es-lint, tests-finish ]
     runs-on: ubuntu-latest
@@ -120,11 +120,6 @@ jobs:
       IMAGE_NAME: safe-client-gateway-nest
     steps:
       - uses: actions/checkout@v3
-      - name: Extract commit metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
       - run: |
           BUILD_NUMBER=${{ github.sha }}
           echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
@@ -143,13 +138,15 @@ jobs:
           build-args: |
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_CACHE_SOURCE }}
           cache-to: type=inline
 
   autodeploy:
     runs-on: ubuntu-latest
-    needs: [ docker-publish ]
+    needs: [ docker-publish-staging ]
     steps:
       - uses: actions/checkout@v3
       - name: Deploy Staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=inline
 
   tag-publish:
-    # if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/'))
+    if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/'))
     needs: [ prettier, es-lint, tests-finish ]
     runs-on: ubuntu-latest
     env:
@@ -143,7 +143,7 @@ jobs:
             BUILD_NUMBER=${{ env.BUILD_NUMBER }}
             VERSION=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:staging
+          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-to: type=inline
 
   autodeploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           cache-to: type=inline
 
   docker-publish-release:
-    if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/'))
+    if: (github.event_name == 'release' && github.event.action == 'released')
     needs: [ prettier, es-lint, tests-finish ]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    tags:
+      - '*'
   pull_request:
 
 jobs:
@@ -106,6 +108,42 @@ jobs:
           tags: ${{ env.DOCKER_IMAGE_TAG }}
           # Use inline cache storage https://docs.docker.com/build/cache/backends/inline/
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
+          cache-to: type=inline
+
+  tag-publish:
+    # if: (github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/'))
+    needs: [ prettier, es-lint, tests-finish ]
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REGISTRY: safeglobal
+      IMAGE_NAME: safe-client-gateway-nest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract commit metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+      - run: |
+          BUILD_NUMBER=${{ github.sha }}
+          echo "BUILD_NUMBER=${BUILD_NUMBER::7}" >> "$GITHUB_ENV"
+      - uses: docker/setup-qemu-action@v2.2.0
+        with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BUILD_NUMBER=${{ env.BUILD_NUMBER }}
+            VERSION=${{ github.ref_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:staging
           cache-to: type=inline
 
   autodeploy:


### PR DESCRIPTION
Closes #521 

This PR adds a new action which:
- Is meant to be executed only when a new release is pushed to the repository.
- Takes the build cache data from the `staging` built from the `main` branch atm.
- Pushes the release-tagged image to the docker images repository.