### PR TITLE
Fix bad scale for timezoneOffset query param

### DIFF
--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -143,11 +143,11 @@ export class TransactionsHistoryMapper {
    * Returns a day {@link Date } at 00:00:00 from the input timestamp.
    *
    * @param timestamp - date to convert
-   * @param timezoneOffset - Offset of time zone in seconds
+   * @param timezoneOffset - Offset of time zone in milliseconds
    */
   private getDayStartForDate(timestamp: Date, timezoneOffset: number): Date {
     if (timezoneOffset != 0) {
-      timestamp.setUTCSeconds(timezoneOffset);
+      timestamp.setUTCSeconds(timezoneOffset / 1000);
     }
     return new Date(
       Date.UTC(

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -287,7 +287,7 @@ describe('Transactions History Controller (Unit)', () => {
 
   it('Should change date label with time offset', async () => {
     const safeAddress = faker.finance.ethereumAddress();
-    const timezoneOffset = 3600 * 2; //Offset of 2 hours
+    const timezoneOffset = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
     const chainResponse = chainBuilder().build();
     const chainId = chainResponse.chainId;
     const moduleTransaction = moduleTransactionToJson(


### PR DESCRIPTION
Closes #547 

This PR:
- Fixes the expected scale for the `timezoneOffset` query param. The clients are sending this value in milliseconds, but the service was expecting to have it in seconds. 
