### PR TITLE
Add ExceptionFilter to log uncaught errors

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,7 +4,7 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 import { ClsMiddleware, ClsModule } from 'nestjs-cls';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -34,6 +34,8 @@ import { RequestScopedLoggingModule } from './logging/logging.module';
 import { RouteLoggerInterceptor } from './routes/common/interceptors/route-logger.interceptor';
 import { NotFoundLoggerMiddleware } from './middleware/not-found-logger.middleware';
 import configuration from './config/entities/configuration';
+import { GlobalErrorFilter } from './routes/common/filters/global-error.filter';
+import { DataSourceErrorFilter } from './routes/common/filters/data-source-error.filter';
 
 // See https://github.com/nestjs/nest/issues/11967
 export const configurationModule = ConfigurationModule.register(configuration);
@@ -78,6 +80,14 @@ export const configurationModule = ConfigurationModule.register(configuration);
     {
       provide: APP_INTERCEPTOR,
       useClass: RouteLoggerInterceptor,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: GlobalErrorFilter,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: DataSourceErrorFilter,
     },
   ],
 })

--- a/src/app.provider.ts
+++ b/src/app.provider.ts
@@ -1,5 +1,4 @@
 import { INestApplication, VersioningType } from '@nestjs/common';
-import { DataSourceErrorFilter } from './routes/common/filters/data-source-error.filter';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestFactory } from '@nestjs/core';
 
@@ -11,10 +10,6 @@ function configureVersioning(app: INestApplication) {
 
 export function configureShutdownHooks(app: INestApplication) {
   app.enableShutdownHooks();
-}
-
-function configureFilters(app: INestApplication) {
-  app.useGlobalFilters(new DataSourceErrorFilter());
 }
 
 function configureSwagger(app: INestApplication) {
@@ -30,7 +25,6 @@ function configureSwagger(app: INestApplication) {
 export const DEFAULT_CONFIGURATION: ((app: INestApplication) => void)[] = [
   configureVersioning,
   configureShutdownHooks,
-  configureFilters,
   configureSwagger,
 ];
 

--- a/src/routes/common/filters/global-error.filter.spec.ts
+++ b/src/routes/common/filters/global-error.filter.spec.ts
@@ -1,0 +1,64 @@
+import { Controller, Get, HttpException, HttpStatus } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestAppProvider } from '../../../__tests__/test-app.provider';
+import * as request from 'supertest';
+import { APP_FILTER } from '@nestjs/core';
+import { GlobalErrorFilter } from './global-error.filter';
+import { TestLoggingModule } from '../../../logging/__tests__/test.logging.module';
+import { ConfigurationModule } from '../../../config/configuration.module';
+import configuration from '../../../config/entities/__tests__/configuration';
+
+@Controller({})
+class TestController {
+  @Get('http-exception')
+  async httpException() {
+    throw new HttpException(
+      { message: 'Some http exception' },
+      HttpStatus.BAD_GATEWAY,
+    );
+  }
+
+  @Get('non-http-exception')
+  async bar() {
+    throw new Error('Some random error');
+  }
+}
+
+describe('GlobalErrorFilter tests', () => {
+  let app;
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [TestLoggingModule, ConfigurationModule.register(configuration)],
+      controllers: [TestController],
+      providers: [
+        {
+          provide: APP_FILTER,
+          useClass: GlobalErrorFilter,
+        },
+      ],
+    }).compile();
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('http exception returns correct error code and message', async () => {
+    await request(app.getHttpServer())
+      .get('/http-exception')
+      .expect(502)
+      .expect({ message: 'Some http exception' });
+  });
+
+  it('non http exception returns correct error code and message', async () => {
+    await request(app.getHttpServer())
+      .get('/non-http-exception')
+      .expect(500)
+      .expect({
+        code: 500,
+        message: 'Internal server error',
+      });
+  });
+});

--- a/src/routes/common/filters/global-error.filter.spec.ts
+++ b/src/routes/common/filters/global-error.filter.spec.ts
@@ -19,7 +19,7 @@ class TestController {
   }
 
   @Get('non-http-exception')
-  async bar() {
+  async nonHttpException() {
     throw new Error('Some random error');
   }
 }

--- a/src/routes/common/filters/global-error.filter.ts
+++ b/src/routes/common/filters/global-error.filter.ts
@@ -1,0 +1,47 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Inject,
+} from '@nestjs/common';
+import {
+  ILoggingService,
+  LoggingService,
+} from '../../../logging/logging.interface';
+import { HttpAdapterHost } from '@nestjs/core';
+
+@Catch()
+export class GlobalErrorFilter implements ExceptionFilter {
+  constructor(
+    private readonly httpAdapterHost: HttpAdapterHost,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  catch(exception: Error, host: ArgumentsHost): any {
+    const { httpAdapter } = this.httpAdapterHost;
+
+    const ctx = host.switchToHttp();
+
+    const httpStatus =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    this.loggingService.error({
+      name: exception.name,
+      message: exception.message,
+      stacktrace: exception.stack,
+    });
+
+    const responseBody =
+      exception instanceof HttpException
+        ? exception.getResponse()
+        : {
+            code: httpStatus,
+            message: 'Internal server error',
+          };
+    httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus);
+  }
+}


### PR DESCRIPTION
Depends on #527 

- Adds an `ExceptionFilter` which logs all errors that do not have a filter associated with it.
- Errors were already being logged to the console (default NestJS logger behavior). This changes that default to use our own `ILoggingService`.
- Moves `DataSourceErrorFilter` from `AppProvider` into `AppModule` – the new exception filter requires dependency injection to be in place (which cannot be done via `app.useGlobalFilters()` and, in order to have a standard way of adding exception filters, both of them are now provided by `AppModule`