### PR TITLE
Make rejectors non-nullable

### DIFF
--- a/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/routes/transactions/entities/transaction-details/multisig-execution-details.entity.ts
@@ -47,8 +47,8 @@ export class MultisigExecutionDetails extends ExecutionDetails {
   confirmationsRequired: number;
   @ApiProperty()
   confirmations: MultisigConfirmationDetails[];
-  @ApiPropertyOptional({ type: AddressInfo, isArray: true, nullable: true })
-  rejectors: AddressInfo[] | null;
+  @ApiProperty({ type: AddressInfo, isArray: true })
+  rejectors: AddressInfo[];
   @ApiPropertyOptional({ type: Token, nullable: true })
   gasTokenInfo: Token | null;
   @ApiProperty()
@@ -67,7 +67,7 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     signers: AddressInfo[],
     confirmationsRequired: number,
     confirmations: MultisigConfirmationDetails[],
-    rejectors: AddressInfo[] | null,
+    rejectors: AddressInfo[],
     gasTokenInfo: Token | null,
     trusted: boolean,
   ) {

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -80,7 +80,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         signers: safe.owners.map((owner) => new AddressInfo(owner)),
         confirmationsRequired: transaction.confirmationsRequired,
         confirmations: [],
-        rejectors: null,
+        rejectors: [],
         gasTokenInfo,
         trusted: transaction.trusted,
       }),

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -101,7 +101,7 @@ export class MultisigTransactionExecutionDetailsMapper {
     chainId: string,
     transaction: MultisigTransaction,
     safe: Safe,
-  ): Promise<AddressInfo[] | null> {
+  ): Promise<AddressInfo[]> {
     const replacementTxsPage =
       await this.safeRepository.getMultisigTransactions(
         chainId,
@@ -118,12 +118,12 @@ export class MultisigTransactionExecutionDetailsMapper {
       this.loggingService.debug(
         `Replacement transaction with nonce ${transaction.nonce} not found for cancelled transaction ${transaction.transactionHash}`,
       );
-      return null;
+      return [];
     }
 
     const replacementTx = replacementTxsPage.results[0];
     return replacementTx.confirmations
       ? replacementTx.confirmations.map((c) => new AddressInfo(c.owner))
-      : null;
+      : [];
   }
 }


### PR DESCRIPTION
Closes #551 

This PR:
- Modifies `MultisigExecutionDetails` entity by making `rejectors` field non-nullable. In the absence of a value, the field contains an empty array.
- Also modifies the OpenAPI specification.