### PR TITLE
Enable keepAlive for http/s connections

### DIFF
--- a/src/datasources/network/network.module.ts
+++ b/src/datasources/network/network.module.ts
@@ -3,6 +3,7 @@ import { AxiosNetworkService } from './axios.network.service';
 import { NetworkService } from './network.service.interface';
 import axios, { Axios } from 'axios';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import * as http from 'http';
 
 /**
  * Use this factory to add any default parameter to the
@@ -12,7 +13,11 @@ function axiosFactory(configurationService: IConfigurationService): Axios {
   const requestTimeout = configurationService.getOrThrow<number>(
     'httpClient.requestTimeout',
   );
-  return axios.create({ timeout: requestTimeout });
+  return axios.create({
+    timeout: requestTimeout,
+    httpAgent: new http.Agent({ keepAlive: true }),
+    httpsAgent: new http.Agent({ keepAlive: true }),
+  });
 }
 
 /**


### PR DESCRIPTION
- Sets the axios network client to keep-alive connections done both with http and https