### PR TITLE
refactor: move schema ids to constants

### DIFF
--- a/src/domain/backbone/backbone.validator.ts
+++ b/src/domain/backbone/backbone.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { Backbone } from './entities/backbone.entity';
-import { backboneSchema } from './entities/schemas/backbone.schema';
+import {
+  BACKBONE_SCHEMA_ID,
+  backboneSchema,
+} from './entities/schemas/backbone.schema';
 
 @Injectable()
 export class BackboneValidator implements IValidator<Backbone> {
@@ -15,7 +18,7 @@ export class BackboneValidator implements IValidator<Backbone> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidBackbone = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/backbone/backbone.json',
+      BACKBONE_SCHEMA_ID,
       backboneSchema,
     );
   }

--- a/src/domain/backbone/entities/schemas/backbone.schema.ts
+++ b/src/domain/backbone/entities/schemas/backbone.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { Backbone } from '../backbone.entity';
 
+export const BACKBONE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/backbone/backbone.json';
+
 export const backboneSchema: JSONSchemaType<Backbone> = {
-  $id: 'https://safe-client.safe.global/schemas/backbone/backbone.json',
+  $id: BACKBONE_SCHEMA_ID,
   type: 'object',
   properties: {
     name: { type: 'string' },

--- a/src/domain/balances/balances.validator.ts
+++ b/src/domain/balances/balances.validator.ts
@@ -5,6 +5,8 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { IValidator } from '../interfaces/validator.interface';
 import { Balance } from './entities/balance.entity';
 import {
+  BALANCE_SCHEMA_ID,
+  BALANCE_TOKEN_SCHEMA_ID,
   balanceSchema,
   balanceTokenSchema,
 } from './entities/schemas/balance.schema';
@@ -18,12 +20,12 @@ export class BalancesValidator implements IValidator<Balance> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/balances/balance-token.json',
+      BALANCE_TOKEN_SCHEMA_ID,
       balanceTokenSchema,
     );
 
     this.isValidBalance = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/balances/balance.json',
+      BALANCE_SCHEMA_ID,
       balanceSchema,
     );
   }

--- a/src/domain/balances/entities/schemas/balance.schema.ts
+++ b/src/domain/balances/entities/schemas/balance.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType, Schema } from 'ajv';
 import { BalanceToken } from '../balance.token.entity';
 
+export const BALANCE_TOKEN_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/balances/balance-token.json';
+
 const balanceTokenSchema: JSONSchemaType<BalanceToken> = {
-  $id: 'https://safe-client.safe.global/schemas/balances/balance-token.json',
+  $id: BALANCE_TOKEN_SCHEMA_ID,
   type: 'object',
   properties: {
     name: { type: 'string' },
@@ -13,8 +16,11 @@ const balanceTokenSchema: JSONSchemaType<BalanceToken> = {
   required: ['name', 'symbol', 'decimals', 'logoUri'],
 };
 
+export const BALANCE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/balances/balance.json';
+
 const balanceSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/balances/balance.json',
+  $id: BALANCE_SCHEMA_ID,
   type: 'object',
   properties: {
     tokenAddress: { type: 'string', nullable: true, default: null },

--- a/src/domain/chains/chains.validator.ts
+++ b/src/domain/chains/chains.validator.ts
@@ -5,6 +5,12 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { IValidator } from '../interfaces/validator.interface';
 import { Chain } from './entities/chain.entity';
 import {
+  BLOCK_EXPLORER_URI_TEMPLATE_SCHEMA_ID,
+  CHAIN_SCHEMA_ID,
+  GAS_PRICE_SCHEMA_ID,
+  NATIVE_CURRENCY_SCHEMA_ID,
+  RPC_URI_SCHEMA_ID,
+  THEME_SCHEMA_ID,
   blockExplorerUriTemplateSchema,
   chainSchema,
   gasPriceSchema,
@@ -22,32 +28,23 @@ export class ChainsValidator implements IValidator<Chain> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/native-currency.json',
+      NATIVE_CURRENCY_SCHEMA_ID,
       nativeCurrencySchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/rpc-uri.json',
-      rpcUriSchema,
-    );
+    this.jsonSchemaService.getSchema(RPC_URI_SCHEMA_ID, rpcUriSchema);
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/block-explorer-uri-template.json',
+      BLOCK_EXPLORER_URI_TEMPLATE_SCHEMA_ID,
       blockExplorerUriTemplateSchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/theme.json',
-      themeSchema,
-    );
+    this.jsonSchemaService.getSchema(THEME_SCHEMA_ID, themeSchema);
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/gas-price.json',
-      gasPriceSchema,
-    );
+    this.jsonSchemaService.getSchema(GAS_PRICE_SCHEMA_ID, gasPriceSchema);
 
     this.isValidChain = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/chain.json',
+      CHAIN_SCHEMA_ID,
       chainSchema,
     );
   }

--- a/src/domain/chains/entities/schemas/chain.schema.ts
+++ b/src/domain/chains/entities/schemas/chain.schema.ts
@@ -8,8 +8,11 @@ import { Theme } from '../theme.entity';
 import { GasPriceOracle } from '../gas-price-oracle.entity';
 import { GasPriceFixed } from '../gas-price-fixed.entity';
 
