### PR TITLE
Add GET /health/ready

### DIFF
--- a/src/datasources/cache/__tests__/fake.cache.service.ts
+++ b/src/datasources/cache/__tests__/fake.cache.service.ts
@@ -3,6 +3,15 @@ import { CacheDir } from '../entities/cache-dir.entity';
 
 export class FakeCacheService implements ICacheService {
   private cache: Record<string, Record<string, any>> = {};
+  private isReady: boolean = true;
+
+  ping(): Promise<unknown> {
+    return this.isReady ? Promise.resolve() : Promise.reject();
+  }
+
+  setReadyState(isReady: boolean) {
+    this.isReady = isReady;
+  }
 
   keyCount(): number {
     return Object.keys(this.cache).length;

--- a/src/datasources/cache/__tests__/test.cache.module.ts
+++ b/src/datasources/cache/__tests__/test.cache.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 import { CacheService } from '../cache.service.interface';
 import { FakeCacheService } from './fake.cache.service';
+import { CacheReadiness } from '../../../domain/interfaces/cache-readiness.interface';
 
 /**
  * The {@link TestCacheModule} should be used whenever you want to
@@ -14,7 +15,13 @@ import { FakeCacheService } from './fake.cache.service';
  */
 @Global()
 @Module({
-  providers: [{ provide: CacheService, useClass: FakeCacheService }],
-  exports: [CacheService],
+  providers: [
+    { provide: CacheService, useClass: FakeCacheService },
+    {
+      provide: CacheReadiness,
+      useExisting: CacheService,
+    },
+  ],
+  exports: [CacheService, CacheReadiness],
 })
 export class TestCacheModule {}

--- a/src/datasources/cache/cache.module.ts
+++ b/src/datasources/cache/cache.module.ts
@@ -7,6 +7,7 @@ import {
   ILoggingService,
   LoggingService,
 } from '../../logging/logging.interface';
+import { CacheReadiness } from '../../domain/interfaces/cache-readiness.interface';
 
 export type RedisClientType = ReturnType<typeof createClient>;
 
@@ -35,7 +36,8 @@ async function redisClientFactory(
       inject: [IConfigurationService, LoggingService],
     },
     { provide: CacheService, useClass: RedisCacheService },
+    { provide: CacheReadiness, useExisting: CacheService },
   ],
-  exports: [CacheService],
+  exports: [CacheService, CacheReadiness],
 })
 export class CacheModule {}

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -7,9 +7,12 @@ import {
 import { RedisClientType } from './cache.module';
 import { ICacheService } from './cache.service.interface';
 import { CacheDir } from './entities/cache-dir.entity';
+import { ICacheReadiness } from '../../domain/interfaces/cache-readiness.interface';
 
 @Injectable()
-export class RedisCacheService implements ICacheService, OnModuleDestroy {
+export class RedisCacheService
+  implements ICacheService, ICacheReadiness, OnModuleDestroy
+{
   private readonly quitTimeoutInSeconds: number = 2;
 
   constructor(
@@ -18,6 +21,10 @@ export class RedisCacheService implements ICacheService, OnModuleDestroy {
     private readonly configuration: IConfigurationService,
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
   ) {}
+
+  async ping(): Promise<unknown> {
+    return this.client.ping();
+  }
 
   async set(
     cacheDir: CacheDir,

--- a/src/domain.module.ts
+++ b/src/domain.module.ts
@@ -53,6 +53,8 @@ import { IMessagesRepository } from './domain/messages/messages.repository.inter
 import { MessageValidator } from './domain/messages/message.validator';
 import { FlushRepository } from './domain/flush/flush.repository';
 import { IFlushRepository } from './domain/flush/flush.repository.interface';
+import { IHealthRepository } from './domain/health/health.repository.interface';
+import { HealthRepository } from './domain/health/health.repository';
 
 @Global()
 @Module({
@@ -68,6 +70,7 @@ import { IFlushRepository } from './domain/flush/flush.repository.interface';
     { provide: IEstimationsRepository, useClass: EstimationsRepository },
     { provide: IExchangeRepository, useClass: ExchangeRepository },
     { provide: IFlushRepository, useClass: FlushRepository },
+    { provide: IHealthRepository, useClass: HealthRepository },
     { provide: IMessagesRepository, useClass: MessagesRepository },
     { provide: INotificationsRepository, useClass: NotificationsRepository },
     { provide: ISafeAppsRepository, useClass: SafeAppsRepository },
@@ -106,6 +109,7 @@ import { IFlushRepository } from './domain/flush/flush.repository.interface';
     IEstimationsRepository,
     IExchangeRepository,
     IFlushRepository,
+    IHealthRepository,
     IMessagesRepository,
     INotificationsRepository,
     ISafeAppsRepository,

--- a/src/domain/health/entities/health.entity.ts
+++ b/src/domain/health/entities/health.entity.ts
@@ -1,0 +1,4 @@
+export enum HealthEntity {
+  READY,
+  NOT_READY,
+}

--- a/src/domain/health/health.repository.interface.ts
+++ b/src/domain/health/health.repository.interface.ts
@@ -1,0 +1,16 @@
+import { HealthEntity } from './entities/health.entity';
+
+export const IHealthRepository = Symbol('IHealthRepository');
+
+export interface IHealthRepository {
+  /**
+   * Checks if the service is considered to be in a ready state.
+   *
+   * Some conditions might be required to consider the service to be ready
+   * (Redis connection established, for example).
+   *
+   * Returns {@link HealthEntity.READY} if the service is ready. Else
+   * returns {@link HealthEntity.NOT_READY}
+   */
+  isReady(): Promise<HealthEntity>;
+}

--- a/src/domain/health/health.repository.ts
+++ b/src/domain/health/health.repository.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { HealthEntity } from './entities/health.entity';
+import {
+  ILoggingService,
+  LoggingService,
+} from '../../logging/logging.interface';
+import { IHealthRepository } from './health.repository.interface';
+import {
+  CacheReadiness,
+  ICacheReadiness,
+} from '../interfaces/cache-readiness.interface';
+
+@Injectable()
+export class HealthRepository implements IHealthRepository {
+  constructor(
+    @Inject(CacheReadiness) private readonly cacheService: ICacheReadiness,
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+  ) {}
+
+  async isReady(): Promise<HealthEntity> {
+    try {
+      await this.cacheService.ping();
+      return HealthEntity.READY;
+    } catch (error) {
+      this.loggingService.warn('Redis connection is not established');
+      return HealthEntity.NOT_READY;
+    }
+  }
+}

--- a/src/domain/health/health.repository.ts
+++ b/src/domain/health/health.repository.ts
@@ -22,7 +22,7 @@ export class HealthRepository implements IHealthRepository {
       await this.cacheService.ping();
       return HealthEntity.READY;
     } catch (error) {
-      this.loggingService.warn('Redis connection is not established');
+      this.loggingService.warn('Cache service connection is not established');
       return HealthEntity.NOT_READY;
     }
   }

--- a/src/domain/interfaces/cache-readiness.interface.ts
+++ b/src/domain/interfaces/cache-readiness.interface.ts
@@ -1,0 +1,9 @@
+export const CacheReadiness = Symbol('ICacheReadiness');
+
+export interface ICacheReadiness {
+  /**
+   * Pings the current cache instance being used. If no connection was
+   * established before, the promise rejects.
+   */
+  ping(): Promise<unknown>;
+}

--- a/src/routes/health/__tests__/get-health.e2e-spec.ts
+++ b/src/routes/health/__tests__/get-health.e2e-spec.ts
@@ -15,9 +15,9 @@ describe('Get health e2e test', () => {
     await app.init();
   });
 
-  it('GET /health', async () => {
+  it('GET /health/live', async () => {
     await request(app.getHttpServer())
-      .get(`/health`)
+      .get(`/health/live`)
       .expect(200)
       .then(({ body }) => {
         expect(body).toEqual({ status: 'OK' });

--- a/src/routes/health/entities/health.entity.ts
+++ b/src/routes/health/entities/health.entity.ts
@@ -8,4 +8,8 @@ export enum HealthStatus {
 export class Health {
   @ApiProperty({ enum: Object.values(HealthStatus) })
   status: HealthStatus;
+
+  constructor(healthStatus: HealthStatus) {
+    this.status = healthStatus;
+  }
 }

--- a/src/routes/health/health.controller.spec.ts
+++ b/src/routes/health/health.controller.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule, configurationModule } from '../../app.module';
+import { CacheModule } from '../../datasources/cache/cache.module';
+import { TestCacheModule } from '../../datasources/cache/__tests__/test.cache.module';
+import { ConfigurationModule } from '../../config/configuration.module';
+import configuration from '../../config/entities/__tests__/configuration';
+import { RequestScopedLoggingModule } from '../../logging/logging.module';
+import { TestLoggingModule } from '../../logging/__tests__/test.logging.module';
+import { NetworkModule } from '../../datasources/network/network.module';
+import { TestNetworkModule } from '../../datasources/network/__tests__/test.network.module';
+import { TestAppProvider } from '../../__tests__/test-app.provider';
+import { INestApplication } from '@nestjs/common';
+import { CacheService } from '../../datasources/cache/cache.service.interface';
+import { FakeCacheService } from '../../datasources/cache/__tests__/fake.cache.service';
+import * as request from 'supertest';
+
+describe('Health Controller tests', () => {
+  let app: INestApplication;
+  let cacheService: FakeCacheService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideModule(CacheModule)
+      .useModule(TestCacheModule)
+      .overrideModule(configurationModule)
+      .useModule(ConfigurationModule.register(configuration))
+      .overrideModule(RequestScopedLoggingModule)
+      .useModule(TestLoggingModule)
+      .overrideModule(NetworkModule)
+      .useModule(TestNetworkModule)
+      .compile();
+
+    app = await new TestAppProvider().provide(moduleFixture);
+
+    cacheService = moduleFixture.get(CacheService);
+
+    await app.init();
+  });
+
+  describe('readiness tests', () => {
+    it('cache service is not ready', async () => {
+      cacheService.setReadyState(false);
+
+      await request(app.getHttpServer())
+        .get(`/health/ready`)
+        .expect(503)
+        .expect({ status: 'KO' });
+    });
+
+    it('cache service is ready', async () => {
+      cacheService.setReadyState(true);
+
+      await request(app.getHttpServer())
+        .get(`/health/ready`)
+        .expect(200)
+        .expect({ status: 'OK' });
+    });
+  });
+
+  describe('liveness tests', () => {
+    it('service is alive if it accepts requests', async () => {
+      await request(app.getHttpServer())
+        .get(`/health/live`)
+        .expect(200)
+        .expect({ status: 'OK' });
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/src/routes/health/health.controller.ts
+++ b/src/routes/health/health.controller.ts
@@ -1,13 +1,22 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Health, HealthStatus } from './entities/health.entity';
+import { HealthService } from './health.service';
 
 @ApiTags('health')
 @Controller({ path: 'health' })
 export class HealthController {
+  constructor(private readonly service: HealthService) {}
+
   @ApiOkResponse({ type: Health })
-  @Get()
-  getHealth(): Health {
-    return { status: HealthStatus.OK };
+  @Get('live')
+  liveness(): Health {
+    return new Health(HealthStatus.OK);
+  }
+
+  @ApiOkResponse({ type: Health })
+  @Get('ready')
+  readiness(): Promise<Health> {
+    return this.service.isReady();
   }
 }

--- a/src/routes/health/health.module.ts
+++ b/src/routes/health/health.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
 
 @Module({
   controllers: [HealthController],
+  providers: [HealthService],
 })
 export class HealthModule {}

--- a/src/routes/health/health.service.ts
+++ b/src/routes/health/health.service.ts
@@ -1,0 +1,35 @@
+import {
+  Inject,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { IHealthRepository } from '../../domain/health/health.repository.interface';
+import { HealthEntity } from '../../domain/health/entities/health.entity';
+import { Health, HealthStatus } from './entities/health.entity';
+import {
+  ILoggingService,
+  LoggingService,
+} from '../../logging/logging.interface';
+
+@Injectable()
+export class HealthService {
+  constructor(
+    @Inject(IHealthRepository)
+    private readonly healthRepository: IHealthRepository,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
+  ) {}
+
+  async isReady(): Promise<Health> {
+    const readiness = await this.healthRepository.isReady();
+    switch (readiness) {
+      case HealthEntity.READY:
+        return new Health(HealthStatus.OK);
+      case HealthEntity.NOT_READY:
+        throw new ServiceUnavailableException(new Health(HealthStatus.KO));
+      default:
+        this.loggingService.debug(`Readiness status ${readiness} not handled`);
+        return new Health(HealthStatus.OK);
+    }
+  }
+}

--- a/src/routes/health/health.service.ts
+++ b/src/routes/health/health.service.ts
@@ -28,8 +28,8 @@ export class HealthService {
       case HealthEntity.NOT_READY:
         throw new ServiceUnavailableException(new Health(HealthStatus.KO));
       default:
-        this.loggingService.debug(`Readiness status ${readiness} not handled`);
-        return new Health(HealthStatus.OK);
+        this.loggingService.error(`Readiness status ${readiness} not handled`);
+        return new Health(HealthStatus.KO);
     }
   }
 }


### PR DESCRIPTION
- Adds a `GET /health/ready` endpoint – this endpoint can be used to check if the service is ready to take in new requests.
- The previous liveness check `GET /health` is now under `GET /health/live`.
- `RedisCacheService` now implements `ICacheReadiness`, a new interface which specifies that implementations of that interface are pingable.
- In the current implementation, the service is considered to be ready if there's an open connection to the redis instance.