### PR TITLE
Add Promise Registry

### DIFF
--- a/src/datasources/promise/promise-registry.module.ts
+++ b/src/datasources/promise/promise-registry.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { PromiseRegistry } from './promise-registry';
+
+function registryFactory(): Record<string, Promise<unknown>> {
+  return {};
+}
+
+@Module({
+  providers: [
+    { provide: 'Registry', useFactory: registryFactory },
+    PromiseRegistry,
+  ],
+  exports: [PromiseRegistry],
+})
+export class PromiseRegistryModule {}

--- a/src/datasources/promise/promise-registry.spec.ts
+++ b/src/datasources/promise/promise-registry.spec.ts
@@ -1,0 +1,44 @@
+import { PromiseRegistry } from './promise-registry';
+
+describe('Promise Registry tests', () => {
+  let promiseRegistry: PromiseRegistry<string>;
+  let registry: Record<string, Promise<unknown>>;
+
+  beforeEach(() => {
+    registry = {};
+    promiseRegistry = new PromiseRegistry(registry);
+  });
+
+  it('registration is successful', () => {
+    const promise = Promise.resolve();
+
+    promiseRegistry.register('foo', () => promise);
+
+    expect(Object.keys(registry)).toEqual(['foo']);
+  });
+
+  it('promise is deleted upon successful completion', async () => {
+    const promise = Promise.resolve();
+
+    await promiseRegistry.register('foo', () => promise);
+
+    expect(Object.keys(registry)).toEqual([]);
+  });
+
+  it('promise is deleted upon error completion', async () => {
+    const promise = Promise.reject('random error');
+
+    await promiseRegistry.register('foo', () => promise).catch(() => {});
+
+    expect(Object.keys(registry)).toEqual([]);
+  });
+
+  it('ongoing promise with same key is returned', async () => {
+    registry['foo'] = Promise.resolve('ongoing');
+    const promise = Promise.resolve('new');
+
+    const actual = await promiseRegistry.register('foo', () => promise);
+
+    expect(actual).toBe('ongoing');
+  });
+});

--- a/src/datasources/promise/promise-registry.ts
+++ b/src/datasources/promise/promise-registry.ts
@@ -1,0 +1,39 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PromiseRegistry<K extends keyof any> {
+  constructor(
+    @Inject('Registry') private readonly registry: Record<K, Promise<unknown>>,
+  ) {}
+
+  /**
+   * Registers a function to be executed with a key. If there's a matching execution,
+   * that promise is returned.
+   *
+   * If there is no match, the function is registered with the provided key.
+   *
+   * Once the promise is settled, it is removed from the registry.
+   *
+   * @param key - the key used to register the provided promise
+   * @param fn - the function to be executed
+   */
+  async register<V>(key: string, fn: () => V): Promise<V> {
+    const activePromise = this.registry[key];
+    if (activePromise) return activePromise;
+
+    const promise = new Promise<V>(async (resolve, reject) => {
+      try {
+        const result = await fn();
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      } finally {
+        delete this.registry[key];
+      }
+    });
+
+    this.registry[key] = promise;
+
+    return promise;
+  }
+}

--- a/src/datasources/transaction-api/transaction-api.manager.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.spec.ts
@@ -7,6 +7,7 @@ import { CacheFirstDataSource } from '../cache/cache.first.data.source';
 import { HttpErrorFactory } from '../errors/http-error-factory';
 import { chainBuilder } from '../../domain/chains/entities/__tests__/chain.builder';
 import { faker } from '@faker-js/faker';
+import { PromiseRegistry } from '../promise/promise-registry';
 
 const configurationService = {
   getOrThrow: jest.fn(),
@@ -74,6 +75,7 @@ describe('Transaction API Manager Tests', () => {
       cacheService,
       httpErrorFactory,
       networkService,
+      new PromiseRegistry<string>({}),
     );
 
     const transactionApi = await target.getTransactionApi(chain.chainId);

--- a/src/datasources/transaction-api/transaction-api.manager.ts
+++ b/src/datasources/transaction-api/transaction-api.manager.ts
@@ -11,6 +11,7 @@ import {
   NetworkService,
 } from '../network/network.service.interface';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { PromiseRegistry } from '../promise/promise-registry';
 
 @Injectable()
 export class TransactionApiManager implements ITransactionApiManager {
@@ -26,6 +27,7 @@ export class TransactionApiManager implements ITransactionApiManager {
     @Inject(CacheService) private readonly cacheService: ICacheService,
     private readonly httpErrorFactory: HttpErrorFactory,
     @Inject(NetworkService) private readonly networkService: INetworkService,
+    private readonly promiseRegistry: PromiseRegistry<string>,
   ) {
     this.useVpcUrl = this.configurationService.getOrThrow<boolean>(
       'safeTransaction.useVpcUrl',
@@ -45,6 +47,7 @@ export class TransactionApiManager implements ITransactionApiManager {
       this.configurationService,
       this.httpErrorFactory,
       this.networkService,
+      this.promiseRegistry,
     );
     return this.transactionApiMap[chainId];
   }

--- a/src/datasources/transaction-api/transaction-api.module.ts
+++ b/src/datasources/transaction-api/transaction-api.module.ts
@@ -3,10 +3,11 @@ import { TransactionApiManager } from './transaction-api.manager';
 import { CacheFirstDataSourceModule } from '../cache/cache.first.data.source.module';
 import { ITransactionApiManager } from '../../domain/interfaces/transaction-api.manager.interface';
 import { HttpErrorFactory } from '../errors/http-error-factory';
+import { PromiseRegistryModule } from '../promise/promise-registry.module';
 
 @Global()
 @Module({
-  imports: [CacheFirstDataSourceModule],
+  imports: [CacheFirstDataSourceModule, PromiseRegistryModule],
   providers: [
     HttpErrorFactory,
     { provide: ITransactionApiManager, useClass: TransactionApiManager },

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -10,6 +10,7 @@ import { backboneBuilder } from '../../domain/backbone/entities/__tests__/backbo
 import { balanceBuilder } from '../../domain/balances/entities/__tests__/balance.builder';
 import { CacheDir } from '../cache/entities/cache-dir.entity';
 import { IConfigurationService } from '../../config/configuration.service.interface';
+import { PromiseRegistry } from '../promise/promise-registry';
 
 const dataSource = {
   get: jest.fn(),
@@ -71,6 +72,7 @@ describe('TransactionApi', () => {
       mockConfigurationService,
       mockHttpErrorFactory,
       networkService,
+      new PromiseRegistry<string>({}),
     );
   });
 


### PR DESCRIPTION
- Introduces a Promise Registry – the goal of this registry is to have a mapping between a deterministic key and a promise in order to represent active promises (e.g. ongoing requests).
- If a promise for key `K` is already registered and the service requests a promise for the same `K`, the already active promise is then returned instead to the caller.
- Upon termination, the promise is also removed from the registry (this behavior is transparent to the caller).
- The `PromiseRegistry` is provided via the `PromiseRegistryModule` – currently this module is not global and is being used only by the `TransactionApi`. Making it more global to the project can be considered depending on how it will be used.