### PR TITLE
Add limit parameter for all-transactions call when retrieving the last transaction

### DIFF
--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -137,6 +137,7 @@ export class SafesService {
       await this.safeRepository.getTransactionHistoryByExecutionDate(
         chainId,
         safeAddress,
+        1,
       )
     ).results[0];
 


### PR DESCRIPTION
Closes #582 

- Adds the `limit` parameter for all-transactions call when retrieving the last transaction.