### PR TITLE
Fix rejectors retrieval

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -9,6 +9,8 @@ import {
 } from './multisig-transaction-confirmation.builder';
 import { dataDecodedBuilder } from '../../../data-decoder/entities/__tests__/data-decoded.builder';
 
+const HASH_LENGTH = 10;
+
 export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
   return Builder.new<MultisigTransaction>()
     .with('baseGas', faker.number.int())
@@ -41,11 +43,11 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
     .with('refundReceiver', faker.finance.ethereumAddress())
     .with('safe', faker.finance.ethereumAddress())
     .with('safeTxGas', faker.number.int())
-    .with('safeTxHash', faker.string.hexadecimal())
+    .with('safeTxHash', faker.string.hexadecimal({ length: HASH_LENGTH }))
     .with('signatures', faker.string.hexadecimal())
     .with('submissionDate', faker.date.recent())
     .with('to', faker.finance.ethereumAddress())
-    .with('transactionHash', faker.string.hexadecimal())
+    .with('transactionHash', faker.string.hexadecimal({ length: HASH_LENGTH }))
     .with('trusted', faker.datatype.boolean())
     .with('value', faker.string.hexadecimal());
 }

--- a/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/add-transaction-confirmations.transactions.controller.spec.ts
@@ -87,7 +87,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         .with('name', faker.word.words())
         .build(),
     ];
-    const replacementTxsPage = pageBuilder().with('results', []).build();
+    const rejectionTxsPage = pageBuilder().with('results', []).build();
     networkService.get.mockImplementation((url) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
       const getMultisigTransactionUrl = `${chain.transactionService}/api/v1/multisig-transactions/${safeTxHash}/`;
@@ -103,7 +103,7 @@ describe('Add transaction confirmations - Transactions Controller (Unit)', () =>
         case getMultisigTransactionUrl:
           return Promise.resolve({ data: transaction });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: replacementTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage });
         case getSafeUrl:
           return Promise.resolve({ data: safe });
         case getSafeAppsUrl:

--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -391,12 +391,12 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .with('baseGas', baseGas)
       .with('confirmations', confirmations)
       .build();
-    const replacementTxConfirmations = [confirmationBuilder().build()];
-    const replacementTx = multisigTransactionBuilder()
-      .with('confirmations', replacementTxConfirmations)
+    const rejectionTxConfirmations = [confirmationBuilder().build()];
+    const rejectionTx = multisigTransactionBuilder()
+      .with('confirmations', rejectionTxConfirmations)
       .build();
-    const replacementTxsPage = pageBuilder()
-      .with('results', [multisigToJson(replacementTx)])
+    const rejectionTxsPage = pageBuilder()
+      .with('results', [multisigToJson(rejectionTx)])
       .build();
     const safeAppsResponse = [
       safeAppBuilder()
@@ -422,7 +422,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getMultisigTransactionUrl:
           return Promise.resolve({ data: multisigToJson(tx) });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: replacementTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage });
         case getSafeUrl:
           return Promise.resolve({ data: safe });
         case getGasTokenContractUrl:
@@ -510,7 +510,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             ],
             rejectors: expect.arrayContaining([
               expect.objectContaining({
-                value: replacementTxConfirmations[0].owner,
+                value: rejectionTxConfirmations[0].owner,
               }),
             ]),
             gasToken: tx.gasToken,
@@ -556,12 +556,12 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .with('baseGas', baseGas)
       .with('confirmations', confirmations)
       .build();
-    const replacementTxConfirmations = [confirmationBuilder().build()];
-    const replacementTx = multisigTransactionBuilder()
-      .with('confirmations', replacementTxConfirmations)
+    const rejectionTxConfirmations = [confirmationBuilder().build()];
+    const rejectionTx = multisigTransactionBuilder()
+      .with('confirmations', rejectionTxConfirmations)
       .build();
-    const replacementTxsPage = pageBuilder()
-      .with('results', [multisigToJson(replacementTx)])
+    const rejectionTxsPage = pageBuilder()
+      .with('results', [multisigToJson(rejectionTx)])
       .build();
     const safeAppsResponse = [
       safeAppBuilder()
@@ -589,7 +589,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getMultisigTransactionUrl:
           return Promise.resolve({ data: multisigToJson(tx) });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: replacementTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage });
         case getSafeUrl:
           return Promise.resolve({ data: safe });
         case getGasTokenContractUrl:
@@ -675,7 +675,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             ],
             rejectors: expect.arrayContaining([
               expect.objectContaining({
-                value: replacementTxConfirmations[0].owner,
+                value: rejectionTxConfirmations[0].owner,
               }),
             ]),
             gasToken: tx.gasToken,
