### PR TITLE
Add configuration param for contract/token not found cache TTL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,6 +22,8 @@
 # The default cache expiration time in seconds if none is set
 # (default=60)
 #EXPIRATION_TIME_DEFAULT_SECONDS
+#CONTRACT_NOT_FOUND_ERROR_TTL_SECONDS
+#TOKEN_NOT_FOUND_ERROR_TTL_SECONDS
 
 # Authorization token to use privileged endpoints.
 # The AUTH_TOKEN should always be set

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -24,6 +24,10 @@ export default (): ReturnType<typeof configuration> => ({
     level: 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
+  notFoundErrorTTLSeconds: {
+    contract: faker.number.int(),
+    token: faker.number.int(),
+  },
   redis: {
     host: faker.internet.domainName(),
     port: faker.internet.port().toString(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -31,6 +31,14 @@ export default () => ({
     level: process.env.LOG_LEVEL || 'debug',
     silent: process.env.LOG_SILENT?.toLowerCase() === 'true',
   },
+  notFoundErrorTTLSeconds: {
+    contract: parseInt(
+      process.env.CONTRACT_NOT_FOUND_ERROR_TTL_SECONDS ?? `${60 * 60}`,
+    ),
+    token: parseInt(
+      process.env.TOKEN_NOT_FOUND_ERROR_TTL_SECONDS ?? `${60 * 60}`,
+    ),
+  },
   redis: {
     host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || '6379',

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -53,10 +53,15 @@ describe('Transaction API Manager Tests', () => {
       .with('vpcTransactionService', vpcTxServiceUrl)
       .build();
     const expirationTimeInSeconds = faker.number.int();
+    const notFoundErrorTTLSeconds = faker.number.int();
     configurationServiceMock.getOrThrow.mockImplementation((key) => {
       if (key === 'safeTransaction.useVpcUrl') return useVpcUrl;
       else if (key === 'expirationTimeInSeconds.default')
         return expirationTimeInSeconds;
+      else if (key === 'notFoundErrorTTLSeconds.contract')
+        return notFoundErrorTTLSeconds;
+      else if (key === 'notFoundErrorTTLSeconds.token')
+        return notFoundErrorTTLSeconds;
       throw new Error(`Unexpected key: ${key}`);
     });
     configApiMock.getChain.mockResolvedValue(chain);

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -40,17 +40,24 @@ describe('TransactionApi', () => {
   const baseUrl = faker.internet.url({ appendSlash: false });
   let service: TransactionApi;
   let defaultExpirationTimeInSeconds: number;
+  let notFoundErrorTTLSeconds: number;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     defaultExpirationTimeInSeconds = faker.number.int();
+    notFoundErrorTTLSeconds = faker.number.int();
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'expirationTimeInSeconds.default') {
         return defaultExpirationTimeInSeconds;
-      } else {
-        throw Error(`Unexpected key: ${key}`);
       }
+      if (key === 'notFoundErrorTTLSeconds.contract') {
+        return notFoundErrorTTLSeconds;
+      }
+      if (key === 'notFoundErrorTTLSeconds.token') {
+        return notFoundErrorTTLSeconds;
+      }
+      throw Error(`Unexpected key: ${key}`);
     });
 
     service = new TransactionApi(

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -30,6 +30,8 @@ import { IConfigurationService } from '../../config/configuration.service.interf
 
 export class TransactionApi implements ITransactionApi {
   private readonly defaultExpirationTimeInSeconds: number;
+  private readonly tokenNotFoundErrorTTLSeconds: number;
+  private readonly contractNotFoundErrorTTLSeconds: number;
 
   constructor(
     private readonly chainId: string,
@@ -43,6 +45,14 @@ export class TransactionApi implements ITransactionApi {
     this.defaultExpirationTimeInSeconds =
       this.configurationService.getOrThrow<number>(
         'expirationTimeInSeconds.default',
+      );
+    this.tokenNotFoundErrorTTLSeconds =
+      this.configurationService.getOrThrow<number>(
+        'notFoundErrorTTLSeconds.token',
+      );
+    this.contractNotFoundErrorTTLSeconds =
+      this.configurationService.getOrThrow<number>(
+        'notFoundErrorTTLSeconds.contract',
       );
   }
 
@@ -205,6 +215,7 @@ export class TransactionApi implements ITransactionApi {
         url,
         undefined,
         this.defaultExpirationTimeInSeconds,
+        this.contractNotFoundErrorTTLSeconds,
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -674,6 +685,7 @@ export class TransactionApi implements ITransactionApi {
         url,
         undefined,
         this.defaultExpirationTimeInSeconds,
+        this.tokenNotFoundErrorTTLSeconds,
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);


### PR DESCRIPTION
Closes #577 

This PR:
 - Adds a CONTRACT_NOT_FOUND_ERROR_TTL_SECONDS environment variable to configure the time to live for cached errors regarding the contracts retrieval from the TX Service.
 -  - Adds a TOKEN_NOT_FOUND_ERROR_TTL_SECONDS environment variable to configure the time to live for cached errors regarding the tokens retrieval from the TX Service.
 - Modifies both production and testing `configuration.ts` accordingly.
 - Adds a unit test checking the new configuration option is passed to the  `CacheFirstDataSource` and to the underlying `CacheService` implementations.