### PR TITLE
Fix getLastTransactionSortedByNonce provided parameter

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -390,6 +390,7 @@ export class SafeRepository implements ISafeRepository {
         undefined,
         undefined,
         undefined,
+        undefined,
         1,
       );
 


### PR DESCRIPTION
Closes #602 

- `1` was being provided as a `nonceGte` instead of as `limit`.
- This bug was likely introduced in 9ab0e70aa33ebd0739ca92a90738e75251ab8224 when a new optional parameter was added (`nonceGte`). See https://github.com/safe-global/safe-client-gateway-nest/commit/9ab0e70aa33ebd0739ca92a90738e75251ab8224#diff-43b9156f9e631726e6cc7662bca73aa1a8f308376f72f895304bd926e0b3784fR126