### PR TITLE
refactor: add `getPromiseRegistryKey` helper to `transaction-api.service`

### DIFF
--- a/src/datasources/promise/promise-registry.spec.ts
+++ b/src/datasources/promise/promise-registry.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { PromiseRegistry } from './promise-registry';
 
 describe('Promise Registry tests', () => {
@@ -10,26 +11,32 @@ describe('Promise Registry tests', () => {
   });
 
   it('registration is successful', () => {
+    const key = faker.string.sample();
+
     const promise = Promise.resolve();
 
-    promiseRegistry.register({ key: 'foo', field: 'bar' }, () => promise);
+    promiseRegistry.register(key, () => promise);
 
-    expect(Object.keys(registry)).toEqual(['foobar']);
+    expect(Object.keys(registry)).toEqual([key]);
   });
 
   it('promise is deleted upon successful completion', async () => {
+    const key = faker.string.sample();
+
     const promise = Promise.resolve();
 
-    await promiseRegistry.register({ key: 'foo', field: 'bar' }, () => promise);
+    await promiseRegistry.register(key, () => promise);
 
     expect(Object.keys(registry)).toEqual([]);
   });
 
   it('promise is deleted upon error completion', async () => {
+    const key = faker.string.sample();
+
     const promise = Promise.reject('random error');
 
     await promiseRegistry
-      .register({ key: 'foo', field: 'bar' }, () => promise)
+      .register(key, () => promise)
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .catch(() => {});
 
@@ -37,13 +44,12 @@ describe('Promise Registry tests', () => {
   });
 
   it('ongoing promise with same key is returned', async () => {
-    registry['foobar'] = Promise.resolve('ongoing');
+    const key = faker.string.sample();
+
+    registry[key] = Promise.resolve('ongoing');
     const promise = Promise.resolve('new');
 
-    const actual = await promiseRegistry.register(
-      { key: 'foo', field: 'bar' },
-      () => promise,
-    );
+    const actual = await promiseRegistry.register(key, () => promise);
 
     expect(actual).toBe('ongoing');
   });

--- a/src/datasources/promise/promise-registry.spec.ts
+++ b/src/datasources/promise/promise-registry.spec.ts
@@ -12,15 +12,15 @@ describe('Promise Registry tests', () => {
   it('registration is successful', () => {
     const promise = Promise.resolve();
 
-    promiseRegistry.register('foo', () => promise);
+    promiseRegistry.register({ key: 'foo', field: 'bar' }, () => promise);
 
-    expect(Object.keys(registry)).toEqual(['foo']);
+    expect(Object.keys(registry)).toEqual(['foobar']);
   });
 
   it('promise is deleted upon successful completion', async () => {
     const promise = Promise.resolve();
 
-    await promiseRegistry.register('foo', () => promise);
+    await promiseRegistry.register({ key: 'foo', field: 'bar' }, () => promise);
 
     expect(Object.keys(registry)).toEqual([]);
   });
@@ -28,16 +28,22 @@ describe('Promise Registry tests', () => {
   it('promise is deleted upon error completion', async () => {
     const promise = Promise.reject('random error');
 
-    await promiseRegistry.register('foo', () => promise).catch(() => {});
+    await promiseRegistry
+      .register({ key: 'foo', field: 'bar' }, () => promise)
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .catch(() => {});
 
     expect(Object.keys(registry)).toEqual([]);
   });
 
   it('ongoing promise with same key is returned', async () => {
-    registry['foo'] = Promise.resolve('ongoing');
+    registry['foobar'] = Promise.resolve('ongoing');
     const promise = Promise.resolve('new');
 
-    const actual = await promiseRegistry.register('foo', () => promise);
+    const actual = await promiseRegistry.register(
+      { key: 'foo', field: 'bar' },
+      () => promise,
+    );
 
     expect(actual).toBe('ongoing');
   });

--- a/src/datasources/promise/promise-registry.ts
+++ b/src/datasources/promise/promise-registry.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { CacheDir } from '../cache/entities/cache-dir.entity';
 
 @Injectable()
 export class PromiseRegistry<K extends keyof any> {
@@ -15,12 +14,10 @@ export class PromiseRegistry<K extends keyof any> {
    *
    * Once the promise is settled, it is removed from the registry.
    *
-   * @param cacheDir - the CacheDir used to register the provided promise
+   * @param key - the key used to register the provided promise
    * @param fn - the function to be executed
    */
-  async register<V>(cacheDir: CacheDir, fn: () => V): Promise<V> {
-    const key = cacheDir.key + cacheDir.field;
-
+  async register<V>(key: string, fn: () => V): Promise<V> {
     const activePromise = this.registry[key];
     if (activePromise) return activePromise;
 

--- a/src/datasources/promise/promise-registry.ts
+++ b/src/datasources/promise/promise-registry.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { CacheDir } from '../cache/entities/cache-dir.entity';
 
 @Injectable()
 export class PromiseRegistry<K extends keyof any> {
@@ -14,10 +15,12 @@ export class PromiseRegistry<K extends keyof any> {
    *
    * Once the promise is settled, it is removed from the registry.
    *
-   * @param key - the key used to register the provided promise
+   * @param cacheDir - the CacheDir used to register the provided promise
    * @param fn - the function to be executed
    */
-  async register<V>(key: string, fn: () => V): Promise<V> {
+  async register<V>(cacheDir: CacheDir, fn: () => V): Promise<V> {
+    const key = cacheDir.key + cacheDir.field;
+
     const activePromise = this.registry[key];
     if (activePromise) return activePromise;
 

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -28,6 +28,7 @@ import { HttpErrorFactory } from '../errors/http-error-factory';
 import { INetworkService } from '../network/network.service.interface';
 import { IConfigurationService } from '../../config/configuration.service.interface';
 import { PromiseRegistry } from '../promise/promise-registry';
+import { CacheDir } from '../cache/entities/cache-dir.entity';
 
 export class TransactionApi implements ITransactionApi {
   private readonly defaultExpirationTimeInSeconds: number;
@@ -63,6 +64,10 @@ export class TransactionApi implements ITransactionApi {
       );
   }
 
+  private getPromiseRegistryKey(cacheDir: CacheDir): string {
+    return cacheDir.key + cacheDir.field;
+  }
+
   async getBalances(
     safeAddress: string,
     trusted?: boolean,
@@ -77,19 +82,21 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Balance[]>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              trusted: trusted,
-              exclude_spam: excludeSpam,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Balance[]>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                trusted: trusted,
+                exclude_spam: excludeSpam,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -132,21 +139,23 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v2/safes/${safeAddress}/collectibles/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Collectible>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              limit: limit,
-              offset: offset,
-              trusted: trusted,
-              exclude_spam: excludeSpam,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Collectible>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                limit: limit,
+                offset: offset,
+                trusted: trusted,
+                exclude_spam: excludeSpam,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -167,14 +176,16 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getBackboneCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Backbone>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Backbone>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -188,14 +199,16 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getMasterCopiesCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about/master-copies/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<MasterCopy[]>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<MasterCopy[]>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -207,14 +220,16 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getSafeCacheDir(this.chainId, safeAddress);
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Safe>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Safe>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -238,14 +253,16 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/contracts/${contractAddress}`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Contract>(
-          cacheDir,
-          url,
-          this.contractNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Contract>(
+            cacheDir,
+            url,
+            this.contractNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -272,22 +289,24 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/delegates/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Delegate>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              safe: safeAddress,
-              delegate: delegate,
-              delegator: delegator,
-              label: label,
-              limit: limit,
-              offset: offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Delegate>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                safe: safeAddress,
+                delegate: delegate,
+                delegator: delegator,
+                label: label,
+                limit: limit,
+                offset: offset,
+              },
             },
-          },
-        ),
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -359,14 +378,16 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/transfer/${transferId}`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Transfer>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Transfer>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -391,21 +412,23 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Transfer>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              erc20: onlyErc20,
-              erc721: onlyErc721,
-              limit: limit,
-              offset: offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Transfer>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                erc20: onlyErc20,
+                erc721: onlyErc721,
+                limit: limit,
+                offset: offset,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -443,24 +466,26 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Transfer>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              execution_date__gte: executionDateGte,
-              execution_date__lte: executionDateLte,
-              to,
-              value,
-              tokenAddress,
-              limit,
-              offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Transfer>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                execution_date__gte: executionDateGte,
+                execution_date__lte: executionDateLte,
+                to,
+                value,
+                tokenAddress,
+                limit,
+                offset,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -504,14 +529,16 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<ModuleTransaction>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<ModuleTransaction>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -536,21 +563,23 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/module-transactions/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<ModuleTransaction>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              to,
-              module,
-              limit,
-              offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<ModuleTransaction>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                to,
+                module,
+                limit,
+                offset,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -599,29 +628,31 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<MultisigTransaction>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              safe: safeAddress,
-              ordering,
-              executed,
-              trusted,
-              execution_date__gte: executionDateGte,
-              execution_date__lte: executionDateLte,
-              to,
-              value,
-              nonce,
-              nonce__gte: nonceGte,
-              limit,
-              offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<MultisigTransaction>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                safe: safeAddress,
+                ordering,
+                executed,
+                trusted,
+                execution_date__gte: executionDateGte,
+                execution_date__lte: executionDateLte,
+                to,
+                value,
+                nonce,
+                nonce__gte: nonceGte,
+                limit,
+                offset,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -648,14 +679,16 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<MultisigTransaction>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<MultisigTransaction>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -684,14 +717,16 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<CreationTransaction>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<CreationTransaction>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -718,23 +753,25 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/all-transactions/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Transaction>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              safe: safeAddress,
-              ordering: ordering,
-              executed: executed,
-              queued: queued,
-              limit: limit,
-              offset: offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Transaction>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                safe: safeAddress,
+                ordering: ordering,
+                executed: executed,
+                queued: queued,
+                limit: limit,
+                offset: offset,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -755,14 +792,16 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getTokenCacheDir(this.chainId, address);
       const url = `${this.baseUrl}/api/v1/tokens/${address}`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Token>(
-          cacheDir,
-          url,
-          this.tokenNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Token>(
+            cacheDir,
+            url,
+            this.tokenNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -780,19 +819,21 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/tokens/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Token>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              limit: limit,
-              offset: offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Token>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                limit: limit,
+                offset: offset,
+              },
             },
-          },
-          this.defaultExpirationTimeInSeconds,
-        ),
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -809,14 +850,16 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/owners/${ownerAddress}/safes/`;
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<SafeList>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          undefined,
-          this.defaultExpirationTimeInSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<SafeList>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            undefined,
+            this.defaultExpirationTimeInSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -884,12 +927,14 @@ export class TransactionApi implements ITransactionApi {
         messageHash,
       );
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Message>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-        ),
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Message>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -910,18 +955,20 @@ export class TransactionApi implements ITransactionApi {
         offset,
       );
 
-      return await this.promiseRegistry.register(cacheDir, () =>
-        this.dataSource.get<Page<Message>>(
-          cacheDir,
-          url,
-          this.defaultNotFoundExpirationTimeSeconds,
-          {
-            params: {
-              limit: limit,
-              offset: offset,
+      return await this.promiseRegistry.register(
+        this.getPromiseRegistryKey(cacheDir),
+        () =>
+          this.dataSource.get<Page<Message>>(
+            cacheDir,
+            url,
+            this.defaultNotFoundExpirationTimeSeconds,
+            {
+              params: {
+                limit: limit,
+                offset: offset,
+              },
             },
-          },
-        ),
+          ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -77,21 +77,19 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Balance[]>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                trusted: trusted,
-                exclude_spam: excludeSpam,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Balance[]>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              trusted: trusted,
+              exclude_spam: excludeSpam,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -134,23 +132,21 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v2/safes/${safeAddress}/collectibles/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Collectible>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                limit: limit,
-                offset: offset,
-                trusted: trusted,
-                exclude_spam: excludeSpam,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Collectible>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              limit: limit,
+              offset: offset,
+              trusted: trusted,
+              exclude_spam: excludeSpam,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -171,16 +167,14 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getBackboneCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Backbone>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Backbone>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -194,16 +188,14 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getMasterCopiesCacheDir(this.chainId);
       const url = `${this.baseUrl}/api/v1/about/master-copies/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<MasterCopy[]>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<MasterCopy[]>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -215,16 +207,14 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getSafeCacheDir(this.chainId, safeAddress);
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Safe>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Safe>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -248,16 +238,14 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/contracts/${contractAddress}`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Contract>(
-            cacheDir,
-            url,
-            this.contractNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Contract>(
+          cacheDir,
+          url,
+          this.contractNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -284,24 +272,22 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/delegates/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Delegate>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                safe: safeAddress,
-                delegate: delegate,
-                delegator: delegator,
-                label: label,
-                limit: limit,
-                offset: offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Delegate>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              safe: safeAddress,
+              delegate: delegate,
+              delegator: delegator,
+              label: label,
+              limit: limit,
+              offset: offset,
             },
-          ),
+          },
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -373,16 +359,14 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/transfer/${transferId}`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Transfer>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Transfer>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -407,23 +391,21 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Transfer>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                erc20: onlyErc20,
-                erc721: onlyErc721,
-                limit: limit,
-                offset: offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Transfer>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              erc20: onlyErc20,
+              erc721: onlyErc721,
+              limit: limit,
+              offset: offset,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -461,26 +443,24 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Transfer>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                execution_date__gte: executionDateGte,
-                execution_date__lte: executionDateLte,
-                to,
-                value,
-                tokenAddress,
-                limit,
-                offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Transfer>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              execution_date__gte: executionDateGte,
+              execution_date__lte: executionDateLte,
+              to,
+              value,
+              tokenAddress,
+              limit,
+              offset,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -524,16 +504,14 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<ModuleTransaction>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<ModuleTransaction>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -558,23 +536,21 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/module-transactions/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<ModuleTransaction>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                to,
-                module,
-                limit,
-                offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<ModuleTransaction>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              to,
+              module,
+              limit,
+              offset,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -623,31 +599,29 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<MultisigTransaction>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                safe: safeAddress,
-                ordering,
-                executed,
-                trusted,
-                execution_date__gte: executionDateGte,
-                execution_date__lte: executionDateLte,
-                to,
-                value,
-                nonce,
-                nonce__gte: nonceGte,
-                limit,
-                offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<MultisigTransaction>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              safe: safeAddress,
+              ordering,
+              executed,
+              trusted,
+              execution_date__gte: executionDateGte,
+              execution_date__lte: executionDateLte,
+              to,
+              value,
+              nonce,
+              nonce__gte: nonceGte,
+              limit,
+              offset,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -674,16 +648,14 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<MultisigTransaction>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<MultisigTransaction>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -712,16 +684,14 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<CreationTransaction>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<CreationTransaction>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -748,25 +718,23 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/all-transactions/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Transaction>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                safe: safeAddress,
-                ordering: ordering,
-                executed: executed,
-                queued: queued,
-                limit: limit,
-                offset: offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Transaction>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              safe: safeAddress,
+              ordering: ordering,
+              executed: executed,
+              queued: queued,
+              limit: limit,
+              offset: offset,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -787,16 +755,14 @@ export class TransactionApi implements ITransactionApi {
       const cacheDir = CacheRouter.getTokenCacheDir(this.chainId, address);
       const url = `${this.baseUrl}/api/v1/tokens/${address}`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Token>(
-            cacheDir,
-            url,
-            this.tokenNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Token>(
+          cacheDir,
+          url,
+          this.tokenNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -814,21 +780,19 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/tokens/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Token>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                limit: limit,
-                offset: offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Token>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              limit: limit,
+              offset: offset,
             },
-            this.defaultExpirationTimeInSeconds,
-          ),
+          },
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -845,16 +809,14 @@ export class TransactionApi implements ITransactionApi {
       );
       const url = `${this.baseUrl}/api/v1/owners/${ownerAddress}/safes/`;
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<SafeList>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            undefined,
-            this.defaultExpirationTimeInSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<SafeList>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          undefined,
+          this.defaultExpirationTimeInSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -922,14 +884,12 @@ export class TransactionApi implements ITransactionApi {
         messageHash,
       );
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Message>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-          ),
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Message>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -950,20 +910,18 @@ export class TransactionApi implements ITransactionApi {
         offset,
       );
 
-      return await this.promiseRegistry.register(
-        cacheDir.key + cacheDir.field,
-        () =>
-          this.dataSource.get<Page<Message>>(
-            cacheDir,
-            url,
-            this.defaultNotFoundExpirationTimeSeconds,
-            {
-              params: {
-                limit: limit,
-                offset: offset,
-              },
+      return await this.promiseRegistry.register(cacheDir, () =>
+        this.dataSource.get<Page<Message>>(
+          cacheDir,
+          url,
+          this.defaultNotFoundExpirationTimeSeconds,
+          {
+            params: {
+              limit: limit,
+              offset: offset,
             },
-          ),
+          },
+        ),
       );
     } catch (error) {
       throw this.httpErrorFactory.from(error);


### PR DESCRIPTION
This adds a helper to the `transaction-api.service` to convert the `CacheDir` into `PromiseRegistry` keys, as well as making the test for the `PromiseRegistry` more robust.