### PR TITLE
fix: return transaction value directly

### DIFF
--- a/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/domain/safe/entities/__tests__/multisig-transaction.builder.ts
@@ -49,7 +49,7 @@ export function multisigTransactionBuilder(): IBuilder<MultisigTransaction> {
     .with('to', faker.finance.ethereumAddress())
     .with('transactionHash', faker.string.hexadecimal({ length: HASH_LENGTH }))
     .with('trusted', faker.datatype.boolean())
-    .with('value', faker.string.hexadecimal());
+    .with('value', faker.string.numeric());
 }
 
 export function toJson(multisigTransaction: MultisigTransaction): unknown {

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.spec.ts
@@ -25,7 +25,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
   it('should build a CustomTransactionInfo with null actionCount', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
-    const value = faker.number.int();
     const dataSize = faker.number.int();
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder()
@@ -34,7 +33,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
-      value,
       dataSize,
       chainId,
     );
@@ -43,7 +41,34 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     expect(customTransaction).toMatchObject({
       to: toAddress,
       dataSize: dataSize.toString(),
-      value: value.toString(),
+      value: transaction.value,
+      methodName: transaction.dataDecoded?.method,
+      actionCount: null,
+      isCancellation: false,
+    });
+  });
+
+  it('should build a CustomTransactionInfo without scientific notation', async () => {
+    const toAddress = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
+    const dataSize = faker.number.int();
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder()
+      .with('value', '1000000000000000000000000') // 1e+24
+      .with('dataDecoded', dataDecodedBuilder().build())
+      .build();
+
+    const customTransaction = await mapper.mapCustomTransaction(
+      transaction,
+      dataSize,
+      chainId,
+    );
+
+    expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
+    expect(customTransaction).toMatchObject({
+      to: toAddress,
+      dataSize: dataSize.toString(),
+      value: transaction.value,
       methodName: transaction.dataDecoded?.method,
       actionCount: null,
       isCancellation: false,
@@ -54,7 +79,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = 'multiSend';
-    const value = faker.number.int();
     const dataSize = faker.number.int();
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder()
@@ -63,7 +87,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
-      value,
       dataSize,
       chainId,
     );
@@ -72,7 +95,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     expect(customTransaction).toMatchObject({
       to: toAddress,
       dataSize: dataSize.toString(),
-      value: value.toString(),
+      value: transaction.value,
       methodName: method,
       actionCount: null,
       isCancellation: false,
@@ -83,7 +106,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = 'multiSend';
-    const value = faker.number.int();
     const dataSize = faker.number.int();
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder()
@@ -107,7 +129,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
-      value,
       dataSize,
       chainId,
     );
@@ -116,7 +137,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     expect(customTransaction).toMatchObject({
       to: toAddress,
       dataSize: dataSize.toString(),
-      value: value.toString(),
+      value: transaction.value,
       methodName: method,
       actionCount: 3,
       isCancellation: false,
@@ -127,13 +148,13 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
     const method = faker.word.sample();
-    const value = faker.number.int();
+    const value = '0';
     const dataSize = 0;
     const chainId = faker.string.numeric();
     const transaction = multisigTransactionBuilder()
       .with('to', toAddress.value)
       .with('safe', toAddress.value)
-      .with('value', '0')
+      .with('value', value)
       .with('operation', 0)
       .with('baseGas', 0)
       .with('gasPrice', '0')
@@ -145,7 +166,6 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
 
     const customTransaction = await mapper.mapCustomTransaction(
       transaction,
-      value,
       dataSize,
       chainId,
     );
@@ -154,7 +174,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     expect(customTransaction).toMatchObject({
       to: toAddress,
       dataSize: dataSize.toString(),
-      value: value.toString(),
+      value,
       methodName: method,
       actionCount: null,
       isCancellation: true,

--- a/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/common/custom-transaction.mapper.ts
@@ -15,7 +15,6 @@ export class CustomTransactionMapper {
 
   async mapCustomTransaction(
     transaction: MultisigTransaction | ModuleTransaction,
-    value: number,
     dataSize: number,
     chainId: string,
   ): Promise<CustomTransactionInfo> {
@@ -28,7 +27,7 @@ export class CustomTransactionMapper {
     return new CustomTransactionInfo(
       toAddressInfo,
       dataSize.toString(),
-      value.toString(),
+      transaction.value,
       transaction?.dataDecoded?.method ?? null,
       this.getActionCount(transaction),
       this.isCancellation(transaction, dataSize),

--- a/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
+import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
 import {
@@ -16,6 +17,7 @@ export class NativeCoinTransferMapper {
   async mapNativeCoinTransfer(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
+    safe: Safe,
   ): Promise<TransferTransactionInfo> {
     const recipient = await this.addressInfoHelper.getOrDefault(
       chainId,
@@ -24,7 +26,7 @@ export class NativeCoinTransferMapper {
     );
 
     return new TransferTransactionInfo(
-      new AddressInfo(transaction.safe),
+      new AddressInfo(safe.address),
       recipient,
       TransferDirection.Outgoing,
       new NativeCoinTransfer(transaction.value),

--- a/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
 import {
@@ -17,7 +16,6 @@ export class NativeCoinTransferMapper {
   async mapNativeCoinTransfer(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
-    safe: Safe,
   ): Promise<TransferTransactionInfo> {
     const recipient = await this.addressInfoHelper.getOrDefault(
       chainId,
@@ -26,7 +24,7 @@ export class NativeCoinTransferMapper {
     );
 
     return new TransferTransactionInfo(
-      new AddressInfo(safe.address),
+      new AddressInfo(transaction.safe),
       recipient,
       TransferDirection.Outgoing,
       new NativeCoinTransfer(transaction.value),

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -60,7 +60,6 @@ export class MultisigTransactionInfoMapper {
     if (this.isCustomTransaction(value, dataSize, transaction.operation)) {
       return await this.customTransactionMapper.mapCustomTransaction(
         transaction,
-        value,
         dataSize,
         chainId,
       );
@@ -126,7 +125,6 @@ export class MultisigTransactionInfoMapper {
 
     return this.customTransactionMapper.mapCustomTransaction(
       transaction,
-      value,
       dataSize,
       chainId,
     );

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -2,7 +2,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import { Operation } from '../../../../domain/safe/entities/operation.entity';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { TokenRepository } from '../../../../domain/tokens/token.repository';
 import { ITokenRepository } from '../../../../domain/tokens/token.repository.interface';
 import { TokenType } from '../../../balances/entities/token-type.entity';
@@ -47,7 +46,6 @@ export class MultisigTransactionInfoMapper {
   async mapTransactionInfo(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
-    safe: Safe,
   ): Promise<TransactionInfo> {
     const value = Number(transaction?.value) || 0;
     const dataByteLength = transaction.data
@@ -69,7 +67,6 @@ export class MultisigTransactionInfoMapper {
       return this.nativeCoinTransferMapper.mapNativeCoinTransfer(
         chainId,
         transaction,
-        safe,
       );
     }
 

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import { Operation } from '../../../../domain/safe/entities/operation.entity';
+import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { TokenRepository } from '../../../../domain/tokens/token.repository';
 import { ITokenRepository } from '../../../../domain/tokens/token.repository.interface';
 import { TokenType } from '../../../balances/entities/token-type.entity';
@@ -46,6 +47,7 @@ export class MultisigTransactionInfoMapper {
   async mapTransactionInfo(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
+    safe: Safe,
   ): Promise<TransactionInfo> {
     const value = Number(transaction?.value) || 0;
     const dataByteLength = transaction.data
@@ -67,6 +69,7 @@ export class MultisigTransactionInfoMapper {
       return this.nativeCoinTransferMapper.mapNativeCoinTransfer(
         chainId,
         transaction,
+        safe,
       );
     }
 


### PR DESCRIPTION
This fixes high values from being returned in scientific notation for custom transactions. The value of the transaction is returned directly instead.

`mapCustomTransaction` was returning the casted number of transaction values. This meant very high values were being returned in scientific notation:

```js
Number('1000000000000000000000000').toString() === '1e+24'
```

Example transaction on the [transaction service](https://safe-transaction-gnosis-chain.safe.global/api/v1/multisig-transactions/0xba31bc6dbda0ad9451e087843b96ba6bccc1d2cbbb8c9ac52df20f105cf727ea/) and on the [gateway](https://safe-client.safe.global/v1/chains/100/transactions/multisig_0x10E4597fF93cbee194F4879f8f1d54a370DB6969_0xba31bc6dbda0ad9451e087843b96ba6bccc1d2cbbb8c9ac52df20f105cf727ea).