### PR TITLE
refactor: remove unnecessary `Safe` usage

### DIFF
--- a/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/get-transaction-by-id.transactions.controller.spec.ts
@@ -86,7 +86,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(2);
+    expect(networkService.get).toBeCalledTimes(1);
     expect(networkService.get).toBeCalledWith(getChainUrl, undefined);
   });
 
@@ -117,7 +117,7 @@ describe('Get by id - Transactions Controller (Unit)', () => {
         code: 500,
       });
 
-    expect(networkService.get).toBeCalledTimes(4);
+    expect(networkService.get).toBeCalledTimes(2);
     expect(networkService.get).toBeCalledWith(getChainUrl, undefined);
     expect(networkService.get).toBeCalledWith(
       getModuleTransactionUrl,

--- a/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-module-transactions-by-safe.transactions.controller.spec.ts
@@ -126,7 +126,6 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
     const safeAddress = faker.finance.ethereumAddress();
     const chainResponse = chainBuilder().with('chainId', chainId).build();
     networkService.get.mockResolvedValueOnce({ data: chainResponse });
-    networkService.get.mockResolvedValueOnce({ data: { results: [] } });
     networkService.get.mockRejectedValueOnce({
       status: 404,
     });
@@ -139,7 +138,7 @@ describe('List module transactions by Safe - Transactions Controller (Unit)', ()
         code: 404,
       });
 
