### PR TITLE
Validate datasource pages metadata

### DIFF
--- a/src/domain/entities/schemas/page.schema.factory.ts
+++ b/src/domain/entities/schemas/page.schema.factory.ts
@@ -1,0 +1,17 @@
+import { Schema, SchemaObject } from 'ajv';
+
+export function buildPageSchema(
+  keyRef: string,
+  itemSchema: SchemaObject,
+): Schema {
+  return <SchemaObject>{
+    $id: keyRef,
+    type: 'object',
+    properties: {
+      count: { type: 'number' },
+      next: { type: 'string', nullable: true },
+      previous: { type: 'string', nullable: true },
+      results: { type: 'array', items: { $ref: itemSchema.$id } },
+    },
+  };
+}

--- a/src/domain/interfaces/page-validator.interface.ts
+++ b/src/domain/interfaces/page-validator.interface.ts
@@ -1,0 +1,5 @@
+import { Page } from '../entities/page.entity';
+
+export interface IPageValidator<T> {
+  validatePage(data: unknown): Page<T>;
+}

--- a/src/domain/messages/entities/schemas/message.schema.ts
+++ b/src/domain/messages/entities/schemas/message.schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'ajv';
+import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
 export const messageConfirmationSchema: Schema = {
   $id: 'https://safe-client.safe.global/schemas/messages/message-confirmation.json',
@@ -40,3 +41,8 @@ export const messageSchema: Schema = {
     'confirmations',
   ],
 };
+
+export const messagePageSchema: Schema = buildPageSchema(
+  'https://safe-client.safe.global/schemas/messages/message-page.json',
+  messageSchema,
+);

--- a/src/domain/messages/message.validator.ts
+++ b/src/domain/messages/message.validator.ts
@@ -1,17 +1,23 @@
 import { Injectable } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
+import { Page } from '../../routes/common/entities/page.entity';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
+import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { Message } from './entities/message.entity';
 import {
   messageConfirmationSchema,
+  messagePageSchema,
   messageSchema,
 } from './entities/schemas/message.schema';
 
 @Injectable()
-export class MessageValidator implements IValidator<Message> {
+export class MessageValidator
+  implements IValidator<Message>, IPageValidator<Message>
+{
   private readonly isValidMessage: ValidateFunction<Message>;
+  private readonly isValidPage: ValidateFunction<Page<Message>>;
 
   constructor(
     private readonly genericValidator: GenericValidator,
@@ -25,9 +31,17 @@ export class MessageValidator implements IValidator<Message> {
       'https://safe-client.safe.global/schemas/messages/message.json',
       messageSchema,
     );
+    this.isValidPage = this.jsonSchemaValidator.getSchema(
+      'https://safe-client.safe.global/schemas/messages/message-page.json',
+      messagePageSchema,
+    );
   }
 
   validate(data: unknown): Message {
     return this.genericValidator.validate(this.isValidMessage, data);
+  }
+
+  validatePage(data: unknown): Page<Message> {
+    return this.genericValidator.validate(this.isValidPage, data);
   }
 }

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -36,8 +36,8 @@ export class MessagesRepository implements IMessagesRepository {
       limit,
       offset,
     );
-    page.results.map((message) => this.messageValidator.validate(message));
-    return page;
+
+    return this.messageValidator.validatePage(page);
   }
 
   async createMessage(

--- a/src/domain/safe/entities/schemas/module-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/module-transaction.schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'ajv';
+import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
 export const moduleTransactionSchema: Schema = {
   $id: 'https://safe-client.safe.global/schemas/safe/module-transaction.json',
@@ -38,3 +39,8 @@ export const moduleTransactionSchema: Schema = {
     'moduleTransactionId',
   ],
 };
+
+export const moduleTransactionPageSchema: Schema = buildPageSchema(
+  'https://safe-client.safe.global/schemas/safe/module-transaction-page.json',
+  moduleTransactionSchema,
+);

--- a/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'ajv';
+import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
 export const confirmationSchema: Schema = {
   $id: 'https://safe-client.safe.global/schemas/safe/confirmation.json',
@@ -83,3 +84,8 @@ export const multisigTransactionSchema: Schema = {
     'trusted',
   ],
 };
+
+export const multisigTransactionPageSchema: Schema = buildPageSchema(
+  'https://safe-client.safe.global/schemas/safe/multisig-transaction-page.json',
+  multisigTransactionSchema,
+);

--- a/src/domain/safe/entities/schemas/transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/transaction-type.schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'ajv';
+import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
 export const transactionTypeSchema: Schema = {
   $id: 'https://safe-client.safe.global/schemas/safe/transaction-type.json',
@@ -17,3 +18,8 @@ export const transactionTypeSchema: Schema = {
     },
   ],
 };
