### PR TITLE
Use warn level for unknown flush patterns

### DIFF
--- a/src/domain/flush/flush.repository.ts
+++ b/src/domain/flush/flush.repository.ts
@@ -24,9 +24,7 @@ export class FlushRepository implements IFlushRepository {
         ]);
         break;
       default:
-        this.loggingService.debug(
-          `Unknown flush pattern ${pattern.invalidate}`,
-        );
+        this.loggingService.warn(`Unknown flush pattern ${pattern.invalidate}`);
     }
   }
 }


### PR DESCRIPTION
Logs with `warn` level instead of `debug` when the flush pattern provided was not recognized. Since this is mostly an admin endpoint, triggering the endpoint with the wrong pattern should have a higher log level.