@@ -724,15 +724,15 @@ describe('Get by id - Transactions Controller (Unit)', () => {
       .with('baseGas', baseGas)
       .with('confirmations', confirmations)
       .build();
-    const replacementTxConfirmations = [
+    const rejectionTxConfirmations = [
       confirmationBuilder().build(),
       confirmationBuilder().build(),
     ];
-    const replacementTx = multisigTransactionBuilder()
-      .with('confirmations', replacementTxConfirmations)
+    const rejectionTx = multisigTransactionBuilder()
+      .with('confirmations', rejectionTxConfirmations)
       .build();
-    const replacementTxsPage = pageBuilder()
-      .with('results', [multisigToJson(replacementTx)])
+    const rejectionTxsPage = pageBuilder()
+      .with('results', [multisigToJson(rejectionTx)])
       .build();
     const safeAppsResponse = [
       safeAppBuilder()
@@ -756,7 +756,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         case getMultisigTransactionUrl:
           return Promise.resolve({ data: multisigToJson(tx) });
         case getMultisigTransactionsUrl:
-          return Promise.resolve({ data: replacementTxsPage });
+          return Promise.resolve({ data: rejectionTxsPage });
         case getSafeUrl:
           return Promise.resolve({ data: safe });
         case getGasTokenContractUrl:
@@ -841,10 +841,10 @@ describe('Get by id - Transactions Controller (Unit)', () => {
             ]),
             rejectors: expect.arrayContaining([
               expect.objectContaining({
-                value: replacementTxConfirmations[0].owner,
+                value: rejectionTxConfirmations[0].owner,
               }),
               expect.objectContaining({
-                value: replacementTxConfirmations[1].owner,
+                value: rejectionTxConfirmations[1].owner,
               }),
             ]),
             gasToken: tx.gasToken,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.spec.ts
@@ -101,13 +101,76 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
       .build();
     const addressInfo = addressInfoBuilder().build();
     addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
-    const replacementTxConfirmation = confirmationBuilder().build();
-    const replacementTx = multisigTransactionBuilder()
-      .with('confirmations', [replacementTxConfirmation])
+    const rejectionTxConfirmation = confirmationBuilder().build();
+    const rejectionTx = multisigTransactionBuilder()
+      .with('confirmations', [rejectionTxConfirmation])
+      .build();
+    safeRepository.getMultisigTransactions.mockResolvedValue(
+      pageBuilder<MultisigTransaction>().with('results', [rejectionTx]).build(),
+    );
+    const expectedConfirmationsDetails = [
+      new MultisigConfirmationDetails(
+        new AddressInfo(transactionConfirmations[0].owner),
+        transactionConfirmations[0].signature,
+        transactionConfirmations[0].submissionDate.getTime(),
+      ),
+      new MultisigConfirmationDetails(
+        new AddressInfo(transactionConfirmations[1].owner),
+        transactionConfirmations[1].signature,
+        transactionConfirmations[1].submissionDate.getTime(),
+      ),
+    ];
+    const expectedRejectors = [new AddressInfo(rejectionTxConfirmation.owner)];
+
+    const actual = await mapper.mapMultisigExecutionDetails(
+      chainId,
+      transaction,
+      safe,
+    );
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        type: 'MULTISIG',
+        submittedAt: transaction.submissionDate.getTime(),
+        nonce: transaction.nonce,
+        safeTxGas: transaction.safeTxGas?.toString(),
+        baseGas: transaction.baseGas?.toString(),
+        gasPrice: transaction.gasPrice?.toString(),
+        gasToken: NULL_ADDRESS,
+        refundReceiver: addressInfo,
+        safeTxHash: transaction.safeTxHash,
+        executor: addressInfo,
+        signers: safe.owners.map((owner) => new AddressInfo(owner)),
+        confirmationsRequired: transaction.confirmationsRequired,
+        confirmations: expectedConfirmationsDetails,
+        rejectors: expectedRejectors,
+        gasTokenInfo: null,
+        trusted: transaction.trusted,
+      }),
+    );
+  });
+
+  it('should return a MultisigExecutionDetails object with rejectors from rejection transaction only', async () => {
+    const chainId = faker.string.numeric();
+    const transactionConfirmations = [
+      confirmationBuilder().build(),
+      confirmationBuilder().build(),
+    ];
+    const safe = safeBuilder().build();
+    const transaction = multisigTransactionBuilder()
+      .with('safe', safe.address)
+      .with('gasToken', NULL_ADDRESS)
+      .with('confirmations', transactionConfirmations)
+      .build();
+    const addressInfo = addressInfoBuilder().build();
+    addressInfoHelper.getOrDefault.mockResolvedValue(addressInfo);
+    const rejectionTxConfirmation = confirmationBuilder().build();
+    const rejectionTx = multisigTransactionBuilder()
+      .with('confirmations', [rejectionTxConfirmation])
       .build();
     safeRepository.getMultisigTransactions.mockResolvedValue(
       pageBuilder<MultisigTransaction>()
-        .with('results', [replacementTx])
+        .with('results', [transaction, rejectionTx]) // returns both rejected and rejection txs
         .build(),
     );
     const expectedConfirmationsDetails = [
@@ -122,9 +185,7 @@ describe('MultisigTransactionExecutionDetails mapper (Unit)', () => {
         transactionConfirmations[1].submissionDate.getTime(),
       ),
     ];
-    const expectedRejectors = [
-      new AddressInfo(replacementTxConfirmation.owner),
-    ];
+    const expectedRejectors = [new AddressInfo(rejectionTxConfirmation.owner)];
 
     const actual = await mapper.mapMultisigExecutionDetails(
       chainId,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -88,8 +88,8 @@ export class MultisigTransactionExecutionDetailsMapper {
    * transaction for the {@link Transaction} passed in.
    *
    * When a transaction is cancelled, another transaction acts as rejection.
-   * The rejection transaction has the same nonce of the transaction being cancelled,
-   * its value is 0, and it destination is the address of the safe that owns the transaction.
+   * The rejection transaction has the same 'nonce' of the transaction being cancelled,
+   * its 'value' is 0, and its 'to' is the address of the safe that owns the transaction.
    *
    * This function retrieves that rejection transaction, and collects its confirmations as rejectors.
    *
@@ -114,6 +114,9 @@ export class MultisigTransactionExecutionDetailsMapper {
       transaction.nonce.toString(),
     );
 
+    // This only considers one page of nonce-sharing transactions, which
+    // would cover the vast majority of the cases. If needed, could be
+    // extended by requesting and iterating over multiple pages.
     const rejectionTx = rejectionTxsPage.results.find(
       (tx) => tx.safeTxHash != transaction.safeTxHash,
     );

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { isEmpty } from 'lodash';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { SafeRepository } from '../../../../domain/safe/safe.repository';
@@ -85,45 +84,44 @@ export class MultisigTransactionExecutionDetailsMapper {
   }
 
   /**
-   * Gets an array of {@link AddressInfo} representing the confirmations of the replacement
+   * Gets an array of {@link AddressInfo} representing the confirmations of the rejection
    * transaction for the {@link Transaction} passed in.
    *
-   * When a transaction is cancelled, another transaction replaces it, having the same nonce
-   * and isExecuted attribute set to true. This function retrieves that transaction, and
-   * collects its confirmations as rejectors.
+   * When a transaction is cancelled, another transaction acts as rejection.
+   * The rejection transaction has the same nonce of the transaction being cancelled,
+   * its value is 0, and it destination is the address of the safe that owns the transaction.
+   *
+   * This function retrieves that rejection transaction, and collects its confirmations as rejectors.
    *
    * @param chainId - chain id to use
    * @param transaction - transaction to use
    * @param safe - safe to use
-   * @returns confirmations for the replacement transaction
+   * @returns confirmations for the rejection transaction
    */
   private async _getRejectors(
     chainId: string,
     transaction: MultisigTransaction,
     safe: Safe,
   ): Promise<AddressInfo[]> {
-    const replacementTxsPage =
-      await this.safeRepository.getMultisigTransactions(
-        chainId,
-        safe.address,
-        true,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        transaction.nonce.toString(),
-      );
+    const rejectionTxsPage = await this.safeRepository.getMultisigTransactions(
+      chainId,
+      safe.address,
+      undefined,
+      undefined,
+      undefined,
+      safe.address,
+      '0',
+      transaction.nonce.toString(),
+    );
 
-    if (isEmpty(replacementTxsPage.results)) {
-      this.loggingService.debug(
-        `Replacement transaction with nonce ${transaction.nonce} not found for cancelled transaction ${transaction.transactionHash}`,
-      );
-      return [];
-    }
+    const rejectionTx = rejectionTxsPage.results.find(
+      (tx) => tx.safeTxHash != transaction.safeTxHash,
+    );
 
-    const replacementTx = replacementTxsPage.results[0];
-    return replacementTx.confirmations
-      ? replacementTx.confirmations.map((c) => new AddressInfo(c.owner))
-      : [];
+    return (
+      rejectionTx?.confirmations?.map(
+        (confirmation) => new AddressInfo(confirmation.owner),
+      ) ?? []
+    );
   }
 }


### PR DESCRIPTION
Closes #554 

This PR aims to change the logic behind `rejectors` attribute calculation. This attribute is filled with the owners `AddressInfo[]` related to the confirmations found for a rejection transaction. This PR changes the way this rejection transaction is picked up, specifically, the rejection transaction will be the first transaction verifying:
- `to` is the `Safe` address.
- `value` is `0`.
- `nonce` is the same as the nonce of the rejected transaction.
- `safeTxHash` differs from the `safeTxHash` of the rejected transaction (to avoid picking up the rejected transaction itself).