### PR TITLE
Change exchange call

### DIFF
--- a/src/datasources/exchange-api/exchange-api.service.spec.ts
+++ b/src/datasources/exchange-api/exchange-api.service.spec.ts
@@ -75,8 +75,8 @@ describe('ExchangeApi', () => {
 
     expect(mockCacheFirstDataSource.get).toBeCalledWith(
       new CacheDir('exchange_fiat_codes', ''),
-      `${exchangeBaseUri}/symbols`,
-      { headers: { apikey: exchangeApiKey } },
+      `${exchangeBaseUri}/symbols?access_key=${exchangeApiKey}`,
+      {},
       ttl, // 60 seconds
     );
   });
@@ -113,8 +113,8 @@ describe('ExchangeApi', () => {
 
     expect(mockCacheFirstDataSource.get).toBeCalledWith(
       new CacheDir('exchange_rates', ''),
-      `${exchangeBaseUri}/latest`,
-      { headers: { apikey: exchangeApiKey } },
+      `${exchangeBaseUri}/latest?access_key=${exchangeApiKey}`,
+      {},
       ttl, // 60 seconds
     );
   });

--- a/src/datasources/exchange-api/exchange-api.service.ts
+++ b/src/datasources/exchange-api/exchange-api.service.ts
@@ -31,10 +31,8 @@ export class ExchangeApi implements IExchangeApi {
     try {
       return await this.dataSource.get<ExchangeFiatCodes>(
         CacheRouter.getExchangeFiatCodesCacheDir(),
-        `${this.baseUrl}/symbols`,
-        {
-          headers: { apikey: this.apiKey },
-        },
+        `${this.baseUrl}/symbols?access_key=${this.apiKey}`,
+        {},
         this.cacheTtlSeconds,
       );
     } catch (error) {
@@ -46,10 +44,8 @@ export class ExchangeApi implements IExchangeApi {
     try {
       return await this.dataSource.get<ExchangeRates>(
         CacheRouter.getExchangeRatesCacheDir(),
-        `${this.baseUrl}/latest`,
-        {
-          headers: { apikey: this.apiKey },
-        },
+        `${this.baseUrl}/latest?access_key=${this.apiKey}`,
+        {},
         this.cacheTtlSeconds,
       );
     } catch (error) {

--- a/src/routes/balances/balances.controller.spec.ts
+++ b/src/routes/balances/balances.controller.spec.ts
@@ -25,6 +25,7 @@ describe('Balances Controller (Unit)', () => {
   let safeConfigUrl;
   let exchangeUrl;
   let networkService;
+  let exchangeApiKey;
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -45,6 +46,7 @@ describe('Balances Controller (Unit)', () => {
     const configurationService = moduleFixture.get(IConfigurationService);
     safeConfigUrl = configurationService.get('safeConfig.baseUri');
     exchangeUrl = configurationService.get('exchange.baseUri');
+    exchangeApiKey = configurationService.get('exchange.apiKey');
     networkService = moduleFixture.get(NetworkService);
 
     app = await new TestAppProvider().provide(moduleFixture);
@@ -75,7 +77,9 @@ describe('Balances Controller (Unit)', () => {
           return Promise.resolve({
             data: transactionApiBalancesResponse,
           });
-        } else if (url == `${exchangeUrl}/latest`) {
+        } else if (
+          url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+        ) {
           return Promise.resolve({ data: exchangeApiResponse });
         } else {
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -116,7 +120,9 @@ describe('Balances Controller (Unit)', () => {
       expect(networkService.get.mock.calls[1][1]).toStrictEqual({
         params: { trusted: undefined, exclude_spam: undefined },
       });
-      expect(networkService.get.mock.calls[2][0]).toBe(`${exchangeUrl}/latest`);
+      expect(networkService.get.mock.calls[2][0]).toBe(
+        `${exchangeUrl}/latest?access_key=${exchangeApiKey}`,
+      );
     });
 
     it(`excludeSpam and trusted params are forwarded to tx service`, async () => {
@@ -138,7 +144,9 @@ describe('Balances Controller (Unit)', () => {
           return Promise.resolve({
             data: transactionApiBalancesResponse,
           });
-        } else if (url == `${exchangeUrl}/latest`) {
+        } else if (
+          url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+        ) {
           return Promise.resolve({ data: exchangeApiResponse });
         } else {
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -180,7 +188,9 @@ describe('Balances Controller (Unit)', () => {
           return Promise.resolve({
             data: transactionApiBalancesResponse,
           });
-        } else if (url == `${exchangeUrl}/latest`) {
+        } else if (
+          url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+        ) {
           return Promise.resolve({ data: exchangeApiResponse });
         } else {
           return Promise.reject(new Error(`Could not match ${url}`));
@@ -281,7 +291,9 @@ describe('Balances Controller (Unit)', () => {
             return Promise.resolve({
               data: transactionApiBalancesResponse,
             });
-          } else if (url == `${exchangeUrl}/latest`) {
+          } else if (
+            url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+          ) {
             return Promise.resolve({ data: exchangeApiResponse });
           } else {
             return Promise.reject(new Error(`Could not match ${url}`));
@@ -319,7 +331,9 @@ describe('Balances Controller (Unit)', () => {
             return Promise.resolve({
               data: transactionApiBalancesResponse,
             });
-          } else if (url == `${exchangeUrl}/latest`) {
+          } else if (
+            url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+          ) {
             return Promise.resolve({ data: exchangeApiResponse });
           } else {
             return Promise.reject(new Error(`Could not match ${url}`));
@@ -357,7 +371,9 @@ describe('Balances Controller (Unit)', () => {
             return Promise.resolve({
               data: transactionApiBalancesResponse,
             });
-          } else if (url == `${exchangeUrl}/latest`) {
+          } else if (
+            url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+          ) {
             return Promise.resolve({ data: exchangeApiResponse });
           } else {
             return Promise.reject(new Error(`Could not match ${url}`));
@@ -396,7 +412,9 @@ describe('Balances Controller (Unit)', () => {
             return Promise.resolve({
               data: transactionApiBalancesResponse,
             });
-          } else if (url == `${exchangeUrl}/latest`) {
+          } else if (
+            url == `${exchangeUrl}/latest?access_key=${exchangeApiKey}`
+          ) {
             return Promise.resolve({ data: exchangeApiResponse });
           } else {
             return Promise.reject(new Error(`Could not match ${url}`));


### PR DESCRIPTION
Closes https://github.com/5afe/safe-support/issues/233

This is caused because our third-party exchange for prices is not accepting the API key as a header anymore, it's required to be in the request as a query param.

