### PR TITLE
Add trusted filter when getting the last transaction to estimate the next nonce

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -384,7 +384,7 @@ export class SafeRepository implements ISafeRepository {
         safeAddress,
         '-nonce',
         undefined,
-        undefined,
+        true,
         undefined,
         undefined,
         undefined,


### PR DESCRIPTION
Closes #595 

- Adds the `trusted` missing filter when calling the TX service to get the last transaction for recommended nonce calculation.

[(Reference in the Rust CGW implementation)](https://github.com/safe-global/safe-client-gateway/blob/eb481938a49c29b979fe98a5577f719f42a2b2eb/src/routes/safes/handlers/estimations.rs#L27)