+export const NATIVE_CURRENCY_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/native-currency.json';
+
 export const nativeCurrencySchema: JSONSchemaType<NativeCurrency> = {
-  $id: 'https://safe-client.safe.global/schemas/chains/native-currency.json',
+  $id: NATIVE_CURRENCY_SCHEMA_ID,
   type: 'object',
   properties: {
     name: { type: 'string' },
@@ -20,8 +23,11 @@ export const nativeCurrencySchema: JSONSchemaType<NativeCurrency> = {
   required: ['name', 'symbol', 'decimals', 'logoUri'],
 };
 
+export const RPC_URI_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/rpc-uri.json';
+
 export const rpcUriSchema: JSONSchemaType<RpcUri> = {
-  $id: 'https://safe-client.safe.global/schemas/chains/rpc-uri.json',
+  $id: RPC_URI_SCHEMA_ID,
   type: 'object',
   properties: {
     authentication: {
@@ -34,9 +40,12 @@ export const rpcUriSchema: JSONSchemaType<RpcUri> = {
   required: ['authentication', 'value'],
 };
 
+export const BLOCK_EXPLORER_URI_TEMPLATE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/block-explorer-uri-template.json';
+
 export const blockExplorerUriTemplateSchema: JSONSchemaType<BlockExplorerUriTemplate> =
   {
-    $id: 'https://safe-client.safe.global/schemas/chains/block-explorer-uri-template.json',
+    $id: BLOCK_EXPLORER_URI_TEMPLATE_SCHEMA_ID,
     type: 'object',
     properties: {
       address: { type: 'string' },
@@ -46,8 +55,11 @@ export const blockExplorerUriTemplateSchema: JSONSchemaType<BlockExplorerUriTemp
     required: ['address', 'txHash', 'api'],
   };
 
+export const THEME_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/theme.json';
+
 export const themeSchema: JSONSchemaType<Theme> = {
-  $id: 'https://safe-client.safe.global/schemas/chains/theme.json',
+  $id: THEME_SCHEMA_ID,
   type: 'object',
   properties: {
     textColor: { type: 'string' },
@@ -56,10 +68,13 @@ export const themeSchema: JSONSchemaType<Theme> = {
   required: ['textColor', 'backgroundColor'],
 };
 
+export const GAS_PRICE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/gas-price.json';
+
 export const gasPriceSchema: JSONSchemaType<
   Array<GasPriceOracle | GasPriceFixed>
 > = {
-  $id: 'https://safe-client.safe.global/schemas/chains/gas-price.json',
+  $id: GAS_PRICE_SCHEMA_ID,
   type: 'array',
   items: {
     anyOf: [
@@ -85,9 +100,12 @@ export const gasPriceSchema: JSONSchemaType<
   },
 };
 
+export const CHAIN_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/chain.json';
+
 export const chainSchema: JSONSchemaType<Chain> = {
   type: 'object',
-  $id: 'https://safe-client.safe.global/schemas/chains/chain.json',
+  $id: CHAIN_SCHEMA_ID,
   properties: {
     chainId: { type: 'string' },
     chainName: { type: 'string' },

--- a/src/domain/chains/entities/schemas/master-copy.schema.ts
+++ b/src/domain/chains/entities/schemas/master-copy.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { MasterCopy } from '../master-copies.entity';
 
+export const MASTER_COPY_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/chains/master-copy.json';
+
 export const masterCopySchema: JSONSchemaType<MasterCopy> = {
-  $id: 'https://safe-client.safe.global/schemas/chains/master-copy.json',
+  $id: MASTER_COPY_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/domain/chains/master-copy.validator.ts
+++ b/src/domain/chains/master-copy.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { MasterCopy } from './entities/master-copies.entity';
-import { masterCopySchema } from './entities/schemas/master-copy.schema';
+import {
+  MASTER_COPY_SCHEMA_ID,
+  masterCopySchema,
+} from './entities/schemas/master-copy.schema';
 
 @Injectable()
 export class MasterCopyValidator implements IValidator<MasterCopy> {
@@ -15,7 +18,7 @@ export class MasterCopyValidator implements IValidator<MasterCopy> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidMasterCopy = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/chains/master-copy.json',
+      MASTER_COPY_SCHEMA_ID,
       masterCopySchema,
     );
   }

--- a/src/domain/collectibles/collectibles.validator.ts
+++ b/src/domain/collectibles/collectibles.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { Collectible } from './entities/collectible.entity';
-import { collectibleSchema } from './entities/schemas/collectible.schema';
+import {
+  COLLECTIBLE_SCHEMA_ID,
+  collectibleSchema,
+} from './entities/schemas/collectible.schema';
 
 @Injectable()
 export class CollectiblesValidator implements IValidator<Collectible> {
@@ -15,7 +18,7 @@ export class CollectiblesValidator implements IValidator<Collectible> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidCollectible = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/collectibles/collectible.json',
+      COLLECTIBLE_SCHEMA_ID,
       collectibleSchema,
     );
   }

--- a/src/domain/collectibles/entities/schemas/collectible.schema.ts
+++ b/src/domain/collectibles/entities/schemas/collectible.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { Collectible } from '../collectible.entity';
 
+export const COLLECTIBLE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/collectibles/collectible.json';
+
 export const collectibleSchema: JSONSchemaType<Collectible> = {
-  $id: 'https://safe-client.safe.global/schemas/collectibles/collectible.json',
+  $id: COLLECTIBLE_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/domain/contracts/contracts.validator.ts
+++ b/src/domain/contracts/contracts.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { Contract } from './entities/contract.entity';
-import { contractSchema } from './entities/schemas/contract.schema';
+import {
+  CONTRACT_SCHEMA_ID,
+  contractSchema,
+} from './entities/schemas/contract.schema';
 
 @Injectable()
 export class ContractsValidator implements IValidator<Contract> {
@@ -15,7 +18,7 @@ export class ContractsValidator implements IValidator<Contract> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidContract = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/contracts/contract.json',
+      CONTRACT_SCHEMA_ID,
       contractSchema,
     );
   }

--- a/src/domain/contracts/entities/schemas/contract.schema.ts
+++ b/src/domain/contracts/entities/schemas/contract.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const CONTRACT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/contracts/contract.json';
+
 export const contractSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/contracts/contract.json',
+  $id: CONTRACT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/domain/data-decoder/data-decoded.validator.ts
+++ b/src/domain/data-decoder/data-decoded.validator.ts
@@ -5,6 +5,8 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { IValidator } from '../interfaces/validator.interface';
 import { DataDecoded } from './entities/data-decoded.entity';
 import {
+  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from './entities/schemas/data-decoded.schema';
@@ -18,11 +20,11 @@ export class DataDecodedValidator implements IValidator<DataDecoded> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json',
+      DATA_DECODED_PARAMTER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
     this.isValidDataDecoded = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json',
+      DATA_DECODED_SCHEMA_ID,
       dataDecodedSchema,
     );
   }

--- a/src/domain/data-decoder/data-decoded.validator.ts
+++ b/src/domain/data-decoder/data-decoded.validator.ts
@@ -5,7 +5,7 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { IValidator } from '../interfaces/validator.interface';
 import { DataDecoded } from './entities/data-decoded.entity';
 import {
-  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_PARAMETER_SCHEMA_ID,
   DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
@@ -20,7 +20,7 @@ export class DataDecodedValidator implements IValidator<DataDecoded> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      DATA_DECODED_PARAMTER_SCHEMA_ID,
+      DATA_DECODED_PARAMETER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
     this.isValidDataDecoded = this.jsonSchemaService.getSchema(

--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -1,10 +1,10 @@
 import { Schema } from 'ajv';
 
-export const DATA_DECODED_PARAMTER_SCHEMA_ID =
+export const DATA_DECODED_PARAMETER_SCHEMA_ID =
   'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json';
 
 export const dataDecodedParameterSchema: Schema = {
-  $id: DATA_DECODED_PARAMTER_SCHEMA_ID,
+  $id: DATA_DECODED_PARAMETER_SCHEMA_ID,
   type: 'object',
   properties: {
     name: { type: 'string' },

--- a/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
+++ b/src/domain/data-decoder/entities/schemas/data-decoded.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const DATA_DECODED_PARAMTER_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json';
+
 export const dataDecodedParameterSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json',
+  $id: DATA_DECODED_PARAMTER_SCHEMA_ID,
   type: 'object',
   properties: {
     name: { type: 'string' },
@@ -13,8 +16,11 @@ export const dataDecodedParameterSchema: Schema = {
   required: ['name', 'type', 'value'],
 };
 
+export const DATA_DECODED_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json';
+
 export const dataDecodedSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json',
+  $id: DATA_DECODED_SCHEMA_ID,
   type: 'object',
   properties: {
     method: { type: 'string' },

--- a/src/domain/delegate/delegate.validator.ts
+++ b/src/domain/delegate/delegate.validator.ts
@@ -4,7 +4,10 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { ValidationErrorFactory } from '../../validation/providers/validation-error-factory';
 import { IValidator } from '../interfaces/validator.interface';
 import { Delegate } from './entities/delegate.entity';
-import { delegateSchema } from './entities/schemas/delegate.schema';
+import {
+  DELEGATE_SCHEMA_ID,
+  delegateSchema,
+} from './entities/schemas/delegate.schema';
 
 @Injectable()
 export class DelegateValidator implements IValidator<Delegate> {
@@ -15,7 +18,7 @@ export class DelegateValidator implements IValidator<Delegate> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidDelegate = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/delegate.json',
+      DELEGATE_SCHEMA_ID,
       delegateSchema,
     );
   }

--- a/src/domain/delegate/entities/schemas/delegate.schema.ts
+++ b/src/domain/delegate/entities/schemas/delegate.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { Delegate } from '../delegate.entity';
 
+export const DELEGATE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/delegates/delegate.json';
+
 export const delegateSchema: JSONSchemaType<Delegate> = {
-  $id: 'https://safe-client.safe.global/schemas/delegates/delegate.json',
+  $id: DELEGATE_SCHEMA_ID,
   type: 'object',
   properties: {
     safe: {

--- a/src/domain/estimations/entities/schemas/estimation.schema.ts
+++ b/src/domain/estimations/entities/schemas/estimation.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { Estimation } from '../estimation.entity';
 
+export const ESTIMATION_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/estimations/estimation.json';
+
 export const estimationSchema: JSONSchemaType<Estimation> = {
-  $id: 'https://safe-client.safe.global/schemas/estimations/estimation.json',
+  $id: ESTIMATION_SCHEMA_ID,
   type: 'object',
   properties: {
     safeTxGas: { type: 'string' },

--- a/src/domain/estimations/estimations.validator.ts
+++ b/src/domain/estimations/estimations.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { Estimation } from './entities/estimation.entity';
-import { estimationSchema } from './entities/schemas/estimation.schema';
+import {
+  ESTIMATION_SCHEMA_ID,
+  estimationSchema,
+} from './entities/schemas/estimation.schema';
 
 @Injectable()
 export class EstimationsValidator implements IValidator<Estimation> {
@@ -15,7 +18,7 @@ export class EstimationsValidator implements IValidator<Estimation> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidEstimation = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/estimations/estimation.json',
+      ESTIMATION_SCHEMA_ID,
       estimationSchema,
     );
   }

--- a/src/domain/exchange/entities/schemas/exchange-fiat-codes.schema.ts
+++ b/src/domain/exchange/entities/schemas/exchange-fiat-codes.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { ExchangeFiatCodes } from '../exchange-fiat-codes.entity';
 
+export const EXCHANGE_FIAT_CODES_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/exchange/exchange-fiat-codes.json';
+
 export const exchangeFiatCodesSchema: JSONSchemaType<ExchangeFiatCodes> = {
-  $id: 'https://safe-client.safe.global/schemas/exchange/exchange-fiat-codes.json',
+  $id: EXCHANGE_FIAT_CODES_SCHEMA_ID,
   type: 'object',
   properties: {
     success: { type: 'boolean' },

--- a/src/domain/exchange/entities/schemas/exchange-rates.schema.ts
+++ b/src/domain/exchange/entities/schemas/exchange-rates.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { ExchangeRates } from '../exchange-rates.entity';
 
+export const EXCHANGE_RATES_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/exchange/exchange-rates.json';
+
 export const exchangeRatesSchema: JSONSchemaType<ExchangeRates> = {
-  $id: 'https://safe-client.safe.global/schemas/exchange/exchange-rates.json',
+  $id: EXCHANGE_RATES_SCHEMA_ID,
   type: 'object',
   properties: {
     success: { type: 'boolean' },

--- a/src/domain/exchange/exchange-fiat-codes.validator.ts
+++ b/src/domain/exchange/exchange-fiat-codes.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { ExchangeFiatCodes } from './entities/exchange-fiat-codes.entity';
-import { exchangeFiatCodesSchema } from './entities/schemas/exchange-fiat-codes.schema';
+import {
+  EXCHANGE_FIAT_CODES_SCHEMA_ID,
+  exchangeFiatCodesSchema,
+} from './entities/schemas/exchange-fiat-codes.schema';
 
 @Injectable()
 export class ExchangeFiatCodesValidator
@@ -17,7 +20,7 @@ export class ExchangeFiatCodesValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidExchangeFiatCodes = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/exchange/exchange-fiat-codes.json',
+      EXCHANGE_FIAT_CODES_SCHEMA_ID,
       exchangeFiatCodesSchema,
     );
   }

--- a/src/domain/exchange/exchange-rates.validator.ts
+++ b/src/domain/exchange/exchange-rates.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { ExchangeRates } from './entities/exchange-rates.entity';
-import { exchangeRatesSchema } from './entities/schemas/exchange-rates.schema';
+import {
+  EXCHANGE_RATES_SCHEMA_ID,
+  exchangeRatesSchema,
+} from './entities/schemas/exchange-rates.schema';
 
 @Injectable()
 export class ExchangeRatesValidator implements IValidator<ExchangeRates> {
@@ -15,7 +18,7 @@ export class ExchangeRatesValidator implements IValidator<ExchangeRates> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidExchangeRates = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/exchange/exchange-rates.json',
+      EXCHANGE_RATES_SCHEMA_ID,
       exchangeRatesSchema,
     );
   }

--- a/src/domain/messages/entities/schemas/message.schema.ts
+++ b/src/domain/messages/entities/schemas/message.schema.ts
@@ -1,8 +1,11 @@
 import { Schema } from 'ajv';
 import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
+export const MESSAGE_CONFIRMATION_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/messages/message-confirmation.json';
+
 export const messageConfirmationSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/messages/message-confirmation.json',
+  $id: MESSAGE_CONFIRMATION_SCHEMA_ID,
   type: 'object',
   properties: {
     created: { type: 'string', isDate: true },
@@ -14,8 +17,11 @@ export const messageConfirmationSchema: Schema = {
   required: ['created', 'modified', 'owner', 'signature', 'signatureType'],
 };
 
+export const MESSAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/messages/message.json';
+
 export const messageSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/messages/message.json',
+  $id: MESSAGE_SCHEMA_ID,
   type: 'object',
   properties: {
     created: { type: 'string', isDate: true },
@@ -42,7 +48,10 @@ export const messageSchema: Schema = {
   ],
 };
 
+export const MESSAGE_PAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/messages/message-page.json';
+
 export const messagePageSchema: Schema = buildPageSchema(
-  'https://safe-client.safe.global/schemas/messages/message-page.json',
+  MESSAGE_PAGE_SCHEMA_ID,
   messageSchema,
 );

--- a/src/domain/messages/message.validator.ts
+++ b/src/domain/messages/message.validator.ts
@@ -7,6 +7,9 @@ import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { Message } from './entities/message.entity';
 import {
+  MESSAGE_CONFIRMATION_SCHEMA_ID,
+  MESSAGE_PAGE_SCHEMA_ID,
+  MESSAGE_SCHEMA_ID,
   messageConfirmationSchema,
   messagePageSchema,
   messageSchema,
@@ -24,15 +27,15 @@ export class MessageValidator
     private readonly jsonSchemaValidator: JsonSchemaService,
   ) {
     this.jsonSchemaValidator.getSchema(
-      'https://safe-client.safe.global/schemas/messages/message-confirmation.json',
+      MESSAGE_CONFIRMATION_SCHEMA_ID,
       messageConfirmationSchema,
     );
     this.isValidMessage = this.jsonSchemaValidator.getSchema(
-      'https://safe-client.safe.global/schemas/messages/message.json',
+      MESSAGE_SCHEMA_ID,
       messageSchema,
     );
     this.isValidPage = this.jsonSchemaValidator.getSchema(
-      'https://safe-client.safe.global/schemas/messages/message-page.json',
+      MESSAGE_PAGE_SCHEMA_ID,
       messagePageSchema,
     );
   }

--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -6,8 +6,11 @@ import {
 import { SafeAppProvider } from '../safe-app-provider.entity';
 import { SafeAppSocialProfile } from '../safe-app-social-profile.entity';
 
+export const SAFE_APP_PROVIDER_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe-apps/safe-app-provider.json';
+
 export const safeAppProviderSchema: JSONSchemaType<SafeAppProvider> = {
-  $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app-provider.json',
+  $id: SAFE_APP_PROVIDER_SCHEMA_ID,
   type: 'object',
   properties: {
     url: { type: 'string' },
@@ -16,9 +19,12 @@ export const safeAppProviderSchema: JSONSchemaType<SafeAppProvider> = {
   required: ['url', 'name'],
 };
 
+export const SAFE_APP_ACCESS_CONTROL_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe-apps/safe-app-access-control.json';
+
 export const safeAppAccessControlSchema: JSONSchemaType<SafeAppAccessControl> =
   {
-    $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app-access-control.json',
+    $id: SAFE_APP_ACCESS_CONTROL_SCHEMA_ID,
     type: 'object',
     anyOf: [
       {
@@ -47,9 +53,12 @@ export const safeAppAccessControlSchema: JSONSchemaType<SafeAppAccessControl> =
     required: ['type'],
   };
 
+export const SAFE_APP_SOCIAL_PROFILE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe-apps/safe-app-social-profile.json';
+
 export const safeAppSocialProfileSchema: JSONSchemaType<SafeAppSocialProfile> =
   {
-    $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app-social-profile.json',
+    $id: SAFE_APP_SOCIAL_PROFILE_SCHEMA_ID,
     type: 'object',
     properties: {
       platform: { type: 'string' },
@@ -58,8 +67,11 @@ export const safeAppSocialProfileSchema: JSONSchemaType<SafeAppSocialProfile> =
     required: ['platform', 'url'],
   };
 
+export const SAFE_APP_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe-apps/safe-app.json';
+
 export const safeAppSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe-apps/safe-app.json',
+  $id: SAFE_APP_SCHEMA_ID,
   type: 'object',
   properties: {
     id: { type: 'number' },

--- a/src/domain/safe-apps/safe-apps.validator.ts
+++ b/src/domain/safe-apps/safe-apps.validator.ts
@@ -5,6 +5,10 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { IValidator } from '../interfaces/validator.interface';
 import { SafeApp } from './entities/safe-app.entity';
 import {
+  SAFE_APP_SCHEMA_ID,
+  SAFE_APP_ACCESS_CONTROL_SCHEMA_ID,
+  SAFE_APP_PROVIDER_SCHEMA_ID,
+  SAFE_APP_SOCIAL_PROFILE_SCHEMA_ID,
   safeAppAccessControlSchema,
   safeAppProviderSchema,
   safeAppSchema,
@@ -20,22 +24,22 @@ export class SafeAppsValidator implements IValidator<SafeApp> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe-apps/safe-app-provider.json',
+      SAFE_APP_PROVIDER_SCHEMA_ID,
       safeAppProviderSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe-apps/safe-app-access-control.json',
+      SAFE_APP_ACCESS_CONTROL_SCHEMA_ID,
       safeAppAccessControlSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe-apps/safe-app-social-profile.json',
+      SAFE_APP_SOCIAL_PROFILE_SCHEMA_ID,
       safeAppSocialProfileSchema,
     );
 
     this.isValidSafeApp = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe-apps/safe-app.json',
+      SAFE_APP_SCHEMA_ID,
       safeAppSchema,
     );
   }

--- a/src/domain/safe/creation-transaction.validator.ts
+++ b/src/domain/safe/creation-transaction.validator.ts
@@ -3,7 +3,7 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
-  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_PARAMETER_SCHEMA_ID,
   DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
@@ -26,7 +26,7 @@ export class CreationTransactionValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      DATA_DECODED_PARAMTER_SCHEMA_ID,
+      DATA_DECODED_PARAMETER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 

--- a/src/domain/safe/creation-transaction.validator.ts
+++ b/src/domain/safe/creation-transaction.validator.ts
@@ -3,12 +3,17 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
+  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
 import { IValidator } from '../interfaces/validator.interface';
 import { CreationTransaction } from './entities/creation-transaction.entity';
-import { creationTransactionSchema } from './entities/schemas/creation-transaction.schema';
+import {
+  CREATION_TRANSACTION_SCHEMA_ID,
+  creationTransactionSchema,
+} from './entities/schemas/creation-transaction.schema';
 
 @Injectable()
 export class CreationTransactionValidator
@@ -21,17 +26,14 @@ export class CreationTransactionValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json',
+      DATA_DECODED_PARAMTER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json',
-      dataDecodedSchema,
-    );
+    this.jsonSchemaService.getSchema(DATA_DECODED_SCHEMA_ID, dataDecodedSchema);
 
     this.isValidCreationTransaction = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/creation-transaction.json',
+      CREATION_TRANSACTION_SCHEMA_ID,
       creationTransactionSchema,
     );
   }

--- a/src/domain/safe/entities/schemas/creation-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/creation-transaction.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const CREATION_TRANSACTION_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/creation-transaction.json';
+
 export const creationTransactionSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/creation-transaction.json',
+  $id: CREATION_TRANSACTION_SCHEMA_ID,
   type: 'object',
   properties: {
     created: { type: 'string', isDate: true },

--- a/src/domain/safe/entities/schemas/erc20-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/erc20-transfer.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const ERC20_TRANSFER_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/erc20-transfer.json';
+
 export const erc20TransferSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/erc20-transfer.json',
+  $id: ERC20_TRANSFER_SCHEMA_ID,
   type: 'object',
   properties: {
     type: {

--- a/src/domain/safe/entities/schemas/erc721-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/erc721-transfer.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const ERC721_TRANSFER_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/erc721-transfer.json';
+
 export const erc721TransferSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/erc721-transfer.json',
+  $id: ERC721_TRANSFER_SCHEMA_ID,
   type: 'object',
   properties: {
     type: {

--- a/src/domain/safe/entities/schemas/ethereum-transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/ethereum-transaction-type.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const ETHEREUM_TRANSACTION_TYPE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/ethereum-transaction-type.json';
+
 export const ethereumTransactionTypeSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/ethereum-transaction-type.json',
+  $id: ETHEREUM_TRANSACTION_TYPE_SCHEMA_ID,
   type: 'object',
   properties: {
     txType: { type: 'string', const: 'ETHEREUM_TRANSACTION' },

--- a/src/domain/safe/entities/schemas/module-transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/module-transaction-type.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const MODULE_TRANSACTION_TYPE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/module-transaction-type.json';
+
 export const moduleTransactionTypeSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/module-transaction-type.json',
+  $id: MODULE_TRANSACTION_TYPE_SCHEMA_ID,
   type: 'object',
   properties: {
     txType: { type: 'string', const: 'MODULE_TRANSACTION' },

--- a/src/domain/safe/entities/schemas/module-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/module-transaction.schema.ts
@@ -1,8 +1,11 @@
 import { Schema } from 'ajv';
 import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
+export const MODULE_TRANSACTION_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/module-transaction.json';
+
 export const moduleTransactionSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/module-transaction.json',
+  $id: MODULE_TRANSACTION_SCHEMA_ID,
   type: 'object',
   properties: {
     safe: { type: 'string' },
@@ -40,7 +43,10 @@ export const moduleTransactionSchema: Schema = {
   ],
 };
 
+export const MODULE_TRANSACTION_PAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/module-transaction-page.json';
+
 export const moduleTransactionPageSchema: Schema = buildPageSchema(
-  'https://safe-client.safe.global/schemas/safe/module-transaction-page.json',
+  MODULE_TRANSACTION_PAGE_SCHEMA_ID,
   moduleTransactionSchema,
 );

--- a/src/domain/safe/entities/schemas/multisig-transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction-type.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const MULTISIG_TRANSACTION_TYPE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/multisig-transaction-type.json';
+
 export const multisigTransactionTypeSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/multisig-transaction-type.json',
+  $id: MULTISIG_TRANSACTION_TYPE_SCHEMA_ID,
   type: 'object',
   properties: {
     txType: { type: 'string', const: 'MULTISIG_TRANSACTION' },

--- a/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
+++ b/src/domain/safe/entities/schemas/multisig-transaction.schema.ts
@@ -1,8 +1,11 @@
 import { Schema } from 'ajv';
 import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
+export const CONFIRMATION_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/confirmation.json';
+
 export const confirmationSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/confirmation.json',
+  $id: CONFIRMATION_SCHEMA_ID,
   type: 'object',
   properties: {
     owner: { type: 'string' },
@@ -14,8 +17,11 @@ export const confirmationSchema: Schema = {
   required: ['owner', 'submissionDate', 'signatureType'],
 };
 
+export const MULTISIG_TRANSACTION_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/multisig-transaction.json';
+
 export const multisigTransactionSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/multisig-transaction.json',
+  $id: MULTISIG_TRANSACTION_SCHEMA_ID,
   type: 'object',
   properties: {
     safe: { type: 'string' },
@@ -85,7 +91,10 @@ export const multisigTransactionSchema: Schema = {
   ],
 };
 
+export const MULTISIG_TRANSACTION_PAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/multisig-transaction-page.json';
+
 export const multisigTransactionPageSchema: Schema = buildPageSchema(
-  'https://safe-client.safe.global/schemas/safe/multisig-transaction-page.json',
+  MULTISIG_TRANSACTION_PAGE_SCHEMA_ID,
   multisigTransactionSchema,
 );

--- a/src/domain/safe/entities/schemas/native-token-transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/native-token-transfer.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const NATIVE_TOKEN_TRANSFER_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/native-token-transfer.json';
+
 export const nativeTokenTransferSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/native-token-transfer.json',
+  $id: NATIVE_TOKEN_TRANSFER_SCHEMA_ID,
   type: 'object',
   properties: {
     type: { type: 'string', const: 'ETHER_TRANSFER' },

--- a/src/domain/safe/entities/schemas/safe-list.schema.ts
+++ b/src/domain/safe/entities/schemas/safe-list.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { SafeList } from '../safe-list.entity';
 
+export const SAFE_LIST_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/safe-list.json';
+
 export const safeListSchema: JSONSchemaType<SafeList> = {
-  $id: 'https://safe-client.safe.global/schemas/safe/safe-list.json',
+  $id: SAFE_LIST_SCHEMA_ID,
   type: 'object',
   properties: {
     safes: { type: 'array', items: { type: 'string' } },

--- a/src/domain/safe/entities/schemas/safe.schema.ts
+++ b/src/domain/safe/entities/schemas/safe.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { Safe } from '../safe.entity';
 
+export const SAFE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/safe.json';
+
 export const safeSchema: JSONSchemaType<Safe> = {
-  $id: 'https://safe-client.safe.global/schemas/safe/safe.json',
+  $id: SAFE_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/domain/safe/entities/schemas/transaction-type.schema.ts
+++ b/src/domain/safe/entities/schemas/transaction-type.schema.ts
@@ -1,8 +1,11 @@
 import { Schema } from 'ajv';
 import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
+export const TRANSACTION_TYPE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/transaction-type.json';
+
 export const transactionTypeSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/transaction-type.json',
+  $id: TRANSACTION_TYPE_SCHEMA_ID,
   type: 'object',
   discriminator: { propertyName: 'txType' },
   required: ['txType'],
@@ -19,7 +22,10 @@ export const transactionTypeSchema: Schema = {
   ],
 };
 
+export const TRANSACTION_TYPE_PAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/transaction-type-page.json';
+
 export const transactionTypePageSchema: Schema = buildPageSchema(
-  'https://safe-client.safe.global/schemas/safe/transaction-type-page.json',
+  TRANSACTION_TYPE_PAGE_SCHEMA_ID,
   transactionTypeSchema,
 );

--- a/src/domain/safe/entities/schemas/transfer.schema.ts
+++ b/src/domain/safe/entities/schemas/transfer.schema.ts
@@ -1,8 +1,11 @@
 import { Schema } from 'ajv';
 import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 
+export const TRANSFER_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/transfer.json';
+
 export const transferSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/safe/transfer.json',
+  $id: TRANSFER_SCHEMA_ID,
   type: 'object',
   discriminator: { propertyName: 'type' },
   required: [
@@ -26,7 +29,10 @@ export const transferSchema: Schema = {
   ],
 };
 
+export const TRANSFER_PAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/safe/transfer-page.json';
+
 export const transferPageSchema: Schema = buildPageSchema(
-  'https://safe-client.safe.global/schemas/safe/transfer-page.json',
+  TRANSFER_PAGE_SCHEMA_ID,
   transferSchema,
 );

--- a/src/domain/safe/module-transaction.validator.ts
+++ b/src/domain/safe/module-transaction.validator.ts
@@ -3,7 +3,7 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
-  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_PARAMETER_SCHEMA_ID,
   DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
@@ -31,7 +31,7 @@ export class ModuleTransactionValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      DATA_DECODED_PARAMTER_SCHEMA_ID,
+      DATA_DECODED_PARAMETER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 

--- a/src/domain/safe/module-transaction.validator.ts
+++ b/src/domain/safe/module-transaction.validator.ts
@@ -3,6 +3,8 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
+  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
@@ -11,6 +13,8 @@ import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { ModuleTransaction } from './entities/module-transaction.entity';
 import {
+  MODULE_TRANSACTION_PAGE_SCHEMA_ID,
+  MODULE_TRANSACTION_SCHEMA_ID,
   moduleTransactionPageSchema,
   moduleTransactionSchema,
 } from './entities/schemas/module-transaction.schema';
@@ -27,22 +31,19 @@ export class ModuleTransactionValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json',
+      DATA_DECODED_PARAMTER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json',
-      dataDecodedSchema,
-    );
+    this.jsonSchemaService.getSchema(DATA_DECODED_SCHEMA_ID, dataDecodedSchema);
 
     this.isValidModuleTransaction = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/module-transaction.json',
+      MODULE_TRANSACTION_SCHEMA_ID,
       moduleTransactionSchema,
     );
 
     this.isValidPage = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/module-transaction-page.json',
+      MODULE_TRANSACTION_PAGE_SCHEMA_ID,
       moduleTransactionPageSchema,
     );
   }

--- a/src/domain/safe/multisig-transaction.validator.ts
+++ b/src/domain/safe/multisig-transaction.validator.ts
@@ -3,7 +3,7 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
-  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_PARAMETER_SCHEMA_ID,
   DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
@@ -35,7 +35,7 @@ export class MultisigTransactionValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      DATA_DECODED_PARAMTER_SCHEMA_ID,
+      DATA_DECODED_PARAMETER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 

--- a/src/domain/safe/multisig-transaction.validator.ts
+++ b/src/domain/safe/multisig-transaction.validator.ts
@@ -3,6 +3,8 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
+  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
@@ -11,6 +13,9 @@ import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
 import { MultisigTransaction } from './entities/multisig-transaction.entity';
 import {
+  CONFIRMATION_SCHEMA_ID,
+  MULTISIG_TRANSACTION_PAGE_SCHEMA_ID,
+  MULTISIG_TRANSACTION_SCHEMA_ID,
   confirmationSchema,
   multisigTransactionPageSchema,
   multisigTransactionSchema,
@@ -30,27 +35,24 @@ export class MultisigTransactionValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json',
+      DATA_DECODED_PARAMTER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json',
-      dataDecodedSchema,
-    );
+    this.jsonSchemaService.getSchema(DATA_DECODED_SCHEMA_ID, dataDecodedSchema);
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/confirmation.json',
+      CONFIRMATION_SCHEMA_ID,
       confirmationSchema,
     );
 
     this.isValidMultisigTransaction = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/multisig-transaction.json',
+      MULTISIG_TRANSACTION_SCHEMA_ID,
       multisigTransactionSchema,
     );
 
     this.isValidPage = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/multisig-transaction-page.json',
+      MULTISIG_TRANSACTION_PAGE_SCHEMA_ID,
       multisigTransactionPageSchema,
     );
   }

--- a/src/domain/safe/safe-list.validator.ts
+++ b/src/domain/safe/safe-list.validator.ts
@@ -4,7 +4,10 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { SafeList } from './entities/safe-list.entity';
-import { safeListSchema } from './entities/schemas/safe-list.schema';
+import {
+  SAFE_LIST_SCHEMA_ID,
+  safeListSchema,
+} from './entities/schemas/safe-list.schema';
 
 @Injectable()
 export class SafeListValidator implements IValidator<SafeList> {
@@ -15,7 +18,7 @@ export class SafeListValidator implements IValidator<SafeList> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidSafesList = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/safe-list.json',
+      SAFE_LIST_SCHEMA_ID,
       safeListSchema,
     );
   }

--- a/src/domain/safe/safe.validator.ts
+++ b/src/domain/safe/safe.validator.ts
@@ -4,7 +4,7 @@ import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import { IValidator } from '../interfaces/validator.interface';
 import { Safe } from './entities/safe.entity';
-import { safeSchema } from './entities/schemas/safe.schema';
+import { SAFE_SCHEMA_ID, safeSchema } from './entities/schemas/safe.schema';
 
 @Injectable()
 export class SafeValidator implements IValidator<Safe> {
@@ -15,7 +15,7 @@ export class SafeValidator implements IValidator<Safe> {
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValidSafe = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/safe.json',
+      SAFE_SCHEMA_ID,
       safeSchema,
     );
   }

--- a/src/domain/safe/transaction-type.validator.ts
+++ b/src/domain/safe/transaction-type.validator.ts
@@ -3,23 +3,48 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
+  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
 } from '../data-decoder/entities/schemas/data-decoded.schema';
 import { Page } from '../entities/page.entity';
 import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
-import { erc20TransferSchema } from './entities/schemas/erc20-transfer.schema';
-import { erc721TransferSchema } from './entities/schemas/erc721-transfer.schema';
-import { ethereumTransactionTypeSchema } from './entities/schemas/ethereum-transaction-type.schema';
-import { moduleTransactionTypeSchema } from './entities/schemas/module-transaction-type.schema';
-import { multisigTransactionTypeSchema } from './entities/schemas/multisig-transaction-type.schema';
-import { nativeTokenTransferSchema } from './entities/schemas/native-token-transfer.schema';
 import {
+  ERC20_TRANSFER_SCHEMA_ID,
+  erc20TransferSchema,
+} from './entities/schemas/erc20-transfer.schema';
+import {
+  ERC721_TRANSFER_SCHEMA_ID,
+  erc721TransferSchema,
+} from './entities/schemas/erc721-transfer.schema';
+import {
+  ETHEREUM_TRANSACTION_TYPE_SCHEMA_ID,
+  ethereumTransactionTypeSchema,
+} from './entities/schemas/ethereum-transaction-type.schema';
+import {
+  MODULE_TRANSACTION_TYPE_SCHEMA_ID,
+  moduleTransactionTypeSchema,
+} from './entities/schemas/module-transaction-type.schema';
+import {
+  MULTISIG_TRANSACTION_TYPE_SCHEMA_ID,
+  multisigTransactionTypeSchema,
+} from './entities/schemas/multisig-transaction-type.schema';
+import {
+  NATIVE_TOKEN_TRANSFER_SCHEMA_ID,
+  nativeTokenTransferSchema,
+} from './entities/schemas/native-token-transfer.schema';
+import {
+  TRANSACTION_TYPE_PAGE_SCHEMA_ID,
+  TRANSACTION_TYPE_SCHEMA_ID,
   transactionTypePageSchema,
   transactionTypeSchema,
 } from './entities/schemas/transaction-type.schema';
-import { transferSchema } from './entities/schemas/transfer.schema';
+import {
+  TRANSFER_SCHEMA_ID,
+  transferSchema,
+} from './entities/schemas/transfer.schema';
 import { Transaction } from './entities/transaction.entity';
 
 @Injectable()
@@ -34,57 +59,51 @@ export class TransactionTypeValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/native-token-transfer.json',
+      NATIVE_TOKEN_TRANSFER_SCHEMA_ID,
       nativeTokenTransferSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/erc20-transfer.json',
+      ERC20_TRANSFER_SCHEMA_ID,
       erc20TransferSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/erc721-transfer.json',
+      ERC721_TRANSFER_SCHEMA_ID,
       erc721TransferSchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/transfer.json',
-      transferSchema,
-    );
+    this.jsonSchemaService.getSchema(TRANSFER_SCHEMA_ID, transferSchema);
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/ethereum-transaction-type.json',
+      ETHEREUM_TRANSACTION_TYPE_SCHEMA_ID,
       ethereumTransactionTypeSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded-parameter.json',
+      DATA_DECODED_PARAMTER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 
-    this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/data-decoded/data-decoded.json',
-      dataDecodedSchema,
-    );
+    this.jsonSchemaService.getSchema(DATA_DECODED_SCHEMA_ID, dataDecodedSchema);
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/module-transaction-type.json',
+      MODULE_TRANSACTION_TYPE_SCHEMA_ID,
       moduleTransactionTypeSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/multisig-transaction-type.json',
+      MULTISIG_TRANSACTION_TYPE_SCHEMA_ID,
       multisigTransactionTypeSchema,
     );
 
     this.isValidTransactionType = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/transaction-type.json',
+      TRANSACTION_TYPE_SCHEMA_ID,
       transactionTypeSchema,
     );
 
     this.isValidPage = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/transaction-type-page.json',
+      TRANSACTION_TYPE_PAGE_SCHEMA_ID,
       transactionTypePageSchema,
     );
   }

--- a/src/domain/safe/transaction-type.validator.ts
+++ b/src/domain/safe/transaction-type.validator.ts
@@ -3,7 +3,7 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../validation/providers/json-schema.service';
 import {
-  DATA_DECODED_PARAMTER_SCHEMA_ID,
+  DATA_DECODED_PARAMETER_SCHEMA_ID,
   DATA_DECODED_SCHEMA_ID,
   dataDecodedParameterSchema,
   dataDecodedSchema,
@@ -81,7 +81,7 @@ export class TransactionTypeValidator
     );
 
     this.jsonSchemaService.getSchema(
-      DATA_DECODED_PARAMTER_SCHEMA_ID,
+      DATA_DECODED_PARAMETER_SCHEMA_ID,
       dataDecodedParameterSchema,
     );
 

--- a/src/domain/safe/transfer.validator.ts
+++ b/src/domain/safe/transfer.validator.ts
@@ -5,10 +5,21 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { Page } from '../entities/page.entity';
 import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
-import { erc20TransferSchema } from './entities/schemas/erc20-transfer.schema';
-import { erc721TransferSchema } from './entities/schemas/erc721-transfer.schema';
-import { nativeTokenTransferSchema } from './entities/schemas/native-token-transfer.schema';
 import {
+  ERC20_TRANSFER_SCHEMA_ID,
+  erc20TransferSchema,
+} from './entities/schemas/erc20-transfer.schema';
+import {
+  ERC721_TRANSFER_SCHEMA_ID,
+  erc721TransferSchema,
+} from './entities/schemas/erc721-transfer.schema';
+import {
+  NATIVE_TOKEN_TRANSFER_SCHEMA_ID,
+  nativeTokenTransferSchema,
+} from './entities/schemas/native-token-transfer.schema';
+import {
+  TRANSFER_PAGE_SCHEMA_ID,
+  TRANSFER_SCHEMA_ID,
   transferPageSchema,
   transferSchema,
 } from './entities/schemas/transfer.schema';
@@ -26,27 +37,27 @@ export class TransferValidator
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/native-token-transfer.json',
+      NATIVE_TOKEN_TRANSFER_SCHEMA_ID,
       nativeTokenTransferSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/erc20-transfer.json',
+      ERC20_TRANSFER_SCHEMA_ID,
       erc20TransferSchema,
     );
 
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/erc721-transfer.json',
+      ERC721_TRANSFER_SCHEMA_ID,
       erc721TransferSchema,
     );
 
     this.isValidTransfer = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/transfer.json',
+      TRANSFER_SCHEMA_ID,
       transferSchema,
     );
 
     this.isValidPage = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/safe/transfer-page.json',
+      TRANSFER_PAGE_SCHEMA_ID,
       transferPageSchema,
     );
   }

--- a/src/domain/tokens/entities/schemas/token.schema.ts
+++ b/src/domain/tokens/entities/schemas/token.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType, Schema } from 'ajv';
 import { buildPageSchema } from '../../../entities/schemas/page.schema.factory';
 import { Token, TokenType } from '../token.entity';
 
+export const TOKEN_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/tokens/token.json';
+
 export const tokenSchema: JSONSchemaType<Token> = {
-  $id: 'https://safe-client.safe.global/schemas/tokens/token.json',
+  $id: TOKEN_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },
@@ -16,7 +19,10 @@ export const tokenSchema: JSONSchemaType<Token> = {
   required: ['address', 'decimals', 'logoUri', 'name', 'symbol', 'type'],
 };
 
+export const TOKEN_PAGE_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/tokens/token-page.json';
+
 export const tokenPageSchema: Schema = buildPageSchema(
-  'https://safe-client.safe.global/schemas/tokens/token-page.json',
+  TOKEN_PAGE_SCHEMA_ID,
   tokenSchema,
 );

--- a/src/domain/tokens/token.validator.ts
+++ b/src/domain/tokens/token.validator.ts
@@ -5,7 +5,12 @@ import { JsonSchemaService } from '../../validation/providers/json-schema.servic
 import { Page } from '../entities/page.entity';
 import { IPageValidator } from '../interfaces/page-validator.interface';
 import { IValidator } from '../interfaces/validator.interface';
-import { tokenPageSchema, tokenSchema } from './entities/schemas/token.schema';
+import {
+  TOKEN_PAGE_SCHEMA_ID,
+  TOKEN_SCHEMA_ID,
+  tokenPageSchema,
+  tokenSchema,
+} from './entities/schemas/token.schema';
 import { Token } from './entities/token.entity';
 
 @Injectable()
@@ -20,11 +25,11 @@ export class TokenValidator
     private readonly jsonSchemaValidator: JsonSchemaService,
   ) {
     this.isValidToken = this.jsonSchemaValidator.getSchema(
-      'https://safe-client.safe.global/schemas/tokens/token.json',
+      TOKEN_SCHEMA_ID,
       tokenSchema,
     );
     this.isValidPage = this.jsonSchemaValidator.getSchema(
-      'https://safe-client.safe.global/schemas/tokens/token-page.json',
+      TOKEN_PAGE_SCHEMA_ID,
       tokenPageSchema,
     );
   }

--- a/src/routes/cache-hooks/entities/schemas/executed-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/executed-transaction.schema.ts
@@ -2,9 +2,12 @@ import { JSONSchemaType } from 'ajv';
 import { ExecutedTransaction } from '../executed-transaction.entity';
 import { EventType } from '../event-payload.entity';
 
+export const EXECUTED_TRANSACTION_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/executed-transaction.json';
+
 export const executedTransactionEventSchema: JSONSchemaType<ExecutedTransaction> =
   {
-    $id: 'https://safe-client.safe.global/schemas/cache-hooks/executed-transaction.json',
+    $id: EXECUTED_TRANSACTION_EVENT_SCHEMA_ID,
     type: 'object',
     properties: {
       address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/incoming-ether.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/incoming-ether.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { IncomingEther } from '../incoming-ether.entity';
 
+export const INCOMING_ETHER_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/incoming-ether.json';
+
 export const incomingEtherEventSchema: JSONSchemaType<IncomingEther> = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/incoming-ether.json',
+  $id: INCOMING_ETHER_EVENT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/incoming-token.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/incoming-token.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { IncomingToken } from '../incoming-token.entity';
 
+export const INCOMING_TOKEN_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/incoming-token.json';
+
 export const incomingTokenEventSchema: JSONSchemaType<IncomingToken> = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/incoming-token.json',
+  $id: INCOMING_TOKEN_EVENT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/module-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/module-transaction.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { ModuleTransaction } from '../module-transaction.entity';
 
+export const MODULE_TRANSACTION_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/module-transaction.json';
+
 export const moduleTransactionEventSchema: JSONSchemaType<ModuleTransaction> = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/module-transaction.json',
+  $id: MODULE_TRANSACTION_EVENT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/new-confirmation.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/new-confirmation.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { NewConfirmation } from '../new-confirmation.entity';
 
+export const NEW_CONFIRMATION_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/new-confirmation.json';
+
 export const newConfirmationEventSchema: JSONSchemaType<NewConfirmation> = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/new-confirmation.json',
+  $id: NEW_CONFIRMATION_EVENT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/outgoing-ether.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/outgoing-ether.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { OutgoingEther } from '../outgoing-ether.entity';
 
+export const OUTGOING_ETHER_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/outgoing-ether.json';
+
 export const outgoingEtherEventSchema: JSONSchemaType<OutgoingEther> = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/outgoing-ether.json',
+  $id: OUTGOING_ETHER_EVENT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/outgoing-token.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/outgoing-token.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { OutgoingToken } from '../outgoing-token.entity';
 
+export const OUTGOING_TOKEN_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/outgoing-token.json';
+
 export const outgoingTokenEventSchema: JSONSchemaType<OutgoingToken> = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/outgoing-token.json',
+  $id: OUTGOING_TOKEN_EVENT_SCHEMA_ID,
   type: 'object',
   properties: {
     address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/pending-transaction.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/pending-transaction.schema.ts
@@ -2,9 +2,12 @@ import { JSONSchemaType } from 'ajv';
 import { EventType } from '../event-payload.entity';
 import { PendingTransaction } from '../pending-transaction.entity';
 
+export const PENDING_TRANSACTION_EVENT_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/pending-transaction.json';
+
 export const pendingTransactionEventSchema: JSONSchemaType<PendingTransaction> =
   {
-    $id: 'https://safe-client.safe.global/schemas/cache-hooks/pending-transaction.json',
+    $id: PENDING_TRANSACTION_EVENT_SCHEMA_ID,
     type: 'object',
     properties: {
       address: { type: 'string' },

--- a/src/routes/cache-hooks/entities/schemas/web-hook.schema.ts
+++ b/src/routes/cache-hooks/entities/schemas/web-hook.schema.ts
@@ -8,6 +8,9 @@ import { IncomingEther } from '../incoming-ether.entity';
 import { OutgoingEther } from '../outgoing-ether.entity';
 import { ModuleTransaction } from '../module-transaction.entity';
 
+export const WEB_HOOK_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/cache-hooks/web-hook.json';
+
 export const webHookSchema: JSONSchemaType<
   | ExecutedTransaction
   | IncomingEther
@@ -18,7 +21,7 @@ export const webHookSchema: JSONSchemaType<
   | OutgoingEther
   | PendingTransaction
 > = {
-  $id: 'https://safe-client.safe.global/schemas/cache-hooks/web-hook.json',
+  $id: WEB_HOOK_SCHEMA_ID,
   type: 'object',
   discriminator: { propertyName: 'type' },
   required: ['type', 'address', 'chainId'],

--- a/src/routes/cache-hooks/pipes/event-validation.pipe.ts
+++ b/src/routes/cache-hooks/pipes/event-validation.pipe.ts
@@ -1,23 +1,50 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
-import { executedTransactionEventSchema } from '../entities/schemas/executed-transaction.schema';
-import { newConfirmationEventSchema } from '../entities/schemas/new-confirmation.schema';
-import { pendingTransactionEventSchema } from '../entities/schemas/pending-transaction.schema';
-import { webHookSchema } from '../entities/schemas/web-hook.schema';
+import {
+  EXECUTED_TRANSACTION_EVENT_SCHEMA_ID,
+  executedTransactionEventSchema,
+} from '../entities/schemas/executed-transaction.schema';
+import {
+  NEW_CONFIRMATION_EVENT_SCHEMA_ID,
+  newConfirmationEventSchema,
+} from '../entities/schemas/new-confirmation.schema';
+import {
+  PENDING_TRANSACTION_EVENT_SCHEMA_ID,
+  pendingTransactionEventSchema,
+} from '../entities/schemas/pending-transaction.schema';
+import {
+  WEB_HOOK_SCHEMA_ID,
+  webHookSchema,
+} from '../entities/schemas/web-hook.schema';
 import { ExecutedTransaction } from '../entities/executed-transaction.entity';
 import { NewConfirmation } from '../entities/new-confirmation.entity';
 import { PendingTransaction } from '../entities/pending-transaction.entity';
 import { IncomingEther } from '../entities/incoming-ether.entity';
-import { incomingEtherEventSchema } from '../entities/schemas/incoming-ether.schema';
-import { incomingTokenEventSchema } from '../entities/schemas/incoming-token.schema';
+import {
+  INCOMING_ETHER_EVENT_SCHEMA_ID,
+  incomingEtherEventSchema,
+} from '../entities/schemas/incoming-ether.schema';
+import {
+  INCOMING_TOKEN_EVENT_SCHEMA_ID,
+  incomingTokenEventSchema,
+} from '../entities/schemas/incoming-token.schema';
 import { IncomingToken } from '../entities/incoming-token.entity';
-import { outgoingEtherEventSchema } from '../entities/schemas/outgoing-ether.schema';
+import {
+  OUTGOING_ETHER_EVENT_SCHEMA_ID,
+  outgoingEtherEventSchema,
+} from '../entities/schemas/outgoing-ether.schema';
 import { OutgoingEther } from '../entities/outgoing-ether.entity';
-import { outgoingTokenEventSchema } from '../entities/schemas/outgoing-token.schema';
+import {
+  OUTGOING_TOKEN_EVENT_SCHEMA_ID,
+  outgoingTokenEventSchema,
+} from '../entities/schemas/outgoing-token.schema';
 import { OutgoingToken } from '../entities/outgoing-token.entity';
 import { ModuleTransaction } from '../entities/module-transaction.entity';
-import { moduleTransactionEventSchema } from '../entities/schemas/module-transaction.schema';
+import {
+  MODULE_TRANSACTION_EVENT_SCHEMA_ID,
+  moduleTransactionEventSchema,
+} from '../entities/schemas/module-transaction.schema';
 
 @Injectable()
 export class EventValidationPipe
@@ -47,39 +74,39 @@ export class EventValidationPipe
 
   constructor(private readonly jsonSchemaService: JsonSchemaService) {
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/executed-transaction.json',
+      EXECUTED_TRANSACTION_EVENT_SCHEMA_ID,
       executedTransactionEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/incoming-ether.json',
+      INCOMING_ETHER_EVENT_SCHEMA_ID,
       incomingEtherEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/incoming-token.json',
+      INCOMING_TOKEN_EVENT_SCHEMA_ID,
       incomingTokenEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/module-transaction.json',
+      MODULE_TRANSACTION_EVENT_SCHEMA_ID,
       moduleTransactionEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/new-confirmation.json',
+      NEW_CONFIRMATION_EVENT_SCHEMA_ID,
       newConfirmationEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/outgoing-ether.json',
+      OUTGOING_ETHER_EVENT_SCHEMA_ID,
       outgoingEtherEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/outgoing-token.json',
+      OUTGOING_TOKEN_EVENT_SCHEMA_ID,
       outgoingTokenEventSchema,
     );
     jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/pending-transaction.json',
+      PENDING_TRANSACTION_EVENT_SCHEMA_ID,
       pendingTransactionEventSchema,
     );
     this.isWebHookEvent = jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/cache-hooks/web-hook.json',
+      WEB_HOOK_SCHEMA_ID,
       webHookSchema,
     );
   }

--- a/src/routes/data-decode/entities/schemas/get-data-decoded.dto.schema.ts
+++ b/src/routes/data-decode/entities/schemas/get-data-decoded.dto.schema.ts
@@ -2,8 +2,11 @@ import { JSONSchemaType } from 'ajv';
 import { GetDataDecodedDto } from '../get-data-decoded.dto.entity';
 import { HEX_PATTERN } from '../../../../validation/patterns';
 
+export const GET_DATA_DECODED_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/delegates/get-data-decoded.dto.json';
+
 export const getDataDecodedDtoSchema: JSONSchemaType<GetDataDecodedDto> = {
-  $id: 'https://safe-client.safe.global/schemas/delegates/get-data-decoded.dto.json',
+  $id: GET_DATA_DECODED_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     data: { type: 'string', pattern: HEX_PATTERN },

--- a/src/routes/data-decode/pipes/get-data-decoded.dto.validation.pipe.ts
+++ b/src/routes/data-decode/pipes/get-data-decoded.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { GetDataDecodedDto } from '../entities/get-data-decoded.dto.entity';
-import { getDataDecodedDtoSchema } from '../entities/schemas/get-data-decoded.dto.schema';
+import {
+  GET_DATA_DECODED_DTO_SCHEMA_ID,
+  getDataDecodedDtoSchema,
+} from '../entities/schemas/get-data-decoded.dto.schema';
 
 @Injectable()
 export class GetDataDecodedDtoValidationPipe
@@ -16,7 +19,7 @@ export class GetDataDecodedDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/get-data-decoded.dto.json',
+      GET_DATA_DECODED_DTO_SCHEMA_ID,
       getDataDecodedDtoSchema,
     );
   }

--- a/src/routes/delegates/entities/schemas/create-delegate.dto.schema.ts
+++ b/src/routes/delegates/entities/schemas/create-delegate.dto.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { CreateDelegateDto } from '../create-delegate.dto.entity';
 
+export const CREATE_DELEGATE_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/delegates/create-delegate.dto.json';
+
 export const createDelegateDtoSchema: JSONSchemaType<CreateDelegateDto> = {
-  $id: 'https://safe-client.safe.global/schemas/delegates/create-delegate.dto.json',
+  $id: CREATE_DELEGATE_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     safe: { type: 'string', nullable: true },

--- a/src/routes/delegates/entities/schemas/delete-delegate.dto.schema.ts
+++ b/src/routes/delegates/entities/schemas/delete-delegate.dto.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { DeleteDelegateDto } from '../delete-delegate.dto.entity';
 
+export const DELETE_DELEGATE_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/delegates/delete-delegate.dto.json';
+
 export const deleteDelegateDtoSchema: JSONSchemaType<DeleteDelegateDto> = {
-  $id: 'https://safe-client.safe.global/schemas/delegates/delete-delegate.dto.json',
+  $id: DELETE_DELEGATE_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     delegate: { type: 'string' },

--- a/src/routes/delegates/entities/schemas/delete-safe-delegate.dto.schema.ts
+++ b/src/routes/delegates/entities/schemas/delete-safe-delegate.dto.schema.ts
@@ -1,9 +1,12 @@
 import { JSONSchemaType } from 'ajv';
 import { DeleteSafeDelegateDto } from '../delete-safe-delegate.dto.entity';
 
+export const DELETE_SAFE_DELEGATE_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/delegates/delete-safe-delegate.dto.json';
+
 export const deleteSafeDelegateDtoSchema: JSONSchemaType<DeleteSafeDelegateDto> =
   {
-    $id: 'https://safe-client.safe.global/schemas/delegates/delete-safe-delegate.dto.json',
+    $id: DELETE_SAFE_DELEGATE_DTO_SCHEMA_ID,
     type: 'object',
     properties: {
       delegate: { type: 'string' },

--- a/src/routes/delegates/entities/schemas/get-delegate.dto.schema.ts
+++ b/src/routes/delegates/entities/schemas/get-delegate.dto.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { GetDelegateDto } from '../get-delegate.dto.entity';
 
+export const GET_DELEGATE_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/delegates/get-delegate.dto.json';
+
 export const getDelegateDtoSchema: JSONSchemaType<GetDelegateDto> = {
-  $id: 'https://safe-client.safe.global/schemas/delegates/get-delegate.dto.json',
+  $id: GET_DELEGATE_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     safe: { type: 'string', nullable: true },

--- a/src/routes/delegates/pipes/create-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/create-delegate.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { CreateDelegateDto } from '../entities/create-delegate.dto.entity';
-import { createDelegateDtoSchema } from '../entities/schemas/create-delegate.dto.schema';
+import {
+  CREATE_DELEGATE_DTO_SCHEMA_ID,
+  createDelegateDtoSchema,
+} from '../entities/schemas/create-delegate.dto.schema';
 
 @Injectable()
 export class CreateDelegateDtoValidationPipe
@@ -16,7 +19,7 @@ export class CreateDelegateDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/create-delegate.dto.json',
+      CREATE_DELEGATE_DTO_SCHEMA_ID,
       createDelegateDtoSchema,
     );
   }

--- a/src/routes/delegates/pipes/delete-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/delete-delegate.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { DeleteDelegateDto } from '../entities/delete-delegate.dto.entity';
-import { deleteDelegateDtoSchema } from '../entities/schemas/delete-delegate.dto.schema';
+import {
+  DELETE_DELEGATE_DTO_SCHEMA_ID,
+  deleteDelegateDtoSchema,
+} from '../entities/schemas/delete-delegate.dto.schema';
 
 @Injectable()
 export class DeleteDelegateDtoValidationPipe
@@ -16,7 +19,7 @@ export class DeleteDelegateDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/delete-delegate.dto.json',
+      DELETE_DELEGATE_DTO_SCHEMA_ID,
       deleteDelegateDtoSchema,
     );
   }

--- a/src/routes/delegates/pipes/delete-safe-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/delete-safe-delegate.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { DeleteSafeDelegateDto } from '../entities/delete-safe-delegate.dto.entity';
-import { deleteSafeDelegateDtoSchema } from '../entities/schemas/delete-safe-delegate.dto.schema';
+import {
+  DELETE_SAFE_DELEGATE_DTO_SCHEMA_ID,
+  deleteSafeDelegateDtoSchema,
+} from '../entities/schemas/delete-safe-delegate.dto.schema';
 
 @Injectable()
 export class DeleteSafeDelegateDtoValidationPipe
@@ -16,7 +19,7 @@ export class DeleteSafeDelegateDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/delete-safe-delegate.dto.json',
+      DELETE_SAFE_DELEGATE_DTO_SCHEMA_ID,
       deleteSafeDelegateDtoSchema,
     );
   }

--- a/src/routes/delegates/pipes/get-delegate.dto.validation.pipe.ts
+++ b/src/routes/delegates/pipes/get-delegate.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { GetDelegateDto } from '../entities/get-delegate.dto.entity';
-import { getDelegateDtoSchema } from '../entities/schemas/get-delegate.dto.schema';
+import {
+  GET_DELEGATE_DTO_SCHEMA_ID,
+  getDelegateDtoSchema,
+} from '../entities/schemas/get-delegate.dto.schema';
 
 @Injectable()
 export class GetDelegateDtoValidationPipe
@@ -16,7 +19,7 @@ export class GetDelegateDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/get-delegate.dto.json',
+      GET_DELEGATE_DTO_SCHEMA_ID,
       getDelegateDtoSchema,
     );
   }

--- a/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
+++ b/src/routes/estimations/entities/schemas/get-estimation.dto.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { GetEstimationDto } from '../get-estimation.dto.entity';
 
+export const GET_ESTIMATION_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/estimations/get-estimation.dto.json';
+
 export const getEstimationDtoSchema: JSONSchemaType<GetEstimationDto> = {
-  $id: 'https://safe-client.safe.global/schemas/estimations/get-estimation.dto.json',
+  $id: GET_ESTIMATION_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     to: { type: 'string' },

--- a/src/routes/estimations/pipes/get-estimation.dto.validation.pipe.ts
+++ b/src/routes/estimations/pipes/get-estimation.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { GetEstimationDto } from '../entities/get-estimation.dto.entity';
-import { getEstimationDtoSchema } from '../entities/schemas/get-estimation.dto.schema';
+import {
+  GET_ESTIMATION_DTO_SCHEMA_ID,
+  getEstimationDtoSchema,
+} from '../entities/schemas/get-estimation.dto.schema';
 
 @Injectable()
 export class GetEstimationDtoValidationPipe
@@ -16,7 +19,7 @@ export class GetEstimationDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/get-estimation.dto.json',
+      GET_ESTIMATION_DTO_SCHEMA_ID,
       getEstimationDtoSchema,
     );
   }

--- a/src/routes/flush/entities/schemas/invalidation-pattern.dto.schema.ts
+++ b/src/routes/flush/entities/schemas/invalidation-pattern.dto.schema.ts
@@ -1,8 +1,11 @@
 import { Schema } from 'ajv';
 import { InvalidationTarget } from '../../../../domain/flush/entities/invalidation-target.entity';
 
+export const INVALIDATION_PATTERN_DETAIL_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/flush/invalidation-pattern-detail.json';
+
 export const invalidationPatternDetailSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/flush/invalidation-pattern-detail.json',
+  $id: INVALIDATION_PATTERN_DETAIL_SCHEMA_ID,
   type: 'object',
   properties: {
     chain_id: { type: ['string', 'null'] },
@@ -10,8 +13,11 @@ export const invalidationPatternDetailSchema: Schema = {
   required: [],
 };
 
+export const INVALIDATION_PATTERN_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/flush/invalidation-pattern.dto.json';
+
 export const invalidationPatternDtoSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/flush/invalidation-pattern.dto.json',
+  $id: INVALIDATION_PATTERN_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     invalidate: { type: 'string', enum: Object.values(InvalidationTarget) },

--- a/src/routes/flush/pipes/invalidation-pattern.dto.validation.pipe.ts
+++ b/src/routes/flush/pipes/invalidation-pattern.dto.validation.pipe.ts
@@ -4,6 +4,8 @@ import { GenericValidator } from '../../../validation/providers/generic.validato
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { InvalidationPatternDto } from '../entities/invalidation-pattern.dto.entity';
 import {
+  INVALIDATION_PATTERN_DETAIL_SCHEMA_ID,
+  INVALIDATION_PATTERN_DTO_SCHEMA_ID,
   invalidationPatternDetailSchema,
   invalidationPatternDtoSchema,
 } from '../entities/schemas/invalidation-pattern.dto.schema';
@@ -19,11 +21,11 @@ export class InvalidationPatternDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/flush/invalidation-pattern-detail.json',
+      INVALIDATION_PATTERN_DETAIL_SCHEMA_ID,
       invalidationPatternDetailSchema,
     );
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/delegates/invalidation-pattern.dto.json',
+      INVALIDATION_PATTERN_DTO_SCHEMA_ID,
       invalidationPatternDtoSchema,
     );
   }

--- a/src/routes/messages/entities/schemas/create-message.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/create-message.dto.schema.ts
@@ -1,7 +1,10 @@
 import { Schema } from 'ajv';
 
+export const CREATE_MESSAGE_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/messages/create-message.dto.json';
+
 export const createMessageDtoSchema: Schema = {
-  $id: 'https://safe-client.safe.global/schemas/messages/create-message.dto.json',
+  $id: CREATE_MESSAGE_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     message: { type: ['object', 'string'] },

--- a/src/routes/messages/entities/schemas/update-message-signature.dto.schema.ts
+++ b/src/routes/messages/entities/schemas/update-message-signature.dto.schema.ts
@@ -1,9 +1,12 @@
 import { JSONSchemaType } from 'ajv';
 import { UpdateMessageSignatureDto } from '../update-message-signature.entity';
 
+export const UPDATE_MESSAGE_SIGNATURE_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/messages/update-message-signature.dto.json';
+
 export const updateMessageSignatureDtoSchema: JSONSchemaType<UpdateMessageSignatureDto> =
   {
-    $id: 'https://safe-client.safe.global/schemas/messages/update-message-signature.dto.json',
+    $id: UPDATE_MESSAGE_SIGNATURE_DTO_SCHEMA_ID,
     type: 'object',
     properties: {
       signature: { type: 'string' },

--- a/src/routes/messages/pipes/create-message.dto.validation.pipe.ts
+++ b/src/routes/messages/pipes/create-message.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { CreateMessageDto } from '../entities/create-message.dto.entity';
-import { createMessageDtoSchema } from '../entities/schemas/create-message.dto.schema';
+import {
+  CREATE_MESSAGE_DTO_SCHEMA_ID,
+  createMessageDtoSchema,
+} from '../entities/schemas/create-message.dto.schema';
 
 @Injectable()
 export class CreateMessageDtoValidationPipe
@@ -16,7 +19,7 @@ export class CreateMessageDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/messages/create-message.dto.json',
+      CREATE_MESSAGE_DTO_SCHEMA_ID,
       createMessageDtoSchema,
     );
   }

--- a/src/routes/messages/pipes/update-message-signature.dto.validation.pipe.ts
+++ b/src/routes/messages/pipes/update-message-signature.dto.validation.pipe.ts
@@ -2,7 +2,10 @@ import { HttpStatus, Injectable, PipeTransform } from '@nestjs/common';
 import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
-import { updateMessageSignatureDtoSchema } from '../entities/schemas/update-message-signature.dto.schema';
+import {
+  UPDATE_MESSAGE_SIGNATURE_DTO_SCHEMA_ID,
+  updateMessageSignatureDtoSchema,
+} from '../entities/schemas/update-message-signature.dto.schema';
 import { UpdateMessageSignatureDto } from '../entities/update-message-signature.entity';
 
 @Injectable()
@@ -16,7 +19,7 @@ export class UpdateMessageSignatureDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/messages/update-message-signature.dto.json',
+      UPDATE_MESSAGE_SIGNATURE_DTO_SCHEMA_ID,
       updateMessageSignatureDtoSchema,
     );
   }

--- a/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/add-confirmation.dto.schema.ts
@@ -1,8 +1,11 @@
 import { JSONSchemaType } from 'ajv';
 import { AddConfirmationDto } from '../add-confirmation.dto';
 
+export const ADD_CONFIRMATION_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/transactions/add-confirmation.dto.json';
+
 export const addConfirmationDtoSchema: JSONSchemaType<AddConfirmationDto> = {
-  $id: 'https://safe-client.safe.global/schemas/transactions/add-confirmation.dto.json',
+  $id: ADD_CONFIRMATION_DTO_SCHEMA_ID,
   type: 'object',
   properties: {
     signedSafeTxHash: { type: 'string' },

--- a/src/routes/transactions/entities/schemas/preview-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/preview-transaction.dto.schema.ts
@@ -1,9 +1,12 @@
 import { JSONSchemaType } from 'ajv';
 import { PreviewTransactionDto } from '../preview-transaction.dto.entity';
 
+export const PREVIEW_TRANSACTION_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/transactions/preview-transaction.dto.json';
+
 export const previewTransactionDtoSchema: JSONSchemaType<PreviewTransactionDto> =
   {
-    $id: 'https://safe-client.safe.global/schemas/transactions/preview-transaction.dto.json',
+    $id: PREVIEW_TRANSACTION_DTO_SCHEMA_ID,
     type: 'object',
     properties: {
       to: { type: 'string' },

--- a/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
+++ b/src/routes/transactions/entities/schemas/propose-transaction.dto.schema.ts
@@ -1,9 +1,12 @@
 import { JSONSchemaType } from 'ajv';
 import { ProposeTransactionDto } from '../propose-transaction.dto.entity';
 
+export const PROPOSE_TRANSACTION_DTO_SCHEMA_ID =
+  'https://safe-client.safe.global/schemas/transactions/propose-transaction.dto.json';
+
 export const proposeTransactionDtoSchema: JSONSchemaType<ProposeTransactionDto> =
   {
-    $id: 'https://safe-client.safe.global/schemas/transactions/propose-transaction.dto.json',
+    $id: PROPOSE_TRANSACTION_DTO_SCHEMA_ID,
     type: 'object',
     properties: {
       to: { type: 'string' },

--- a/src/routes/transactions/pipes/add-confirmation.validation.pipe.ts
+++ b/src/routes/transactions/pipes/add-confirmation.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { AddConfirmationDto } from '../entities/add-confirmation.dto';
-import { addConfirmationDtoSchema } from '../entities/schemas/add-confirmation.dto.schema';
+import {
+  ADD_CONFIRMATION_DTO_SCHEMA_ID,
+  addConfirmationDtoSchema,
+} from '../entities/schemas/add-confirmation.dto.schema';
 
 @Injectable()
 export class AddConfirmationDtoValidationPipe
@@ -16,7 +19,7 @@ export class AddConfirmationDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/transactions/add-confirmation.dto.json',
+      ADD_CONFIRMATION_DTO_SCHEMA_ID,
       addConfirmationDtoSchema,
     );
   }

--- a/src/routes/transactions/pipes/preview-transaction.validation.pipe.ts
+++ b/src/routes/transactions/pipes/preview-transaction.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { PreviewTransactionDto } from '../entities/preview-transaction.dto.entity';
-import { previewTransactionDtoSchema } from '../entities/schemas/preview-transaction.dto.schema';
+import {
+  PREVIEW_TRANSACTION_DTO_SCHEMA_ID,
+  previewTransactionDtoSchema,
+} from '../entities/schemas/preview-transaction.dto.schema';
 
 @Injectable()
 export class PreviewTransactionDtoValidationPipe
@@ -16,7 +19,7 @@ export class PreviewTransactionDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/transactions/preview-transaction.dto.json',
+      PREVIEW_TRANSACTION_DTO_SCHEMA_ID,
       previewTransactionDtoSchema,
     );
   }

--- a/src/routes/transactions/pipes/propose-transaction.dto.validation.pipe.ts
+++ b/src/routes/transactions/pipes/propose-transaction.dto.validation.pipe.ts
@@ -3,7 +3,10 @@ import { ValidateFunction } from 'ajv';
 import { GenericValidator } from '../../../validation/providers/generic.validator';
 import { JsonSchemaService } from '../../../validation/providers/json-schema.service';
 import { ProposeTransactionDto } from '../entities/propose-transaction.dto.entity';
-import { proposeTransactionDtoSchema } from '../entities/schemas/propose-transaction.dto.schema';
+import {
+  PROPOSE_TRANSACTION_DTO_SCHEMA_ID,
+  proposeTransactionDtoSchema,
+} from '../entities/schemas/propose-transaction.dto.schema';
 
 @Injectable()
 export class ProposeTransactionDtoValidationPipe
@@ -16,7 +19,7 @@ export class ProposeTransactionDtoValidationPipe
     private readonly jsonSchemaService: JsonSchemaService,
   ) {
     this.isValid = this.jsonSchemaService.getSchema(
-      'https://safe-client.safe.global/schemas/transactions/propose-transaction.dto.json',
+      PROPOSE_TRANSACTION_DTO_SCHEMA_ID,
       proposeTransactionDtoSchema,
     );
   }


### PR DESCRIPTION
This prevents typos of schema `$id`s by moving them to constants and importing them in their relevant validators.