-    expect(networkService.get).toBeCalledTimes(3);
+    expect(networkService.get).toBeCalledTimes(2);
     expect(networkService.get).toBeCalledWith(
       `${safeConfigUrl}/api/v1/chains/${chainId}`,
       undefined,

--- a/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
+++ b/src/routes/transactions/mappers/common/native-coin-transfer.mapper.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { AddressInfo } from '../../../common/entities/address-info.entity';
 import {
@@ -17,7 +16,6 @@ export class NativeCoinTransferMapper {
   async mapNativeCoinTransfer(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
-    safe: Safe,
   ): Promise<TransferTransactionInfo> {
     const recipient = await this.addressInfoHelper.getOrDefault(
       chainId,
@@ -26,7 +24,7 @@ export class NativeCoinTransferMapper {
     );
 
     return new TransferTransactionInfo(
-      new AddressInfo(safe.address),
+      new AddressInfo(transaction.safe),
       recipient,
       TransferDirection.Outgoing,
       new NativeCoinTransfer(transaction.value),

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -1,8 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
-import { Operation } from '../../../../domain/safe/entities/operation.entity';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { TokenRepository } from '../../../../domain/tokens/token.repository';
 import { ITokenRepository } from '../../../../domain/tokens/token.repository.interface';
 import { TokenType } from '../../../balances/entities/token-type.entity';
@@ -47,7 +45,6 @@ export class MultisigTransactionInfoMapper {
   async mapTransactionInfo(
     chainId: string,
     transaction: MultisigTransaction | ModuleTransaction,
-    safe: Safe,
   ): Promise<TransactionInfo> {
     const value = Number(transaction?.value) || 0;
     const dataByteLength = transaction.data
@@ -57,19 +54,10 @@ export class MultisigTransactionInfoMapper {
     const dataSize =
       dataByteLength >= 2 ? Math.floor((dataByteLength - 2) / 2) : 0;
 
-    if (this.isCustomTransaction(value, dataSize, transaction.operation)) {
-      return await this.customTransactionMapper.mapCustomTransaction(
-        transaction,
-        dataSize,
-        chainId,
-      );
-    }
-
     if (this.isNativeCoinTransfer(value, dataSize)) {
       return this.nativeCoinTransferMapper.mapNativeCoinTransfer(
         chainId,
         transaction,
-        safe,
       );
     }
 
@@ -128,14 +116,6 @@ export class MultisigTransactionInfoMapper {
       dataSize,
       chainId,
     );
-  }
-
-  private isCustomTransaction(
-    value: number,
-    dataSize: number,
-    operation: Operation,
-  ): boolean {
-    return (value > 0 && dataSize > 0) || operation !== 0;
   }
 
   private isNativeCoinTransfer(value: number, dataSize: number): boolean {

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.spec.ts
@@ -61,7 +61,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       trustedDelegateCallTarget,
     );
 
-    const actual = await mapper.mapDetails(chainId, transaction, safe);
+    const actual = await mapper.mapDetails(chainId, transaction);
 
     expect(actual).toEqual({
       safeAddress: safe.address,
@@ -109,7 +109,7 @@ describe('ModuleTransactionDetails mapper (Unit)', () => {
       trustedDelegateCallTarget,
     );
 
-    const actual = await mapper.mapDetails(chainId, transaction, safe);
+    const actual = await mapper.mapDetails(chainId, transaction);
 
     expect(actual).toEqual({
       safeAddress: safe.address,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction-details.mapper.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { isEmpty } from 'lodash';
 import { ModuleTransaction } from '../../../../domain/safe/entities/module-transaction.entity';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import {
   MODULE_TRANSACTION_PREFIX,
@@ -26,19 +25,18 @@ export class ModuleTransactionDetailsMapper {
   async mapDetails(
     chainId: string,
     transaction: ModuleTransaction,
-    safe: Safe,
   ): Promise<TransactionDetails> {
     const [moduleAddress, txInfo, txData] = await Promise.all([
       this.addressInfoHelper.getOrDefault(chainId, transaction.module, [
         'CONTRACT',
       ]),
-      this.transactionInfoMapper.mapTransactionInfo(chainId, transaction, safe),
+      this.transactionInfoMapper.mapTransactionInfo(chainId, transaction),
       this.mapTransactionData(chainId, transaction),
     ]);
 
     return {
-      safeAddress: safe.address,
-      txId: `${MODULE_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${safe.address}${TRANSACTION_ID_SEPARATOR}${transaction.moduleTransactionId}`,
+      safeAddress: transaction.safe,
+      txId: `${MODULE_TRANSACTION_PREFIX}${TRANSACTION_ID_SEPARATOR}${transaction.safe}${TRANSACTION_ID_SEPARATOR}${transaction.moduleTransactionId}`,
       executedAt: transaction.executionDate?.getTime() ?? null,
       txStatus: this.statusMapper.mapTransactionStatus(transaction),
       txInfo,

--- a/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/module-transactions/module-transaction.mapper.ts
@@ -1,6 +1,5 @@
 import { AddressInfoHelper } from '../../../common/address-info/address-info.helper';
 import { Injectable } from '@nestjs/common';
-import { Safe } from '../../../../domain/safe/entities/safe.entity';
 import { Transaction } from '../../entities/transaction.entity';
 import { MultisigTransactionInfoMapper } from '../common/transaction-info.mapper';
 import { ModuleTransactionStatusMapper } from './module-transaction-status.mapper';
@@ -22,13 +21,11 @@ export class ModuleTransactionMapper {
   async mapTransaction(
     chainId: string,
     transaction: ModuleTransaction,
-    safe: Safe,
   ): Promise<Transaction> {
     const txStatus = this.statusMapper.mapTransactionStatus(transaction);
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
       chainId,
       transaction,
-      safe,
     );
     const executionInfo = new ModuleExecutionInfo(
       await this.addressInfoHelper.getOrDefault(chainId, transaction.module, [

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-details.mapper.ts
@@ -52,7 +52,7 @@ export class MultisigTransactionDetailsMapper {
         transaction.dataDecoded,
       ),
       this.safeAppInfoMapper.mapSafeAppInfo(chainId, transaction),
-      this.transactionInfoMapper.mapTransactionInfo(chainId, transaction, safe),
+      this.transactionInfoMapper.mapTransactionInfo(chainId, transaction),
       this.multisigTransactionExecutionDetailsMapper.mapMultisigExecutionDetails(
         chainId,
         transaction,

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction.mapper.ts
@@ -29,7 +29,6 @@ export class MultisigTransactionMapper {
     const txInfo = await this.transactionInfoMapper.mapTransactionInfo(
       chainId,
       transaction,
-      safe,
     );
     const executionInfo = this.executionInfoMapper.mapExecutionInfo(
       transaction,

--- a/src/routes/transactions/mappers/transaction-preview.mapper.ts
+++ b/src/routes/transactions/mappers/transaction-preview.mapper.ts
@@ -53,7 +53,6 @@ export class TransactionPreviewMapper {
         data: previewTransactionDto.data,
         operation: previewTransactionDto.operation,
       },
-      safe,
     );
     const txData = await this.transactionDataMapper.mapTransactionData(
       chainId,

--- a/src/routes/transactions/mappers/transactions-history.mapper.ts
+++ b/src/routes/transactions/mappers/transactions-history.mapper.ts
@@ -191,7 +191,6 @@ export class TransactionsHistoryMapper {
             await this.moduleTransactionMapper.mapTransaction(
               chainId,
               transaction as ModuleTransaction,
-              safe,
             ),
           );
         } else if (isEthereumTransaction(transaction)) {

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -57,15 +57,10 @@ export class TransactionsService {
 
     switch (txType) {
       case MODULE_TRANSACTION_PREFIX: {
-        const [tx, safe] = await Promise.all([
+        const [tx] = await Promise.all([
           this.safeRepository.getModuleTransaction(chainId, id),
-          this.safeRepository.getSafe(chainId, safeAddress),
         ]);
-        return this.moduleTransactionDetailsMapper.mapDetails(
-          chainId,
-          tx,
-          safe,
-        );
+        return this.moduleTransactionDetailsMapper.mapDetails(chainId, tx);
       }
 
       case TRANSFER_PREFIX: {
@@ -201,8 +196,6 @@ export class TransactionsService {
       paginationData?.offset,
     );
 
-    const safeInfo = await this.safeRepository.getSafe(chainId, safeAddress);
-
     const results = await Promise.all(
       domainTransactions.results.map(
         async (domainTransaction) =>
@@ -210,7 +203,6 @@ export class TransactionsService {
             await this.moduleTransactionMapper.mapTransaction(
               chainId,
               domainTransaction,
-              safeInfo,
             ),
           ),
       ),


### PR DESCRIPTION
This removes the `safe` argument from `mapNativeCoinTransfer` and updates all relevant other functions and tests accordingly.