### PR TITLE
Use overrideModule to replace modules

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,9 @@ import { RouteLoggerInterceptor } from './routes/common/interceptors/route-logge
 import { NotFoundLoggerMiddleware } from './middleware/not-found-logger.middleware';
 import configuration from './config/entities/configuration';
 
+// See https://github.com/nestjs/nest/issues/11967
+export const configurationModule = ConfigurationModule.register(configuration);
+
 @Module({
   imports: [
     // features
@@ -65,7 +68,7 @@ import configuration from './config/entities/configuration';
         idGenerator: () => uuidv4(),
       },
     }),
-    ConfigurationModule.register(configuration),
+    configurationModule,
     DomainModule,
     NetworkModule,
     RequestScopedLoggingModule,

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -4,20 +4,21 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { balanceBuilder } from '../../domain/balances/entities/__tests__/balance.builder';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { exchangeFiatCodesBuilder } from '../../domain/exchange/entities/__tests__/exchange-fiat-codes.builder';
 import { exchangeRatesBuilder } from '../../domain/exchange/entities/__tests__/exchange-rates.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { BalancesModule } from './balances.module';
 import { NULL_ADDRESS } from '../common/constants';
 import { faker } from '@faker-js/faker';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { NetworkService } from '../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 
 describe('Balances Controller (Unit)', () => {
   let app: INestApplication;
@@ -29,18 +30,17 @@ describe('Balances Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        BalancesModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/cache-hooks/cache-hooks.controller.spec.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.spec.ts
@@ -4,17 +4,18 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { CacheHooksModule } from './cache-hooks.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { CacheDir } from '../../datasources/cache/entities/cache-dir.entity';
 import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
 import { CacheService } from '../../datasources/cache/cache.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Post Hook Events (Unit)', () => {
@@ -28,18 +29,17 @@ describe('Post Hook Events (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        CacheHooksModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
     app = moduleFixture.createNestApplication();
 
     fakeCacheService = moduleFixture.get<FakeCacheService>(CacheService);

--- a/src/routes/chains/chains.controller.spec.ts
+++ b/src/routes/chains/chains.controller.spec.ts
@@ -6,7 +6,6 @@ import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { Backbone } from '../../domain/backbone/entities/backbone.entity';
 import { backboneBuilder } from '../../domain/backbone/entities/__tests__/backbone.builder';
 import { Chain } from '../../domain/chains/entities/chain.entity';
@@ -14,14 +13,16 @@ import { MasterCopy as DomainMasterCopy } from '../../domain/chains/entities/mas
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { masterCopyBuilder } from '../../domain/chains/entities/__tests__/master-copy.builder';
 import { Page } from '../../domain/entities/page.entity';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { PaginationData } from '../common/pagination/pagination.data';
-import { ChainsModule } from './chains.module';
 import { MasterCopy } from './entities/master-copy.entity';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Chains Controller (Unit)', () => {
@@ -47,18 +48,17 @@ describe('Chains Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        ChainsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/collectibles/collectibles.controller.spec.ts
+++ b/src/routes/collectibles/collectibles.controller.spec.ts
@@ -1,9 +1,7 @@
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
-import { DomainModule } from '../../domain.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
 import { INestApplication } from '@nestjs/common';
-import { CollectiblesModule } from './collectibles.module';
 import * as request from 'supertest';
 import { faker } from '@faker-js/faker';
 import { Collectible } from '../../domain/collectibles/entities/collectible.entity';
@@ -19,11 +17,14 @@ import {
 } from '../../domain/entities/__tests__/page.builder';
 import { PaginationData } from '../common/pagination/pagination.data';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Collectibles Controller (Unit)', () => {
@@ -35,18 +36,17 @@ describe('Collectibles Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        CollectiblesModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/contracts/contracts.controller.spec.ts
+++ b/src/routes/contracts/contracts.controller.spec.ts
@@ -4,15 +4,16 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../domain/contracts/entities/__tests__/contract.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { ContractsModule } from './contracts.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Contracts controller', () => {
@@ -24,18 +25,17 @@ describe('Contracts controller', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        ContractsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/delegates/delegates.controller.spec.ts
+++ b/src/routes/delegates/delegates.controller.spec.ts
@@ -6,13 +6,10 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { delegateBuilder } from '../../domain/delegate/entities/__tests__/delegate.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { DelegatesModule } from './delegates.module';
 import { createDelegateDtoBuilder } from './entities/__tests__/create-delegate.dto.builder';
 import { deleteDelegateDtoBuilder } from './entities/__tests__/delete-delegate.dto.builder';
 import { deleteSafeDelegateDtoBuilder } from './entities/__tests__/delete-safe-delegate.dto.builder';
@@ -20,6 +17,10 @@ import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { NetworkService } from '../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 
 describe('Delegates controller', () => {
   let app: INestApplication;
@@ -30,18 +31,17 @@ describe('Delegates controller', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        DelegatesModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/estimations/estimations.controller.spec.ts
+++ b/src/routes/estimations/estimations.controller.spec.ts
@@ -6,7 +6,6 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
 import { GetEstimationDto } from '../../domain/estimations/entities/get-estimation.dto.entity';
@@ -16,12 +15,14 @@ import {
   toJson as multisigTransactionToJson,
 } from '../../domain/safe/entities/__tests__/multisig-transaction.builder';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { EstimationsModule } from './estimations.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Estimations Controller (Unit)', () => {
@@ -33,18 +34,17 @@ describe('Estimations Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        EstimationsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/flush/flush.controller.spec.ts
+++ b/src/routes/flush/flush.controller.spec.ts
@@ -4,21 +4,19 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
-import { ValidationModule } from '../../validation/validation.module';
-import { ChainsModule } from '../chains/chains.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { ContractsModule } from '../contracts/contracts.module';
-import { TransactionsModule } from '../transactions/transactions.module';
 import { invalidationPatternDtoBuilder } from './entities/__tests__/invalidation-pattern.dto.builder';
-import { FlushModule } from './flush.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
 import { CacheService } from '../../datasources/cache/cache.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Flush Controller (Unit)', () => {
@@ -32,21 +30,17 @@ describe('Flush Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        FlushModule,
-        ChainsModule,
-        ContractsModule,
-        TransactionsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     fakeCacheService = moduleFixture.get<FakeCacheService>(CacheService);
     const configurationService = moduleFixture.get(IConfigurationService);

--- a/src/routes/messages/messages.controller.spec.ts
+++ b/src/routes/messages/messages.controller.spec.ts
@@ -6,7 +6,6 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../domain/entities/__tests__/page.builder';
 import { messageConfirmationBuilder } from '../../domain/messages/entities/__tests__/message-confirmation.builder';
@@ -16,15 +15,17 @@ import {
 } from '../../domain/messages/entities/__tests__/message.builder';
 import { safeAppBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app.builder';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { MessageStatus } from './entities/message.entity';
 import { createMessageDtoBuilder } from './entities/__tests__/create-message.dto.builder';
 import { updateMessageSignatureDtoBuilder } from './entities/__tests__/update-message-signature.dto.builder';
-import { MessagesModule } from './messages.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Messages controller', () => {
@@ -36,18 +37,17 @@ describe('Messages controller', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        MessagesModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/notifications/notifications.controller.spec.ts
+++ b/src/routes/notifications/notifications.controller.spec.ts
@@ -7,16 +7,17 @@ import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { NetworkResponseError } from '../../datasources/network/entities/network.error.entity';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { registerDeviceDtoBuilder } from './entities/__tests__/register-device.dto.builder';
 import { safeRegistrationBuilder } from './entities/__tests__/safe-registration.builder';
-import { NotificationsModule } from './notifications.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Notifications Controller (Unit)', () => {
@@ -28,18 +29,17 @@ describe('Notifications Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        NotificationsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/owners/owners.controller.spec.ts
+++ b/src/routes/owners/owners.controller.spec.ts
@@ -5,15 +5,16 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { OwnersModule } from './owners.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { NetworkService } from '../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 
 describe('Owners Controller (Unit)', () => {
   let app: INestApplication;
@@ -24,18 +25,17 @@ describe('Owners Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        OwnersModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/safe-apps/safe-apps.controller.spec.ts
+++ b/src/routes/safe-apps/safe-apps.controller.spec.ts
@@ -5,17 +5,18 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { SafeAppAccessControlPolicies } from '../../domain/safe-apps/entities/safe-app-access-control.entity';
 import { safeAppAccessControlBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app-access-control.builder';
 import { safeAppBuilder } from '../../domain/safe-apps/entities/__tests__/safe-app.builder';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { ValidationModule } from '../../validation/validation.module';
-import { SafeAppsModule } from './safe-apps.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Safe Apps Controller (Unit)', () => {
@@ -27,18 +28,17 @@ describe('Safe Apps Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        SafeAppsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -1,9 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { Test, TestingModule } from '@nestjs/testing';
-import { DomainModule } from '../../domain.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { SafesModule } from './safes.module';
 import * as request from 'supertest';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
@@ -28,7 +26,6 @@ import {
   toJson as moduleTransactionToJson,
 } from '../../domain/safe/entities/__tests__/module-transaction.builder';
 import { TestAppProvider } from '../../__tests__/test-app.provider';
-import { ValidationModule } from '../../validation/validation.module';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
 import { ConfigurationModule } from '../../config/configuration.module';
 import configuration from '../../config/entities/__tests__/configuration';
@@ -38,6 +35,10 @@ import {
   messageBuilder,
   toJson as messageToJson,
 } from '../../domain/messages/entities/__tests__/message.builder';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
 describe('Safes Controller (Unit)', () => {
@@ -49,18 +50,17 @@ describe('Safes Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        SafesModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -5,7 +5,6 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
 import { pageBuilder } from '../../../../domain/entities/__tests__/page.builder';
@@ -27,12 +26,14 @@ import {
 import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
 import { TestLoggingModule } from '../../../../logging/__tests__/test.logging.module';
-import { ValidationModule } from '../../../../validation/validation.module';
-import { TransactionsModule } from '../../transactions.module';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import { NetworkService } from '../../../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../../../app.module';
+import { CacheModule } from '../../../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../../../logging/logging.module';
+import { NetworkModule } from '../../../../datasources/network/network.module';
 
 describe('Get by id - Transactions Controller (Unit)', () => {
   let app: INestApplication;
@@ -43,18 +44,17 @@ describe('Get by id - Transactions Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        TransactionsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -8,7 +8,6 @@ import { IConfigurationService } from '../../../../config/configuration.service.
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { pageBuilder } from '../../../../domain/entities/__tests__/page.builder';
 import {
@@ -27,9 +26,11 @@ import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.bui
 import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
 import { TokenType } from '../../../../domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '../../../../logging/__tests__/test.logging.module';
-import { ValidationModule } from '../../../../validation/validation.module';
-import { TransactionsModule } from '../../transactions.module';
 import { NetworkService } from '../../../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../../../app.module';
+import { CacheModule } from '../../../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../../../logging/logging.module';
+import { NetworkModule } from '../../../../datasources/network/network.module';
 
 describe('List incoming transfers by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
@@ -40,18 +41,17 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        TransactionsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -5,7 +5,6 @@ import * as request from 'supertest';
 import { TestAppProvider } from '../../../../__tests__/test-app.provider';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import {
   moduleTransactionBuilder,
@@ -13,12 +12,14 @@ import {
 } from '../../../../domain/safe/entities/__tests__/module-transaction.builder';
 import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.builder';
 import { TestLoggingModule } from '../../../../logging/__tests__/test.logging.module';
-import { ValidationModule } from '../../../../validation/validation.module';
-import { TransactionsModule } from '../../transactions.module';
 import { ConfigurationModule } from '../../../../config/configuration.module';
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { IConfigurationService } from '../../../../config/configuration.service.interface';
 import { NetworkService } from '../../../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../../../app.module';
+import { CacheModule } from '../../../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../../../logging/logging.module';
+import { NetworkModule } from '../../../../datasources/network/network.module';
 
 describe('List module transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
@@ -29,18 +30,17 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        TransactionsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -8,7 +8,6 @@ import { IConfigurationService } from '../../../../config/configuration.service.
 import configuration from '../../../../config/entities/__tests__/configuration';
 import { TestCacheModule } from '../../../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../../../domain.module';
 import { chainBuilder } from '../../../../domain/chains/entities/__tests__/chain.builder';
 import { contractBuilder } from '../../../../domain/contracts/entities/__tests__/contract.builder';
 import {
@@ -26,9 +25,11 @@ import { safeBuilder } from '../../../../domain/safe/entities/__tests__/safe.bui
 import { tokenBuilder } from '../../../../domain/tokens/__tests__/token.builder';
 import { TokenType } from '../../../../domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '../../../../logging/__tests__/test.logging.module';
-import { ValidationModule } from '../../../../validation/validation.module';
-import { TransactionsModule } from '../../transactions.module';
 import { NetworkService } from '../../../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../../../app.module';
+import { CacheModule } from '../../../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../../../logging/logging.module';
+import { NetworkModule } from '../../../../datasources/network/network.module';
 
 describe('List multisig transactions by Safe - Transactions Controller (Unit)', () => {
   let app: INestApplication;
@@ -39,18 +40,17 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        TransactionsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -8,7 +8,6 @@ import { IConfigurationService } from '../../config/configuration.service.interf
 import configuration from '../../config/entities/__tests__/configuration';
 import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
 import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
-import { DomainModule } from '../../domain.module';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import {
   dataDecodedBuilder,
@@ -40,10 +39,12 @@ import { safeBuilder } from '../../domain/safe/entities/__tests__/safe.builder';
 import { tokenBuilder } from '../../domain/tokens/__tests__/token.builder';
 import { TokenType } from '../../domain/tokens/entities/token.entity';
 import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
-import { ValidationModule } from '../../validation/validation.module';
-import { TransactionsModule } from './transactions.module';
 import { Transfer } from '../../domain/safe/entities/transfer.entity';
 import { NetworkService } from '../../datasources/network/network.service.interface';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
 
 describe('Transactions History Controller (Unit)', () => {
   let app: INestApplication;
@@ -54,18 +55,17 @@ describe('Transactions History Controller (Unit)', () => {
     jest.clearAllMocks();
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [
-        // feature
-        TransactionsModule,
-        // common
-        DomainModule,
-        TestCacheModule,
-        ConfigurationModule.register(configuration),
-        TestLoggingModule,
-        TestNetworkModule,
-        ValidationModule,
-      ],
-    }).compile();
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
 
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');


### PR DESCRIPTION
- Uses `overrideModule` to override the production modules with testing ones.
- Extracts the dynamic module which was built in place in `AppModule` so that the module can be replaced in a testing scenario using its direct reference. Context: https://github.com/nestjs/nest/issues/11967
- Uses `AppModule` throughout the tests instead of the modules for each feature. This way the setup between the tests can be shared, and all the required modules should be available by default.

`overrideModule` was introduced in NestJS 10 – https://github.com/nestjs/nest/releases/tag/v10.0.0