+
+export const transactionTypePageSchema: Schema = buildPageSchema(
+  'https://safe-client.safe.global/schemas/safe/transaction-type-page.json',
+  transactionTypeSchema,
+);

--- a/src/domain/safe/entities/schemas/transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/transfer.schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'ajv';
+import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
 export const transferSchema: Schema = {
   $id: 'https://safe-client.safe.global/schemas/safe/transfer.json',
@@ -24,3 +25,8 @@ export const transferSchema: Schema = {
     },
   ],
 };
+
+export const transferPageSchema: Schema = buildPageSchema(
+  'https://safe-client.safe.global/schemas/safe/transfer-page.json',
+  transferSchema,
+);

--- a/src/domain/safe/module-transaction.validator.ts
+++ b/src/domain/safe/module-transaction.validator.ts
@@ -6,15 +6,21 @@ import {
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
+import { Page } from '../entities/page.entity';
+import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { ModuleTransaction } from './entities/module-transaction.entity';
-import { moduleTransactionSchema } from './entities/schemas/module-transaction.schema';
+import {
+  moduleTransactionPageSchema,
+  moduleTransactionSchema,
+} from './entities/schemas/module-transaction.schema';
 
 @Injectable()
 export class ModuleTransactionValidator
-  implements IValidator<ModuleTransaction>
+  implements IValidator<ModuleTransaction>, IPageValidator<ModuleTransaction>
 {
   private readonly isValidModuleTransaction: ValidateFunction<ModuleTransaction>;
+  private readonly isValidPage: ValidateFunction<Page<ModuleTransaction>>;
 
   constructor(
     private readonly genericValidator: GenericValidator,
@@ -34,9 +40,18 @@ export class ModuleTransactionValidator
       'https://safe-client.safe.global/schemas/safe/module-transaction.json',
       moduleTransactionSchema,
     );
+
+    this.isValidPage = this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/safe/module-transaction-page.json',
+      moduleTransactionPageSchema,
+    );
   }
 
   validate(data: unknown): ModuleTransaction {
     return this.genericValidator.validate(this.isValidModuleTransaction, data);
+  }
+
+  validatePage(data: unknown): Page<ModuleTransaction> {
+    return this.genericValidator.validate(this.isValidPage, data);
   }
 }

--- a/src/domain/safe/multisig-transaction.validator.ts
+++ b/src/domain/safe/multisig-transaction.validator.ts
@@ -6,18 +6,24 @@ import {
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
+import { Page } from '../entities/page.entity';
+import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { MultisigTransaction } from './entities/multisig-transaction.entity';
 import {
   confirmationSchema,
+  multisigTransactionPageSchema,
   multisigTransactionSchema,
 } from './entities/schemas/multisig-transaction.schema';
 
 @Injectable()
 export class MultisigTransactionValidator
-  implements IValidator<MultisigTransaction>
+  implements
+    IValidator<MultisigTransaction>,
+    IPageValidator<MultisigTransaction>
 {
   private readonly isValidMultisigTransaction: ValidateFunction<MultisigTransaction>;
+  private readonly isValidPage: ValidateFunction<Page<MultisigTransaction>>;
 
   constructor(
     private readonly genericValidator: GenericValidator,
@@ -42,6 +48,11 @@ export class MultisigTransactionValidator
       'https://safe-client.safe.global/schemas/safe/multisig-transaction.json',
       multisigTransactionSchema,
     );
+
+    this.isValidPage = this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/safe/multisig-transaction-page.json',
+      multisigTransactionPageSchema,
+    );
   }
 
   validate(data: unknown): MultisigTransaction {
@@ -49,5 +60,9 @@ export class MultisigTransactionValidator
       this.isValidMultisigTransaction,
       data,
     );
