### PR TITLE
Isolate @nestjs/testing dependency

### DIFF
--- a/src/__tests__/test-app.provider.ts
+++ b/src/__tests__/test-app.provider.ts
@@ -1,0 +1,37 @@
+import { INestApplication } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+import {
+  AppProvider,
+  DEFAULT_CONFIGURATION,
+  configureShutdownHooks,
+} from '../app.provider';
+
+/**
+ * A test {@link AppProvider}
+ *
+ * This provider provides an application given a {@link TestingModule}
+ *
+ * If the module provided is not a {@link TestingModule}, an error is thrown
+ */
+export class TestAppProvider extends AppProvider {
+  // Disables shutdown hooks for tests (they are not required)
+  // Enabling this in the tests might result in a MaxListenersExceededWarning
+  // as the number of listeners that this adds exceed the default
+  protected readonly configuration: Array<(app: INestApplication) => void> =
+    DEFAULT_CONFIGURATION.filter((config) => config !== configureShutdownHooks);
+
+  constructor() {
+    super();
+    if (process.env.NODE_ENV !== 'test') {
+      throw Error('TestAppProvider used outside of a testing environment');
+    }
+  }
+
+  protected getApp(module: any): Promise<INestApplication> {
+    if (!(module instanceof TestingModule))
+      return Promise.reject(
+        `${module.constructor.name} is not a TestingModule`,
+      );
+    return Promise.resolve(module.createNestApplication());
+  }
+}

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -2,7 +2,6 @@ import { INestApplication, VersioningType } from '@nestjs/common';
 import { DataSourceErrorFilter } from './routes/common/filters/data-source-error.filter';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
-import { TestingModule } from '@nestjs/testing/testing-module';
 
 function configureVersioning(app: INestApplication) {
   app.enableVersioning({
@@ -10,7 +9,7 @@ function configureVersioning(app: INestApplication) {
   });
 }
 
-function configureShutdownHooks(app: INestApplication) {
+export function configureShutdownHooks(app: INestApplication) {
   app.enableShutdownHooks();
 }
 
@@ -28,7 +27,7 @@ function configureSwagger(app: INestApplication) {
   SwaggerModule.setup('', app, document);
 }
 
-const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
+export const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
   configureVersioning,
   configureShutdownHooks,
   configureFilters,
@@ -71,35 +70,5 @@ export class DefaultAppProvider extends AppProvider {
 
   protected getApp(module: any): Promise<INestApplication> {
     return NestFactory.create(module);
-  }
-}
-
-/**
- * A test {@link AppProvider}
- *
- * This provider provides an application given a {@link TestingModule}
- *
- * If the module provided is not a {@link TestingModule}, an error is thrown
- */
-export class TestAppProvider extends AppProvider {
-  // Disables shutdown hooks for tests (they are not required)
-  // Enabling this in the tests might result in a MaxListenersExceededWarning
-  // as the number of listeners that this adds exceed the default
-  protected readonly configuration: Array<(app: INestApplication) => void> =
-    DEFAULT_CONFIGURATION.filter((config) => config !== configureShutdownHooks);
-
-  constructor() {
-    super();
-    if (process.env.NODE_ENV !== 'test') {
-      throw Error('TestAppProvider used outside of a testing environment');
-    }
-  }
-
-  protected getApp(module: any): Promise<INestApplication> {
-    if (!(module instanceof TestingModule))
-      return Promise.reject(
-        `${module.constructor.name} is not a TestingModule`,
-      );
-    return Promise.resolve(module.createNestApplication());
   }
 }

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -18,7 +18,7 @@ import {
   pageBuilder,
 } from '../../domain/entities/__tests__/page.builder';
 import { PaginationData } from '../common/pagination/pagination.data';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '../../config/configuration.module';

--- a/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
+++ b/src/routes/contracts/__tests__/get-contract.e2e-spec.ts
@@ -4,7 +4,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { AppModule } from '../../../app.module';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
-import { TestAppProvider } from '../../../app.provider';
+import { TestAppProvider } from '../../../__tests__/test-app.provider';
 
 describe('Get contract e2e test', () => {
   let app: INestApplication;

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
+++ b/src/routes/data-decode/__tests__/data-decode.e2e-spec.ts
@@ -4,7 +4,7 @@ import { Test } from '@nestjs/testing';
 import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
-import { TestAppProvider } from '../../../app.provider';
+import { TestAppProvider } from '../../../__tests__/test-app.provider';
 import { DataDecoded } from '../../../domain/data-decoder/entities/data-decoded.entity';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
 import { getDataDecodedDtoBuilder } from '../entities/__tests__/get-data-decoded.dto.builder';

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { omit } from 'lodash';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
-import { TestAppProvider } from '../../../app.provider';
+import { TestAppProvider } from '../../../__tests__/test-app.provider';
 
 describe('Get health e2e test', () => {
   let app: INestApplication;

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { random, range } from 'lodash';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { range } from 'lodash';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
+++ b/src/routes/safe-apps/__tests__/get-safe-apps.e2e-spec.ts
@@ -3,7 +3,7 @@ import { Test } from '@nestjs/testing';
 import { RedisClientType } from 'redis';
 import * as request from 'supertest';
 import { AppModule } from '../../../app.module';
-import { TestAppProvider } from '../../../app.provider';
+import { TestAppProvider } from '../../../__tests__/test-app.provider';
 import { redisClientFactory } from '../../../__tests__/redis-client.factory';
 
 describe('Get Safe Apps e2e test', () => {

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../domain.module';

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -27,7 +27,7 @@ import {
   moduleTransactionBuilder,
   toJson as moduleTransactionToJson,
 } from '../../domain/safe/entities/__tests__/module-transaction.builder';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '../../config/configuration.module';

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import configuration from '../../../../config/entities/__tests__/configuration';

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import configuration from '../../../../config/entities/__tests__/configuration';

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';

--- a/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/preview-transaction.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';

--- a/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/propose-transaction.transactions.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../../../app.provider';
+import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
 import { DomainModule } from '../../../../domain.module';

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { TestAppProvider } from '../../app.provider';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { ConfigurationModule } from '../../config/configuration.module';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import configuration from '../../config/entities/__tests__/configuration';


### PR DESCRIPTION
This PR:

(This is heavily inspired by https://github.com/safe-global/safe-gelato-relay-service/pull/99, thanks to @fmrsabino)

- Extracts TestAppProvider to a different file (under src/__tests__)
- This change removes the direct reference from app.provider.ts (used in production code) to @nestjs/testing