### PR TITLE
Invalidate safe apps cache

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -346,6 +346,10 @@ export class CacheRouter {
     );
   }
 
+  static getSafeAppsCachePattern(): string {
+    return `*_${CacheRouter.SAFE_APPS_KEY}$`;
+  }
+
   static getExchangeFiatCodesCacheDir(): CacheDir {
     return new CacheDir(CacheRouter.EXCHANGE_FIAT_CODES_KEY, '');
   }

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -173,4 +173,12 @@ describe('ConfigApi', () => {
     expect(mockCacheService.deleteByKey).toBeCalledTimes(1);
     expect(mockCacheService.deleteByKeyPattern).toBeCalledTimes(1);
   });
+
+  it('clear safe apps should trigger delete on cache service', async () => {
+    await service.clearSafeApps();
+
+    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_safe_apps$');
+    expect(mockCacheService.deleteByKeyPattern).toBeCalledTimes(1);
+    expect(mockCacheService.deleteByKey).toBeCalledTimes(0);
+  });
 });

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -90,4 +90,9 @@ export class ConfigApi implements IConfigApi {
       throw this.httpErrorFactory.from(error);
     }
   }
+
+  async clearSafeApps(): Promise<void> {
+    const pattern = CacheRouter.getSafeAppsCachePattern();
+    await this.cacheService.deleteByKeyPattern(pattern);
+  }
 }

--- a/src/domain/flush/flush.repository.ts
+++ b/src/domain/flush/flush.repository.ts
@@ -18,7 +18,11 @@ export class FlushRepository implements IFlushRepository {
   async execute(pattern: InvalidationPatternDto): Promise<void> {
     switch (pattern.invalidate) {
       case InvalidationTarget[InvalidationTarget.Chains]:
-        return this.configApi.clearChains();
+        await Promise.allSettled([
+          this.configApi.clearChains(),
+          this.configApi.clearSafeApps(),
+        ]);
+        break;
       default:
         this.loggingService.debug(
           `Unknown flush pattern ${pattern.invalidate}`,

--- a/src/domain/flush/flush.repository.ts
+++ b/src/domain/flush/flush.repository.ts
@@ -18,7 +18,7 @@ export class FlushRepository implements IFlushRepository {
   async execute(pattern: InvalidationPatternDto): Promise<void> {
     switch (pattern.invalidate) {
       case InvalidationTarget[InvalidationTarget.Chains]:
-        await Promise.allSettled([
+        await Promise.all([
           this.configApi.clearChains(),
           this.configApi.clearSafeApps(),
         ]);

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -6,11 +6,16 @@ export const IConfigApi = Symbol('IConfigApi');
 
 export interface IConfigApi {
   getChains(limit?: number, offset?: number): Promise<Page<Chain>>;
+
   clearChains(): Promise<void>;
+
   getChain(chainId: string): Promise<Chain>;
+
   getSafeApps(
     chainId?: string,
     clientUrl?: string,
     url?: string,
   ): Promise<SafeApp[]>;
+
+  clearSafeApps(): Promise<void>;
 }


### PR DESCRIPTION
Invalidates the Safe Apps cache on a `Chains` invalidation hook event.