+  }
+
+  validatePage(data: unknown): Page<MultisigTransaction> {
+    return this.genericValidator.validate(this.isValidPage, data);
   }
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -63,9 +63,7 @@ export class SafeRepository implements ISafeRepository {
       limit,
       offset,
     );
-    page.results.map((transfer) => this.transferValidator.validate(transfer));
-
-    return page;
+    return this.transferValidator.validatePage(page);
   }
 
   async clearCollectibleTransfers(
@@ -101,9 +99,7 @@ export class SafeRepository implements ISafeRepository {
       limit,
       offset,
     );
-    page.results.map((transfer) => this.transferValidator.validate(transfer));
-
-    return page;
+    return this.transferValidator.validatePage(page);
   }
 
   async clearIncomingTransfers(
@@ -159,11 +155,7 @@ export class SafeRepository implements ISafeRepository {
       limit,
       offset,
     );
-    page.results.map((moduleTransaction) =>
-      this.moduleTransactionValidator.validate(moduleTransaction),
-    );
-
-    return page;
+    return this.moduleTransactionValidator.validatePage(page);
   }
 
   async clearModuleTransactions(
@@ -224,12 +216,7 @@ export class SafeRepository implements ISafeRepository {
         limit,
         offset,
       );
-
-    page.results.map((multisigTransaction) =>
-      this.multisigTransactionValidator.validate(multisigTransaction),
-    );
-
-    return page;
+    return this.multisigTransactionValidator.validatePage(page);
   }
 
   async getCreationTransaction(
@@ -291,12 +278,7 @@ export class SafeRepository implements ISafeRepository {
       limit,
       offset,
     );
-
-    page.results.map((transaction) =>
-      this.transactionTypeValidator.validate(transaction),
-    );
-
-    return page;
+    return this.transactionTypeValidator.validatePage(page);
   }
 
   async clearAllExecutedTransactions(
@@ -370,11 +352,7 @@ export class SafeRepository implements ISafeRepository {
       offset,
     );
 
-    page.results.map((multiSigTransaction) =>
-      this.multisigTransactionValidator.validate(multiSigTransaction),
-    );
-
-    return page;
+    return this.multisigTransactionValidator.validatePage(page);
   }
 
   async getTransfer(chainId: string, transferId: string): Promise<Transfer> {

--- a/src/domain/safe/transaction-type.validator.ts
+++ b/src/domain/safe/transaction-type.validator.ts
@@ -6,6 +6,8 @@ import {
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
+import { Page } from '../entities/page.entity';
+import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { erc20TransferSchema } from './entities/schemas/erc20-transfer.schema';
 import { erc721TransferSchema } from './entities/schemas/erc721-transfer.schema';
@@ -13,13 +15,19 @@ import { ethereumTransactionTypeSchema } from './entities/schemas/ethereum-trans
 import { moduleTransactionTypeSchema } from './entities/schemas/module-transaction-type.schema';
 import { multisigTransactionTypeSchema } from './entities/schemas/multisig-transaction-type.schema';
 import { nativeTokenTransferSchema } from './entities/schemas/native-token-transfer.schema';
-import { transactionTypeSchema } from './entities/schemas/transaction-type.schema';
+import {
+  transactionTypePageSchema,
+  transactionTypeSchema,
+} from './entities/schemas/transaction-type.schema';
 import { transferSchema } from './entities/schemas/transfer.schema';
 import { Transaction } from './entities/transaction.entity';
 
 @Injectable()
-export class TransactionTypeValidator implements IValidator<Transaction> {
+export class TransactionTypeValidator
+  implements IValidator<Transaction>, IPageValidator<Transaction>
+{
   private readonly isValidTransactionType: ValidateFunction<Transaction>;
+  private readonly isValidPage: ValidateFunction<Page<Transaction>>;
 
   constructor(
     private readonly genericValidator: GenericValidator,
@@ -74,9 +82,18 @@ export class TransactionTypeValidator implements IValidator<Transaction> {
       'https://safe-client.safe.global/schemas/safe/transaction-type.json',
       transactionTypeSchema,
     );
+
+    this.isValidPage = this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/safe/transaction-type-page.json',
+      transactionTypePageSchema,
+    );
   }
 
   validate(data: unknown): Transaction {
     return this.genericValidator.validate(this.isValidTransactionType, data);
+  }
+
+  validatePage(data: unknown): Page<Transaction> {
+    return this.genericValidator.validate(this.isValidPage, data);
   }
 }

--- a/src/domain/safe/transfer.validator.ts
+++ b/src/domain/safe/transfer.validator.ts
@@ -2,16 +2,24 @@ import { Injectable } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
+import { Page } from '../entities/page.entity';
+import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { erc20TransferSchema } from './entities/schemas/erc20-transfer.schema';
 import { erc721TransferSchema } from './entities/schemas/erc721-transfer.schema';
 import { nativeTokenTransferSchema } from './entities/schemas/native-token-transfer.schema';
-import { transferSchema } from './entities/schemas/transfer.schema';
+import {
+  transferPageSchema,
+  transferSchema,
+} from './entities/schemas/transfer.schema';
 import { Transfer } from './entities/transfer.entity';
 
 @Injectable()
-export class TransferValidator implements IValidator<Transfer> {
+export class TransferValidator
+  implements IValidator<Transfer>, IPageValidator<Transfer>
+{
   private readonly isValidTransfer: ValidateFunction<Transfer>;
+  private readonly isValidPage: ValidateFunction<Page<Transfer>>;
 
   constructor(
     private readonly genericValidator: GenericValidator,
@@ -21,21 +29,33 @@ export class TransferValidator implements IValidator<Transfer> {
       'https://safe-client.safe.global/schemas/safe/native-token-transfer.json',
       nativeTokenTransferSchema,
     );
+
     this.jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/safe/erc20-transfer.json',
       erc20TransferSchema,
     );
+
     this.jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/safe/erc721-transfer.json',
       erc721TransferSchema,
     );
+
     this.isValidTransfer = this.jsonSchemaService.getSchema(
       'https://safe-client.safe.global/schemas/safe/transfer.json',
       transferSchema,
+    );
+
+    this.isValidPage = this.jsonSchemaService.getSchema(
+      'https://safe-client.safe.global/schemas/safe/transfer-page.json',
+      transferPageSchema,
     );
   }
 
   validate(data: unknown): Transfer {
     return this.genericValidator.validate(this.isValidTransfer, data);
+  }
+
+  validatePage(data: unknown): Page<Transfer> {
+    return this.genericValidator.validate(this.isValidPage, data);
   }
 }

--- a/src/domain/tokens/entities/schemas/token.schema.ts
+++ b/src/domain/tokens/entities/schemas/token.schema.ts
@@ -1,4 +1,5 @@
-import { JSONSchemaType } from 'ajv';
+import { JSONSchemaType, Schema } from 'ajv';
+import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 import { Token, TokenType } from '../token.entity';
 
 export const tokenSchema: JSONSchemaType<Token> = {
@@ -14,3 +15,8 @@ export const tokenSchema: JSONSchemaType<Token> = {
   },
   required: ['address', 'decimals', 'logoUri', 'name', 'symbol', 'type'],
 };
+
+export const tokenPageSchema: Schema = buildPageSchema(
+  'https://safe-client.safe.global/schemas/tokens/token-page.json',
+  tokenSchema,
+);

--- a/src/domain/tokens/token.repository.ts
+++ b/src/domain/tokens/token.repository.ts
@@ -29,8 +29,6 @@ export class TokenRepository implements ITokenRepository {
       await this.transactionApiManager.getTransactionApi(chainId);
     const page = await transactionService.getTokens(limit, offset);
 
-    page.results.map((token) => this.tokenValidator.validate(token));
-
-    return page;
+    return this.tokenValidator.validatePage(page);
   }
 }

