### PR TITLE
Update coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Safe Client Gateway
 
-[![Coverage Status](https://coveralls.io/repos/github/5afe/safe-client-gateway-nest/badge.svg?branch=main)](https://coveralls.io/github/5afe/safe-client-gateway-nest?branch=main)
-
+[![Coverage Status](https://coveralls.io/repos/github/safe-global/safe-client-gateway-nest/badge.svg?branch=main)](https://coveralls.io/github/safe-global/safe-client-gateway-nest?branch=main)
 ## Requirements
 
 - Node 18.16.0 – https://nodejs.org/en/


### PR DESCRIPTION
The Coveralls link was using the previous org, `5afe`, instead of `safe-global`.