--- a/src/domain/tokens/token.validator.ts
+++ b/src/domain/tokens/token.validator.ts
@@ -2,13 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
+import { Page } from '../entities/page.entity';
+import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
-import { tokenSchema } from './entities/schemas/token.schema';
+import { tokenPageSchema, tokenSchema } from './entities/schemas/token.schema';
 import { Token } from './entities/token.entity';
 
 @Injectable()
-export class TokenValidator implements IValidator<Token> {
+export class TokenValidator
+  implements IValidator<Token>, IPageValidator<Token>
+{
   private readonly isValidToken: ValidateFunction<Token>;
+  private readonly isValidPage: ValidateFunction<Page<Token>>;
 
   constructor(
     private readonly genericValidator: GenericValidator,
@@ -18,9 +23,17 @@ export class TokenValidator implements IValidator<Token> {
       'https://safe-client.safe.global/schemas/tokens/token.json',
       tokenSchema,
     );
+    this.isValidPage = this.jsonSchemaValidator.getSchema(
+      'https://safe-client.safe.global/schemas/tokens/token-page.json',
+      tokenPageSchema,
+    );
   }
 
   validate(data: unknown): Token {
     return this.genericValidator.validate(this.isValidToken, data);
+  }
+
+  validatePage(data: unknown): Page<Token> {
+    return this.genericValidator.validate(this.isValidPage, data);
   }
 }

--- a/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-incoming-transfers-by-safe.transactions.controller.spec.ts
@@ -140,6 +140,26 @@ describe('List incoming transfers by Safe - Transactions Controller (Unit)', () 
       });
   });
 
+  it('Failure: data page validation fails', async () => {
+    const chain = chainBuilder().build();
+    const safe = safeBuilder().build();
+    const page = pageBuilder().build();
+    networkService.get.mockResolvedValueOnce({ data: chain });
+    networkService.get.mockResolvedValueOnce({
+      data: { ...page, next: faker.datatype.boolean() },
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chain.chainId}/safes/${safe.address}/incoming-transfers/`,
+      )
+      .expect({
+        message: 'Validation failed',
+        code: 42,
+        arguments: [],
+      });
+  });
+
   it('Should get a ERC20 incoming transfer mapped to the expected format', async () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -139,6 +139,26 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       });
   });
 
+  it('Failure: data page validation fails', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+    const chainResponse = chainBuilder().with('chainId', chainId).build();
+    const page = pageBuilder().build();
+    networkService.get.mockResolvedValueOnce({ data: chainResponse });
+    networkService.get.mockResolvedValueOnce({
+      data: { ...page, count: null },
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/safes/${safeAddress}/multisig-transactions`)
+      .expect(500)
+      .expect({
+        message: 'Validation failed',
+        code: 42,
+        arguments: [],
+      });
+  });
+
   it('Should get a ERC20 transfer mapped to the expected format', async () => {
     const chain = chainBuilder().build();
     const safe = safeBuilder().build();


### PR DESCRIPTION
Closes #71 

This PR aims to implement `Page` entity validation for use in several endpoints. Currently, the application is not validating the metadata (`count`, `previous`, `next`) coming from external data sources when requesting a page of data items. So this PR:

- Creates an `IPageValidator` interface, which can be optionally implemented by each validator.
- This `IPageValidator` contains one function only, `validatePage`, which will be responsible for validating the metadata and returning a `Page<T>`, being `T` the content (`results`) of the `Page`.
- Removes validation by loops (`page.results.map(item => validator.validate(item))`) in favor of validating all the items at once, which should increase the performance.
- Adds unit tests validating malformed `Page` objects would trigger validation errors.