### PR TITLE
Use anonymous interfaces for function args

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -28,39 +28,48 @@ export class CacheRouter {
   private static readonly TRANSFER_KEY = 'transfer';
   private static readonly TRANSFERS_KEY = 'transfers';
 
-  static getBalancesCacheKey(chainId: string, safeAddress: string): string {
-    return `${chainId}_${CacheRouter.BALANCES_KEY}_${safeAddress}`;
+  static getBalancesCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.BALANCES_KEY}_${args.safeAddress}`;
   }
 
-  static getBalanceCacheDir(
-    chainId: string,
-    safeAddress: string,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): CacheDir {
+  static getBalanceCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): CacheDir {
     return new CacheDir(
-      CacheRouter.getBalancesCacheKey(chainId, safeAddress),
-      `${trusted}_${excludeSpam}`,
+      CacheRouter.getBalancesCacheKey(args),
+      `${args.trusted}_${args.excludeSpam}`,
     );
   }
 
-  static getSafeCacheDir(chainId: string, safeAddress: string): CacheDir {
+  static getSafeCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.SAFE_KEY}_${safeAddress}`,
+      `${args.chainId}_${CacheRouter.SAFE_KEY}_${args.safeAddress}`,
       '',
     );
   }
 
-  static getSafeCacheKey(chainId: string, safeAddress: string): string {
-    return `${chainId}_${CacheRouter.SAFE_KEY}_${safeAddress}`;
+  static getSafeCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.SAFE_KEY}_${args.safeAddress}`;
   }
 
-  static getContractCacheDir(
-    chainId: string,
-    contractAddress: string,
-  ): CacheDir {
+  static getContractCacheDir(args: {
+    chainId: string;
+    contractAddress: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.CONTRACT_KEY}_${contractAddress}`,
+      `${args.chainId}_${CacheRouter.CONTRACT_KEY}_${args.contractAddress}`,
       '',
     );
   }
@@ -77,209 +86,221 @@ export class CacheRouter {
     return new CacheDir(`${chainId}_${CacheRouter.MASTER_COPIES_KEY}`, '');
   }
 
-  static getCollectiblesCacheDir(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): CacheDir {
+  static getCollectiblesCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.COLLECTIBLES_KEY}_${safeAddress}`,
-      `${limit}_${offset}_${trusted}_${excludeSpam}`,
+      `${args.chainId}_${CacheRouter.COLLECTIBLES_KEY}_${args.safeAddress}`,
+      `${args.limit}_${args.offset}_${args.trusted}_${args.excludeSpam}`,
     );
   }
 
-  static getCollectiblesKey(chainId: string, safeAddress: string) {
-    return `${chainId}_${CacheRouter.COLLECTIBLES_KEY}_${safeAddress}`;
+  static getCollectiblesKey(args: { chainId: string; safeAddress: string }) {
+    return `${args.chainId}_${CacheRouter.COLLECTIBLES_KEY}_${args.safeAddress}`;
   }
 
-  static getDelegatesCacheDir(
-    chainId: string,
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    label?: string,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getDelegatesCacheDir(args: {
+    chainId: string;
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.DELEGATES_KEY}_${safeAddress}`,
-      `${delegate}_${delegator}_${label}_${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.DELEGATES_KEY}_${args.safeAddress}`,
+      `${args.delegate}_${args.delegator}_${args.label}_${args.limit}_${args.offset}`,
     );
   }
 
-  static getTransferCacheDir(chainId: string, transferId: string): CacheDir {
+  static getTransferCacheDir(args: {
+    chainId: string;
+    transferId: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.TRANSFER_KEY}_${transferId}`,
+      `${args.chainId}_${CacheRouter.TRANSFER_KEY}_${args.transferId}`,
       '',
     );
   }
 
-  static getTransfersCacheDir(
-    chainId: string,
-    safeAddress: string,
-    onlyErc20: boolean,
-    onlyErc721: boolean,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getTransfersCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    onlyErc20: boolean;
+    onlyErc721: boolean;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.TRANSFERS_KEY}_${safeAddress}`,
-      `${onlyErc20}_${onlyErc721}_${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.TRANSFERS_KEY}_${args.safeAddress}`,
+      `${args.onlyErc20}_${args.onlyErc721}_${args.limit}_${args.offset}`,
     );
   }
 
-  static getTransfersCacheKey(chainId: string, safeAddress: string) {
-    return `${chainId}_${CacheRouter.TRANSFERS_KEY}_${safeAddress}`;
+  static getTransfersCacheKey(args: { chainId: string; safeAddress: string }) {
+    return `${args.chainId}_${CacheRouter.TRANSFERS_KEY}_${args.safeAddress}`;
   }
 
-  static getModuleTransactionCacheDir(
-    chainId: string,
-    moduleTransactionId: string,
-  ): CacheDir {
+  static getModuleTransactionCacheDir(args: {
+    chainId: string;
+    moduleTransactionId: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.MODULE_TRANSACTION_KEY}_${moduleTransactionId}`,
+      `${args.chainId}_${CacheRouter.MODULE_TRANSACTION_KEY}_${args.moduleTransactionId}`,
       '',
     );
   }
 
-  static getModuleTransactionsCacheDir(
-    chainId: string,
-    safeAddress: string,
-    to?: string,
-    module?: string,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getModuleTransactionsCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    to?: string;
+    module?: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.MODULE_TRANSACTIONS_KEY}_${safeAddress}`,
-      `${to}_${module}_${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.MODULE_TRANSACTIONS_KEY}_${args.safeAddress}`,
+      `${args.to}_${args.module}_${args.limit}_${args.offset}`,
     );
   }
 
-  static getModuleTransactionsCacheKey(
-    chainId: string,
-    safeAddress: string,
-  ): string {
-    return `${chainId}_${CacheRouter.MODULE_TRANSACTIONS_KEY}_${safeAddress}`;
+  static getModuleTransactionsCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.MODULE_TRANSACTIONS_KEY}_${args.safeAddress}`;
   }
 
-  static getIncomingTransfersCacheDir(
-    chainId: string,
-    safeAddress: string,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    tokenAddress?: string,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getIncomingTransfersCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    tokenAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.INCOMING_TRANSFERS_KEY}_${safeAddress}`,
-      `${executionDateGte}_${executionDateLte}_${to}_${value}_${tokenAddress}_${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.INCOMING_TRANSFERS_KEY}_${args.safeAddress}`,
+      `${args.executionDateGte}_${args.executionDateLte}_${args.to}_${args.value}_${args.tokenAddress}_${args.limit}_${args.offset}`,
     );
   }
 
-  static getIncomingTransfersCacheKey(
-    chainId: string,
-    safeAddress: string,
-  ): string {
-    return `${chainId}_${CacheRouter.INCOMING_TRANSFERS_KEY}_${safeAddress}`;
+  static getIncomingTransfersCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.INCOMING_TRANSFERS_KEY}_${args.safeAddress}`;
   }
 
-  static getMultisigTransactionsCacheDir(
-    chainId: string,
-    safeAddress: string,
-    ordering?: string,
-    executed?: boolean,
-    trusted?: boolean,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    nonce?: string,
-    nonceGte?: number,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getMultisigTransactionsCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    ordering?: string;
+    executed?: boolean;
+    trusted?: boolean;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    nonce?: string;
+    nonceGte?: number;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${safeAddress}`,
-      `${ordering}_${executed}_${trusted}_${executionDateGte}_${executionDateLte}_${to}_${value}_${nonce}_${nonceGte}_${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${args.safeAddress}`,
+      `${args.ordering}_${args.executed}_${args.trusted}_${args.executionDateGte}_${args.executionDateLte}_${args.to}_${args.value}_${args.nonce}_${args.nonceGte}_${args.limit}_${args.offset}`,
     );
   }
 
-  static getMultisigTransactionsCacheKey(
-    chainId: string,
-    safeAddress: string,
-  ): string {
-    return `${chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${safeAddress}`;
+  static getMultisigTransactionsCacheKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.MULTISIG_TRANSACTIONS_KEY}_${args.safeAddress}`;
   }
 
-  static getMultisigTransactionCacheDir(
-    chainId: string,
-    safeTransactionHash: string,
-  ): CacheDir {
+  static getMultisigTransactionCacheDir(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.MULTISIG_TRANSACTION_KEY}_${safeTransactionHash}`,
+      `${args.chainId}_${CacheRouter.MULTISIG_TRANSACTION_KEY}_${args.safeTransactionHash}`,
       '',
     );
   }
 
-  static getMultisigTransactionCacheKey(
-    chainId: string,
-    safeTransactionHash: string,
-  ): string {
-    return `${chainId}_${CacheRouter.MULTISIG_TRANSACTION_KEY}_${safeTransactionHash}`;
+  static getMultisigTransactionCacheKey(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.MULTISIG_TRANSACTION_KEY}_${args.safeTransactionHash}`;
   }
 
-  static getCreationTransactionCacheDir(
-    chainId: string,
-    safeAddress: string,
-  ): CacheDir {
+  static getCreationTransactionCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.CREATION_TRANSACTION_KEY}_${safeAddress}`,
+      `${args.chainId}_${CacheRouter.CREATION_TRANSACTION_KEY}_${args.safeAddress}`,
       '',
     );
   }
 
-  static getAllTransactionsCacheDir(
-    chainId: string,
-    safeAddress: string,
-    ordering?: string,
-    executed?: boolean,
-    queued?: boolean,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getAllTransactionsCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    ordering?: string;
+    executed?: boolean;
+    queued?: boolean;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.ALL_TRANSACTIONS_KEY}_${safeAddress}`,
-      `${ordering}_${executed}_${queued}_${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.ALL_TRANSACTIONS_KEY}_${args.safeAddress}`,
+      `${args.ordering}_${args.executed}_${args.queued}_${args.limit}_${args.offset}`,
     );
   }
 
-  static getAllTransactionsKey(chainId: string, safeAddress: string): string {
-    return `${chainId}_${CacheRouter.ALL_TRANSACTIONS_KEY}_${safeAddress}`;
+  static getAllTransactionsKey(args: {
+    chainId: string;
+    safeAddress: string;
+  }): string {
+    return `${args.chainId}_${CacheRouter.ALL_TRANSACTIONS_KEY}_${args.safeAddress}`;
   }
 
-  static getTokenCacheDir(chainId: string, address: string): CacheDir {
-    return new CacheDir(`${chainId}_${CacheRouter.TOKEN_KEY}_${address}`, '');
+  static getTokenCacheDir(args: {
+    chainId: string;
+    address: string;
+  }): CacheDir {
+    return new CacheDir(
+      `${args.chainId}_${CacheRouter.TOKEN_KEY}_${args.address}`,
+      '',
+    );
   }
 
   static getTokensCacheKey(chainId: string): string {
     return `${chainId}_${CacheRouter.TOKENS_KEY}`;
   }
 
-  static getTokensCacheDir(
-    chainId: string,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getTokensCacheDir(args: {
+    chainId: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      CacheRouter.getTokensCacheKey(chainId),
-      `${limit}_${offset}`,
+      CacheRouter.getTokensCacheKey(args.chainId),
+      `${args.limit}_${args.offset}`,
     );
   }
 
@@ -287,35 +308,35 @@ export class CacheRouter {
     return `${chainId}_${CacheRouter.TOKEN_KEY}_*`;
   }
 
-  static getSafesByOwnerCacheDir(
-    chainId: string,
-    ownerAddress: string,
-  ): CacheDir {
+  static getSafesByOwnerCacheDir(args: {
+    chainId: string;
+    ownerAddress: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.OWNERS_SAFE_KEY}_${ownerAddress}`,
+      `${args.chainId}_${CacheRouter.OWNERS_SAFE_KEY}_${args.ownerAddress}`,
       '',
     );
   }
 
-  static getMessageByHashCacheDir(
-    chainId: string,
-    messageHash: string,
-  ): CacheDir {
+  static getMessageByHashCacheDir(args: {
+    chainId: string;
+    messageHash: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.MESSAGE_KEY}_${messageHash}`,
+      `${args.chainId}_${CacheRouter.MESSAGE_KEY}_${args.messageHash}`,
       '',
     );
   }
 
-  static getMessagesBySafeCacheDir(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): CacheDir {
+  static getMessagesBySafeCacheDir(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.MESSAGES_KEY}_${safeAddress}`,
-      `${limit}_${offset}`,
+      `${args.chainId}_${CacheRouter.MESSAGES_KEY}_${args.safeAddress}`,
+      `${args.limit}_${args.offset}`,
     );
   }
 
@@ -323,8 +344,14 @@ export class CacheRouter {
     return CacheRouter.CHAINS_KEY;
   }
 
-  static getChainsCacheDir(limit?: number, offset?: number): CacheDir {
-    return new CacheDir(CacheRouter.getChainsCacheKey(), `${limit}_${offset}`);
+  static getChainsCacheDir(args: {
+    limit?: number;
+    offset?: number;
+  }): CacheDir {
+    return new CacheDir(
+      CacheRouter.getChainsCacheKey(),
+      `${args.limit}_${args.offset}`,
+    );
   }
 
   static getChainCacheDir(chainId: string): CacheDir {
@@ -335,14 +362,14 @@ export class CacheRouter {
     return `*_${CacheRouter.CHAIN_KEY}$`;
   }
 
-  static getSafeAppsCacheDir(
-    chainId?: string,
-    clientUrl?: string,
-    url?: string,
-  ): CacheDir {
+  static getSafeAppsCacheDir(args: {
+    chainId?: string;
+    clientUrl?: string;
+    url?: string;
+  }): CacheDir {
     return new CacheDir(
-      `${chainId}_${CacheRouter.SAFE_APPS_KEY}`,
-      `${clientUrl}_${url}`,
+      `${args.chainId}_${CacheRouter.SAFE_APPS_KEY}`,
+      `${args.clientUrl}_${args.url}`,
     );
   }
 

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -73,7 +73,7 @@ describe('ConfigApi', () => {
     const data = [chainBuilder().build(), chainBuilder().build()];
     mockDataSource.get.mockResolvedValue(data);
 
-    const actual = await service.getChains();
+    const actual = await service.getChains({});
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
@@ -110,7 +110,7 @@ describe('ConfigApi', () => {
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
     mockDataSource.get.mockResolvedValue(data);
 
-    const actual = await service.getSafeApps(chainId);
+    const actual = await service.getSafeApps({ chainId });
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
@@ -130,7 +130,7 @@ describe('ConfigApi', () => {
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
     mockDataSource.get.mockResolvedValue(data);
 
-    const actual = await service.getSafeApps(chainId, undefined, url);
+    const actual = await service.getSafeApps({ chainId, url });
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
@@ -150,7 +150,7 @@ describe('ConfigApi', () => {
     const data = [safeAppBuilder().build(), safeAppBuilder().build()];
     mockDataSource.get.mockResolvedValue(data);
 
-    const actual = await service.getSafeApps(chainId, clientUrl);
+    const actual = await service.getSafeApps({ chainId, clientUrl });
 
     expect(actual).toBe(data);
     expect(mockDataSource.get).toBeCalledTimes(1);
@@ -169,7 +169,7 @@ describe('ConfigApi', () => {
     mockHttpErrorFactory.from.mockReturnValue(expected);
     mockDataSource.get.mockRejectedValueOnce(new Error('Some error'));
 
-    await expect(service.getChains()).rejects.toThrowError(expected);
+    await expect(service.getChains({})).rejects.toThrowError(expected);
 
     expect(mockDataSource.get).toHaveBeenCalledTimes(1);
     expect(mockHttpErrorFactory.from).toBeCalledTimes(1);

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -34,11 +34,14 @@ export class ConfigApi implements IConfigApi {
       );
   }
 
-  async getChains(limit?: number, offset?: number): Promise<Page<Chain>> {
+  async getChains(args: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Chain>> {
     try {
       const url = `${this.baseUri}/api/v1/chains`;
-      const params = { limit, offset };
-      const cacheDir = CacheRouter.getChainsCacheDir(limit, offset);
+      const params = { limit: args.limit, offset: args.offset };
+      const cacheDir = CacheRouter.getChainsCacheDir(args.limit, args.offset);
       return await this.dataSource.get(
         cacheDir,
         url,
@@ -78,15 +81,23 @@ export class ConfigApi implements IConfigApi {
     }
   }
 
-  async getSafeApps(
-    chainId?: string,
-    clientUrl?: string,
-    url?: string,
-  ): Promise<SafeApp[]> {
+  async getSafeApps(args: {
+    chainId?: string;
+    clientUrl?: string;
+    url?: string;
+  }): Promise<SafeApp[]> {
     try {
       const providerUrl = `${this.baseUri}/api/v1/safe-apps/`;
-      const params = { chainId, clientUrl, url };
-      const cacheDir = CacheRouter.getSafeAppsCacheDir(chainId, clientUrl, url);
+      const params = {
+        chainId: args.chainId,
+        clientUrl: args.clientUrl,
+        url: args.url,
+      };
+      const cacheDir = CacheRouter.getSafeAppsCacheDir(
+        args.chainId,
+        args.clientUrl,
+        args.url,
+      );
       return await this.dataSource.get(
         cacheDir,
         providerUrl,

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -41,7 +41,7 @@ export class ConfigApi implements IConfigApi {
     try {
       const url = `${this.baseUri}/api/v1/chains`;
       const params = { limit: args.limit, offset: args.offset };
-      const cacheDir = CacheRouter.getChainsCacheDir(args.limit, args.offset);
+      const cacheDir = CacheRouter.getChainsCacheDir(args);
       return await this.dataSource.get(
         cacheDir,
         url,
@@ -93,11 +93,7 @@ export class ConfigApi implements IConfigApi {
         clientUrl: args.clientUrl,
         url: args.url,
       };
-      const cacheDir = CacheRouter.getSafeAppsCacheDir(
-        args.chainId,
-        args.clientUrl,
-        args.url,
-      );
+      const cacheDir = CacheRouter.getSafeAppsCacheDir(args);
       return await this.dataSource.get(
         cacheDir,
         providerUrl,

--- a/src/datasources/transaction-api/transaction-api.service.spec.ts
+++ b/src/datasources/transaction-api/transaction-api.service.spec.ts
@@ -79,7 +79,11 @@ describe('TransactionApi', () => {
       const data = [balanceBuilder().build(), balanceBuilder().build()];
       mockDataSource.get.mockResolvedValue(data);
 
-      const actual = await service.getBalances('test', true, true);
+      const actual = await service.getBalances({
+        safeAddress: 'test',
+        trusted: true,
+        excludeSpam: true,
+      });
 
       expect(actual).toBe(data);
       expect(mockHttpErrorFactory.from).toBeCalledTimes(0);
@@ -91,7 +95,11 @@ describe('TransactionApi', () => {
       mockHttpErrorFactory.from.mockReturnValue(expected);
 
       await expect(
-        service.getBalances('test', true, true),
+        service.getBalances({
+          safeAddress: 'test',
+          trusted: true,
+          excludeSpam: true,
+        }),
       ).rejects.toThrowError(expected);
 
       expect(mockDataSource.get).toHaveBeenCalledTimes(1);

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -67,12 +67,10 @@ export class TransactionApi implements ITransactionApi {
     excludeSpam?: boolean;
   }): Promise<Balance[]> {
     try {
-      const cacheDir = CacheRouter.getBalanceCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.trusted,
-        args.excludeSpam,
-      );
+      const cacheDir = CacheRouter.getBalanceCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/balances/usd/`;
       return await this.dataSource.get(
         cacheDir,
@@ -92,7 +90,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async clearLocalBalances(safeAddress: string): Promise<void> {
-    const cacheKey = CacheRouter.getBalancesCacheKey(this.chainId, safeAddress);
+    const cacheKey = CacheRouter.getBalancesCacheKey({
+      chainId: this.chainId,
+      safeAddress,
+    });
     await this.cacheService.deleteByKey(cacheKey);
   }
 
@@ -120,14 +121,10 @@ export class TransactionApi implements ITransactionApi {
     excludeSpam?: boolean;
   }): Promise<Page<Collectible>> {
     try {
-      const cacheDir = CacheRouter.getCollectiblesCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.limit,
-        args.offset,
-        args.trusted,
-        args.excludeSpam,
-      );
+      const cacheDir = CacheRouter.getCollectiblesCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v2/safes/${args.safeAddress}/collectibles/`;
       return await this.dataSource.get(
         cacheDir,
@@ -149,7 +146,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   clearCollectibles(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getCollectiblesKey(this.chainId, safeAddress);
+    const key = CacheRouter.getCollectiblesKey({
+      chainId: this.chainId,
+      safeAddress,
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -193,7 +193,10 @@ export class TransactionApi implements ITransactionApi {
 
   async getSafe(safeAddress: string): Promise<Safe> {
     try {
-      const cacheDir = CacheRouter.getSafeCacheDir(this.chainId, safeAddress);
+      const cacheDir = CacheRouter.getSafeCacheDir({
+        chainId: this.chainId,
+        safeAddress,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}`;
       return await this.dataSource.get(
         cacheDir,
@@ -208,7 +211,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async clearSafe(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getSafeCacheKey(this.chainId, safeAddress);
+    const key = CacheRouter.getSafeCacheKey({
+      chainId: this.chainId,
+      safeAddress,
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -218,10 +224,10 @@ export class TransactionApi implements ITransactionApi {
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
   async getContract(contractAddress: string): Promise<Contract> {
     try {
-      const cacheDir = CacheRouter.getContractCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getContractCacheDir({
+        chainId: this.chainId,
         contractAddress,
-      );
+      });
       const url = `${this.baseUrl}/api/v1/contracts/${contractAddress}`;
       return await this.dataSource.get(
         cacheDir,
@@ -244,15 +250,10 @@ export class TransactionApi implements ITransactionApi {
     offset?: number;
   }): Promise<Page<Delegate>> {
     try {
-      const cacheDir = CacheRouter.getDelegatesCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.delegate,
-        args.delegator,
-        args.label,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getDelegatesCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/delegates/`;
       return await this.dataSource.get(
         cacheDir,
@@ -333,10 +334,10 @@ export class TransactionApi implements ITransactionApi {
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
   async getTransfer(transferId: string): Promise<Transfer> {
     try {
-      const cacheDir = CacheRouter.getTransferCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getTransferCacheDir({
+        chainId: this.chainId,
         transferId,
-      );
+      });
       const url = `${this.baseUrl}/api/v1/transfer/${transferId}`;
       return await this.dataSource.get(
         cacheDir,
@@ -358,14 +359,10 @@ export class TransactionApi implements ITransactionApi {
     offset?: number;
   }): Promise<Page<Transfer>> {
     try {
-      const cacheDir = CacheRouter.getTransfersCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.onlyErc20,
-        args.onlyErc721,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getTransfersCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/transfers/`;
       return await this.dataSource.get(
         cacheDir,
@@ -387,7 +384,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   clearTransfers(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getTransfersCacheKey(this.chainId, safeAddress);
+    const key = CacheRouter.getTransfersCacheKey({
+      chainId: this.chainId,
+      safeAddress,
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -404,17 +404,10 @@ export class TransactionApi implements ITransactionApi {
     offset?: number;
   }): Promise<Page<Transfer>> {
     try {
-      const cacheDir = CacheRouter.getIncomingTransfersCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.executionDateGte,
-        args.executionDateLte,
-        args.to,
-        args.value,
-        args.tokenAddress,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getIncomingTransfersCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/incoming-transfers/`;
       return await this.dataSource.get(
         cacheDir,
@@ -439,24 +432,24 @@ export class TransactionApi implements ITransactionApi {
   }
 
   clearIncomingTransfers(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getIncomingTransfersCacheKey(
-      this.chainId,
+    const key = CacheRouter.getIncomingTransfersCacheKey({
+      chainId: this.chainId,
       safeAddress,
-    );
+    });
 
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
   }
 
-  async postConfirmation(
-    safeTxHash: string,
-    addConfirmationDto: AddConfirmationDto,
-  ): Promise<unknown> {
+  async postConfirmation(args: {
+    safeTxHash: string;
+    addConfirmationDto: AddConfirmationDto;
+  }): Promise<unknown> {
     try {
-      const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTxHash}/confirmations/`;
+      const url = `${this.baseUrl}/api/v1/multisig-transactions/${args.safeTxHash}/confirmations/`;
       return await this.networkService.post(url, {
-        signature: addConfirmationDto.signedSafeTxHash,
+        signature: args.addConfirmationDto.signedSafeTxHash,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -469,10 +462,10 @@ export class TransactionApi implements ITransactionApi {
     moduleTransactionId: string,
   ): Promise<ModuleTransaction> {
     try {
-      const cacheDir = CacheRouter.getModuleTransactionsCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getModuleTransactionCacheDir({
+        chainId: this.chainId,
         moduleTransactionId,
-      );
+      });
       const url = `${this.baseUrl}/api/v1/module-transaction/${moduleTransactionId}`;
       return await this.dataSource.get(
         cacheDir,
@@ -494,14 +487,10 @@ export class TransactionApi implements ITransactionApi {
     offset?: number;
   }): Promise<Page<ModuleTransaction>> {
     try {
-      const cacheDir = CacheRouter.getModuleTransactionsCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.to,
-        args.module,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getModuleTransactionsCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/module-transactions/`;
       return await this.dataSource.get(
         cacheDir,
@@ -523,10 +512,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   clearModuleTransactions(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getModuleTransactionsCacheKey(
-      this.chainId,
+    const key = CacheRouter.getModuleTransactionsCacheKey({
+      chainId: this.chainId,
       safeAddress,
-    );
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -547,21 +536,10 @@ export class TransactionApi implements ITransactionApi {
     offset?: number;
   }): Promise<Page<MultisigTransaction>> {
     try {
-      const cacheDir = CacheRouter.getMultisigTransactionsCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.ordering,
-        args.executed,
-        args.trusted,
-        args.executionDateGte,
-        args.executionDateLte,
-        args.to,
-        args.value,
-        args.nonce,
-        args.nonceGte,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getMultisigTransactionsCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/multisig-transactions/`;
       return await this.dataSource.get(
         cacheDir,
@@ -591,10 +569,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   async clearMultisigTransactions(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getMultisigTransactionsCacheKey(
-      this.chainId,
+    const key = CacheRouter.getMultisigTransactionsCacheKey({
+      chainId: this.chainId,
       safeAddress,
-    );
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -604,10 +582,10 @@ export class TransactionApi implements ITransactionApi {
     safeTransactionHash: string,
   ): Promise<MultisigTransaction> {
     try {
-      const cacheDir = CacheRouter.getMultisigTransactionCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getMultisigTransactionCacheDir({
+        chainId: this.chainId,
         safeTransactionHash,
-      );
+      });
       const url = `${this.baseUrl}/api/v1/multisig-transactions/${safeTransactionHash}/`;
       return await this.dataSource.get(
         cacheDir,
@@ -622,10 +600,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   clearMultisigTransaction(safeTransactionHash: string): Promise<void> {
-    const key = CacheRouter.getMultisigTransactionCacheKey(
-      this.chainId,
+    const key = CacheRouter.getMultisigTransactionCacheKey({
+      chainId: this.chainId,
       safeTransactionHash,
-    );
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -637,10 +615,10 @@ export class TransactionApi implements ITransactionApi {
     safeAddress: string,
   ): Promise<CreationTransaction> {
     try {
-      const cacheDir = CacheRouter.getCreationTransactionCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getCreationTransactionCacheDir({
+        chainId: this.chainId,
         safeAddress,
-      );
+      });
       const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/creation/`;
       return await this.dataSource.get(
         cacheDir,
@@ -663,15 +641,10 @@ export class TransactionApi implements ITransactionApi {
     offset?: number;
   }): Promise<Page<Transaction>> {
     try {
-      const cacheDir = CacheRouter.getAllTransactionsCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.ordering,
-        args.executed,
-        args.queued,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getAllTransactionsCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/all-transactions/`;
       return await this.dataSource.get(
         cacheDir,
@@ -695,7 +668,10 @@ export class TransactionApi implements ITransactionApi {
   }
 
   clearAllTransactions(safeAddress: string): Promise<void> {
-    const key = CacheRouter.getAllTransactionsKey(this.chainId, safeAddress);
+    const key = CacheRouter.getAllTransactionsKey({
+      chainId: this.chainId,
+      safeAddress,
+    });
     return this.cacheService.deleteByKey(key).then(() => {
       return;
     });
@@ -705,7 +681,10 @@ export class TransactionApi implements ITransactionApi {
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
   async getToken(address: string): Promise<Token> {
     try {
-      const cacheDir = CacheRouter.getTokenCacheDir(this.chainId, address);
+      const cacheDir = CacheRouter.getTokenCacheDir({
+        chainId: this.chainId,
+        address,
+      });
       const url = `${this.baseUrl}/api/v1/tokens/${address}`;
       return await this.dataSource.get(
         cacheDir,
@@ -721,13 +700,15 @@ export class TransactionApi implements ITransactionApi {
 
   // Important: there is no hook which invalidates this endpoint,
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
-  async getTokens(limit?: number, offset?: number): Promise<Page<Token>> {
+  async getTokens(args: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Token>> {
     try {
-      const cacheDir = CacheRouter.getTokensCacheDir(
-        this.chainId,
-        limit,
-        offset,
-      );
+      const cacheDir = CacheRouter.getTokensCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       const url = `${this.baseUrl}/api/v1/tokens/`;
       return await this.dataSource.get(
         cacheDir,
@@ -735,8 +716,8 @@ export class TransactionApi implements ITransactionApi {
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            limit: limit,
-            offset: offset,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -750,10 +731,10 @@ export class TransactionApi implements ITransactionApi {
   // Therefore, this data will live in cache until [defaultExpirationTimeInSeconds]
   async getSafesByOwner(ownerAddress: string): Promise<SafeList> {
     try {
-      const cacheDir = CacheRouter.getSafesByOwnerCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getSafesByOwnerCacheDir({
+        chainId: this.chainId,
         ownerAddress,
-      );
+      });
       const url = `${this.baseUrl}/api/v1/owners/${ownerAddress}/safes/`;
       return await this.dataSource.get(
         cacheDir,
@@ -767,23 +748,23 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async postDeviceRegistration(
-    device: Device,
-    safes: string[],
-    signatures: string[],
-  ): Promise<void> {
+  async postDeviceRegistration(args: {
+    device: Device;
+    safes: string[];
+    signatures: string[];
+  }): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/notifications/devices/`;
       await this.networkService.post(url, {
-        uuid: device.uuid,
-        cloudMessagingToken: device.cloudMessagingToken,
-        buildNumber: device.buildNumber,
-        bundle: device.bundle,
-        deviceType: device.deviceType,
-        version: device.version,
-        timestamp: device.timestamp,
-        safes,
-        signatures,
+        uuid: args.device.uuid,
+        cloudMessagingToken: args.device.cloudMessagingToken,
+        buildNumber: args.device.buildNumber,
+        bundle: args.device.bundle,
+        deviceType: args.device.deviceType,
+        version: args.device.version,
+        timestamp: args.device.timestamp,
+        safes: args.safes,
+        signatures: args.signatures,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -802,17 +783,17 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getEstimation(
-    address: string,
-    getEstimationDto: GetEstimationDto,
-  ): Promise<Estimation> {
+  async getEstimation(args: {
+    address: string;
+    getEstimationDto: GetEstimationDto;
+  }): Promise<Estimation> {
     try {
-      const url = `${this.baseUrl}/api/v1/safes/${address}/multisig-transactions/estimations/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.address}/multisig-transactions/estimations/`;
       const { data: estimation } = await this.networkService.post(url, {
-        to: getEstimationDto.to,
-        value: getEstimationDto.value,
-        data: getEstimationDto.data,
-        operation: getEstimationDto.operation,
+        to: args.getEstimationDto.to,
+        value: args.getEstimationDto.value,
+        data: args.getEstimationDto.data,
+        operation: args.getEstimationDto.operation,
       });
       return estimation;
     } catch (error) {
@@ -823,10 +804,10 @@ export class TransactionApi implements ITransactionApi {
   async getMessageByHash(messageHash: string): Promise<Message> {
     try {
       const url = `${this.baseUrl}/api/v1/messages/${messageHash}`;
-      const cacheDir = CacheRouter.getMessageByHashCacheDir(
-        this.chainId,
+      const cacheDir = CacheRouter.getMessageByHashCacheDir({
+        chainId: this.chainId,
         messageHash,
-      );
+      });
       return await this.dataSource.get(
         cacheDir,
         url,
@@ -844,12 +825,10 @@ export class TransactionApi implements ITransactionApi {
   }): Promise<Page<Message>> {
     try {
       const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/messages/`;
-      const cacheDir = CacheRouter.getMessagesBySafeCacheDir(
-        this.chainId,
-        args.safeAddress,
-        args.limit,
-        args.offset,
-      );
+      const cacheDir = CacheRouter.getMessagesBySafeCacheDir({
+        chainId: this.chainId,
+        ...args,
+      });
       return await this.dataSource.get(
         cacheDir,
         url,
@@ -866,27 +845,27 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async postMultisigTransaction(
-    address: string,
-    proposeTransactionDto: ProposeTransactionDto,
-  ): Promise<unknown> {
+  async postMultisigTransaction(args: {
+    address: string;
+    data: ProposeTransactionDto;
+  }): Promise<unknown> {
     try {
-      const url = `${this.baseUrl}/api/v1/safes/${address}/multisig-transactions/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.address}/multisig-transactions/`;
       return await this.networkService.post(url, {
-        to: proposeTransactionDto.to,
-        value: proposeTransactionDto.value,
-        data: proposeTransactionDto.data,
-        operation: proposeTransactionDto.operation,
-        baseGas: proposeTransactionDto.baseGas,
-        gasPrice: proposeTransactionDto.gasPrice,
-        gasToken: proposeTransactionDto.gasToken,
-        refundReceiver: proposeTransactionDto.refundReceiver,
-        nonce: proposeTransactionDto.nonce,
-        safeTxGas: proposeTransactionDto.safeTxGas,
-        contractTransactionHash: proposeTransactionDto.safeTxHash,
-        sender: proposeTransactionDto.sender,
-        signature: proposeTransactionDto.signature,
-        origin: proposeTransactionDto.origin,
+        to: args.data.to,
+        value: args.data.value,
+        data: args.data.data,
+        operation: args.data.operation,
+        baseGas: args.data.baseGas,
+        gasPrice: args.data.gasPrice,
+        gasToken: args.data.gasToken,
+        refundReceiver: args.data.refundReceiver,
+        nonce: args.data.nonce,
+        safeTxGas: args.data.safeTxGas,
+        contractTransactionHash: args.data.safeTxHash,
+        sender: args.data.sender,
+        signature: args.data.signature,
+        origin: args.data.origin,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -61,27 +61,27 @@ export class TransactionApi implements ITransactionApi {
       );
   }
 
-  async getBalances(
-    safeAddress: string,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Balance[]> {
+  async getBalances(args: {
+    safeAddress: string;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Balance[]> {
     try {
       const cacheDir = CacheRouter.getBalanceCacheDir(
         this.chainId,
-        safeAddress,
-        trusted,
-        excludeSpam,
+        args.safeAddress,
+        args.trusted,
+        args.excludeSpam,
       );
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/balances/usd/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/balances/usd/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            trusted: trusted,
-            exclude_spam: excludeSpam,
+            trusted: args.trusted,
+            exclude_spam: args.excludeSpam,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -96,12 +96,15 @@ export class TransactionApi implements ITransactionApi {
     await this.cacheService.deleteByKey(cacheKey);
   }
 
-  async getDataDecoded(data: string, to?: string): Promise<DataDecoded> {
+  async getDataDecoded(args: {
+    data: string;
+    to?: string;
+  }): Promise<DataDecoded> {
     try {
       const url = `${this.baseUrl}/api/v1/data-decoder/`;
       const { data: dataDecoded } = await this.networkService.post(url, {
-        data,
-        to,
+        data: args.data,
+        to: args.to,
       });
       return dataDecoded;
     } catch (error) {
@@ -109,33 +112,33 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getCollectibles(
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Page<Collectible>> {
+  async getCollectibles(args: {
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Page<Collectible>> {
     try {
       const cacheDir = CacheRouter.getCollectiblesCacheDir(
         this.chainId,
-        safeAddress,
-        limit,
-        offset,
-        trusted,
-        excludeSpam,
+        args.safeAddress,
+        args.limit,
+        args.offset,
+        args.trusted,
+        args.excludeSpam,
       );
-      const url = `${this.baseUrl}/api/v2/safes/${safeAddress}/collectibles/`;
+      const url = `${this.baseUrl}/api/v2/safes/${args.safeAddress}/collectibles/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            limit: limit,
-            offset: offset,
-            trusted: trusted,
-            exclude_spam: excludeSpam,
+            limit: args.limit,
+            offset: args.offset,
+            trusted: args.trusted,
+            exclude_spam: args.excludeSpam,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -232,23 +235,23 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getDelegates(
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    label?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Delegate>> {
+  async getDelegates(args: {
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Delegate>> {
     try {
       const cacheDir = CacheRouter.getDelegatesCacheDir(
         this.chainId,
-        safeAddress,
-        delegate,
-        delegator,
-        label,
-        limit,
-        offset,
+        args.safeAddress,
+        args.delegate,
+        args.delegator,
+        args.label,
+        args.limit,
+        args.offset,
       );
       const url = `${this.baseUrl}/api/v1/delegates/`;
       return await this.dataSource.get(
@@ -257,12 +260,12 @@ export class TransactionApi implements ITransactionApi {
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            safe: safeAddress,
-            delegate: delegate,
-            delegator: delegator,
-            label: label,
-            limit: limit,
-            offset: offset,
+            safe: args.safeAddress,
+            delegate: args.delegate,
+            delegator: args.delegator,
+            label: args.label,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
       );
@@ -271,55 +274,55 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async postDelegate(
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    signature?: string,
-    label?: string,
-  ): Promise<void> {
+  async postDelegate(args: {
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    signature?: string;
+    label?: string;
+  }): Promise<void> {
     try {
       const url = `${this.baseUrl}/api/v1/delegates/`;
       await this.networkService.post(url, {
-        safe: safeAddress ?? null, // TODO: this is a workaround while https://github.com/safe-global/safe-transaction-service/issues/1521 is not fixed.
-        delegate: delegate,
-        delegator: delegator,
-        signature: signature,
-        label: label,
+        safe: args.safeAddress ?? null, // TODO: this is a workaround while https://github.com/safe-global/safe-transaction-service/issues/1521 is not fixed.
+        delegate: args.delegate,
+        delegator: args.delegator,
+        signature: args.signature,
+        label: args.label,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
-  async deleteDelegate(
-    delegate: string,
-    delegator: string,
-    signature: string,
-  ): Promise<unknown> {
+  async deleteDelegate(args: {
+    delegate: string;
+    delegator: string;
+    signature: string;
+  }): Promise<unknown> {
     try {
-      const url = `${this.baseUrl}/api/v1/delegates/${delegate}`;
+      const url = `${this.baseUrl}/api/v1/delegates/${args.delegate}`;
       return await this.networkService.delete(url, {
-        delegate: delegate,
-        delegator: delegator,
-        signature: signature,
+        delegate: args.delegate,
+        delegator: args.delegator,
+        signature: args.signature,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
     }
   }
 
-  async deleteSafeDelegate(
-    delegate: string,
-    safeAddress: string,
-    signature: string,
-  ): Promise<void> {
+  async deleteSafeDelegate(args: {
+    delegate: string;
+    safeAddress: string;
+    signature: string;
+  }): Promise<void> {
     try {
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/delegates/${delegate}`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/delegates/${args.delegate}`;
       return await this.networkService.delete(url, {
-        delegate: delegate,
-        safe: safeAddress,
-        signature: signature,
+        delegate: args.delegate,
+        safe: args.safeAddress,
+        signature: args.signature,
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -347,33 +350,33 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getTransfers(
-    safeAddress: string,
-    onlyErc20: boolean,
-    onlyErc721: boolean,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>> {
+  async getTransfers(args: {
+    safeAddress: string;
+    onlyErc20: boolean;
+    onlyErc721: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>> {
     try {
       const cacheDir = CacheRouter.getTransfersCacheDir(
         this.chainId,
-        safeAddress,
-        onlyErc20,
-        onlyErc721,
-        limit,
-        offset,
+        args.safeAddress,
+        args.onlyErc20,
+        args.onlyErc721,
+        args.limit,
+        args.offset,
       );
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/transfers/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/transfers/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            erc20: onlyErc20,
-            erc721: onlyErc721,
-            limit: limit,
-            offset: offset,
+            erc20: args.onlyErc20,
+            erc721: args.onlyErc721,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -390,42 +393,42 @@ export class TransactionApi implements ITransactionApi {
     });
   }
 
-  async getIncomingTransfers(
-    safeAddress: string,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    tokenAddress?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>> {
+  async getIncomingTransfers(args: {
+    safeAddress: string;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    tokenAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>> {
     try {
       const cacheDir = CacheRouter.getIncomingTransfersCacheDir(
         this.chainId,
-        safeAddress,
-        executionDateGte,
-        executionDateLte,
-        to,
-        value,
-        tokenAddress,
-        limit,
-        offset,
+        args.safeAddress,
+        args.executionDateGte,
+        args.executionDateLte,
+        args.to,
+        args.value,
+        args.tokenAddress,
+        args.limit,
+        args.offset,
       );
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/incoming-transfers/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/incoming-transfers/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            execution_date__gte: executionDateGte,
-            execution_date__lte: executionDateLte,
-            to,
-            value,
-            tokenAddress,
-            limit,
-            offset,
+            execution_date__gte: args.executionDateGte,
+            execution_date__lte: args.executionDateLte,
+            to: args.to,
+            value: args.value,
+            tokenAddress: args.tokenAddress,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -483,33 +486,33 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getModuleTransactions(
-    safeAddress: string,
-    to?: string,
-    module?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<ModuleTransaction>> {
+  async getModuleTransactions(args: {
+    safeAddress: string;
+    to?: string;
+    module?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<ModuleTransaction>> {
     try {
       const cacheDir = CacheRouter.getModuleTransactionsCacheDir(
         this.chainId,
-        safeAddress,
-        to,
-        module,
-        limit,
-        offset,
+        args.safeAddress,
+        args.to,
+        args.module,
+        args.limit,
+        args.offset,
       );
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/module-transactions/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/module-transactions/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            to,
-            module,
-            limit,
-            offset,
+            to: args.to,
+            module: args.module,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -529,55 +532,55 @@ export class TransactionApi implements ITransactionApi {
     });
   }
 
-  async getMultisigTransactions(
-    safeAddress: string,
-    ordering?: string,
-    executed?: boolean,
-    trusted?: boolean,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    nonce?: string,
-    nonceGte?: number,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>> {
+  async getMultisigTransactions(args: {
+    safeAddress: string;
+    ordering?: string;
+    executed?: boolean;
+    trusted?: boolean;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    nonce?: string;
+    nonceGte?: number;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>> {
     try {
       const cacheDir = CacheRouter.getMultisigTransactionsCacheDir(
         this.chainId,
-        safeAddress,
-        ordering,
-        executed,
-        trusted,
-        executionDateGte,
-        executionDateLte,
-        to,
-        value,
-        nonce,
-        nonceGte,
-        limit,
-        offset,
+        args.safeAddress,
+        args.ordering,
+        args.executed,
+        args.trusted,
+        args.executionDateGte,
+        args.executionDateLte,
+        args.to,
+        args.value,
+        args.nonce,
+        args.nonceGte,
+        args.limit,
+        args.offset,
       );
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/multisig-transactions/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            safe: safeAddress,
-            ordering,
-            executed,
-            trusted,
-            execution_date__gte: executionDateGte,
-            execution_date__lte: executionDateLte,
-            to,
-            value,
-            nonce,
-            nonce__gte: nonceGte,
-            limit,
-            offset,
+            safe: args.safeAddress,
+            ordering: args.ordering,
+            executed: args.executed,
+            trusted: args.trusted,
+            execution_date__gte: args.executionDateGte,
+            execution_date__lte: args.executionDateLte,
+            to: args.to,
+            value: args.value,
+            nonce: args.nonce,
+            nonce__gte: args.nonceGte,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -651,37 +654,37 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getAllTransactions(
-    safeAddress: string,
-    ordering?: string,
-    executed?: boolean,
-    queued?: boolean,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>> {
+  async getAllTransactions(args: {
+    safeAddress: string;
+    ordering?: string;
+    executed?: boolean;
+    queued?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>> {
     try {
       const cacheDir = CacheRouter.getAllTransactionsCacheDir(
         this.chainId,
-        safeAddress,
-        ordering,
-        executed,
-        queued,
-        limit,
-        offset,
+        args.safeAddress,
+        args.ordering,
+        args.executed,
+        args.queued,
+        args.limit,
+        args.offset,
       );
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/all-transactions/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/all-transactions/`;
       return await this.dataSource.get(
         cacheDir,
         url,
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            safe: safeAddress,
-            ordering: ordering,
-            executed: executed,
-            queued: queued,
-            limit: limit,
-            offset: offset,
+            safe: args.safeAddress,
+            ordering: args.ordering,
+            executed: args.executed,
+            queued: args.queued,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
         this.defaultExpirationTimeInSeconds,
@@ -787,12 +790,12 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async deleteDeviceRegistration(
-    uuid: string,
-    safeAddress: string,
-  ): Promise<void> {
+  async deleteDeviceRegistration(args: {
+    uuid: string;
+    safeAddress: string;
+  }): Promise<void> {
     try {
-      const url = `${this.baseUrl}/api/v1/notifications/devices/${uuid}/safes/${safeAddress}`;
+      const url = `${this.baseUrl}/api/v1/notifications/devices/${args.uuid}/safes/${args.safeAddress}`;
       await this.networkService.delete(url);
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -834,18 +837,18 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async getMessagesBySafe(
-    safeAddress: string,
-    limit?: number | undefined,
-    offset?: number | undefined,
-  ): Promise<Page<Message>> {
+  async getMessagesBySafe(args: {
+    safeAddress: string;
+    limit?: number | undefined;
+    offset?: number | undefined;
+  }): Promise<Page<Message>> {
     try {
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/messages/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/messages/`;
       const cacheDir = CacheRouter.getMessagesBySafeCacheDir(
         this.chainId,
-        safeAddress,
-        limit,
-        offset,
+        args.safeAddress,
+        args.limit,
+        args.offset,
       );
       return await this.dataSource.get(
         cacheDir,
@@ -853,8 +856,8 @@ export class TransactionApi implements ITransactionApi {
         this.defaultNotFoundExpirationTimeSeconds,
         {
           params: {
-            limit: limit,
-            offset: offset,
+            limit: args.limit,
+            offset: args.offset,
           },
         },
       );
@@ -890,18 +893,18 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async postMessage(
-    safeAddress: string,
-    message: unknown,
-    safeAppId: number | null,
-    signature: string,
-  ): Promise<Message> {
+  async postMessage(args: {
+    safeAddress: string;
+    message: unknown;
+    safeAppId: number | null;
+    signature: string;
+  }): Promise<Message> {
     try {
-      const url = `${this.baseUrl}/api/v1/safes/${safeAddress}/messages/`;
+      const url = `${this.baseUrl}/api/v1/safes/${args.safeAddress}/messages/`;
       const { data } = await this.networkService.post(url, {
-        message,
-        safeAppId,
-        signature,
+        message: args.message,
+        safeAppId: args.safeAppId,
+        signature: args.signature,
       });
       return data;
     } catch (error) {
@@ -909,13 +912,15 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async postMessageSignature(
-    messageHash: string,
-    signature: string,
-  ): Promise<unknown> {
+  async postMessageSignature(args: {
+    messageHash: string;
+    signature: string;
+  }): Promise<unknown> {
     try {
-      const url = `${this.baseUrl}/api/v1/messages/${messageHash}/signatures/`;
-      const { data } = await this.networkService.post(url, { signature });
+      const url = `${this.baseUrl}/api/v1/messages/${args.messageHash}/signatures/`;
+      const { data } = await this.networkService.post(url, {
+        signature: args.signature,
+      });
       return data;
     } catch (error) {
       throw this.httpErrorFactory.from(error);

--- a/src/domain/balances/balances.repository.interface.ts
+++ b/src/domain/balances/balances.repository.interface.ts
@@ -6,24 +6,19 @@ export interface IBalancesRepository {
   /**
    * Gets the collection of {@link Balance} associated with {@link safeAddress}
    * on {@link chainId}
-   *
-   * @param chainId
-   * @param safeAddress
-   * @param trusted - filters trusted tokens
-   * @param excludeSpam - excludes tokens marked as spam
    */
-  getBalances(
-    chainId: string,
-    safeAddress: string,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Balance[]>;
+  getBalances(args: {
+    chainId: string;
+    safeAddress: string;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Balance[]>;
 
   /**
    * Clears any stored local balance data of {@link safeAddress} on {@link chainId}
-   *
-   * @param chainId
-   * @param safeAddress
    */
-  clearLocalBalances(chainId: string, safeAddress: string): Promise<void>;
+  clearLocalBalances(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 }

--- a/src/domain/balances/balances.repository.ts
+++ b/src/domain/balances/balances.repository.ts
@@ -12,22 +12,30 @@ export class BalancesRepository implements IBalancesRepository {
     private readonly validator: BalancesValidator,
   ) {}
 
-  async getBalances(
-    chainId: string,
-    safeAddress: string,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Balance[]> {
-    const api = await this.transactionApiManager.getTransactionApi(chainId);
-    const balances = await api.getBalances(safeAddress, trusted, excludeSpam);
+  async getBalances(args: {
+    chainId: string;
+    safeAddress: string;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Balance[]> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    const balances = await api.getBalances({
+      safeAddress: args.safeAddress,
+      trusted: args.trusted,
+      excludeSpam: args.excludeSpam,
+    });
     return balances.map((balance) => this.validator.validate(balance));
   }
 
-  async clearLocalBalances(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
-    const api = await this.transactionApiManager.getTransactionApi(chainId);
-    await api.clearLocalBalances(safeAddress);
+  async clearLocalBalances(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    await api.clearLocalBalances(args.safeAddress);
   }
 }

--- a/src/domain/chains/chains.repository.ts
+++ b/src/domain/chains/chains.repository.ts
@@ -24,7 +24,7 @@ export class ChainsRepository implements IChainsRepository {
   }
 
   async getChains(limit?: number, offset?: number): Promise<Page<Chain>> {
-    const page = await this.configApi.getChains(limit, offset);
+    const page = await this.configApi.getChains({ limit, offset });
     page?.results.map((result) => this.chainValidator.validate(result));
     return page;
   }

--- a/src/domain/collectibles/collectibles.repository.interface.ts
+++ b/src/domain/collectibles/collectibles.repository.interface.ts
@@ -6,14 +6,17 @@ export const IChainsRepository = Symbol('IChainsRepository');
 export const ICollectiblesRepository = Symbol('ICollectiblesRepository');
 
 export interface ICollectiblesRepository {
-  getCollectibles(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Page<Collectible>>;
+  getCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Page<Collectible>>;
 
-  clearCollectibles(chainId: string, safeAddress: string): Promise<void>;
+  clearCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 }

--- a/src/domain/collectibles/collectibles.repository.ts
+++ b/src/domain/collectibles/collectibles.repository.ts
@@ -13,34 +13,37 @@ export class CollectiblesRepository implements ICollectiblesRepository {
     private readonly validator: CollectiblesValidator,
   ) {}
 
-  async getCollectibles(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Page<Collectible>> {
+  async getCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Page<Collectible>> {
     const transactionApi = await this.transactionApiManager.getTransactionApi(
-      chainId,
+      args.chainId,
     );
-    const page = await transactionApi.getCollectibles(
-      safeAddress,
-      limit,
-      offset,
-      trusted,
-      excludeSpam,
-    );
+    const page = await transactionApi.getCollectibles({
+      safeAddress: args.safeAddress,
+      limit: args.limit,
+      offset: args.offset,
+      trusted: args.trusted,
+      excludeSpam: args.excludeSpam,
+    });
 
     page?.results.map((result) => this.validator.validate(result));
     return page;
   }
 
-  async clearCollectibles(chainId: string, safeAddress: string): Promise<void> {
+  async clearCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
     const transactionApi = await this.transactionApiManager.getTransactionApi(
-      chainId,
+      args.chainId,
     );
 
-    return transactionApi.clearCollectibles(safeAddress);
+    return transactionApi.clearCollectibles(args.safeAddress);
   }
 }

--- a/src/domain/contracts/contracts.repository.interface.ts
+++ b/src/domain/contracts/contracts.repository.interface.ts
@@ -5,9 +5,9 @@ export const IContractsRepository = Symbol('IContractsRepository');
 export interface IContractsRepository {
   /**
    * Gets the {@link Contract} associated with the {@link chainId} and the {@link contractAddress}.
-   *
-   * @param chainId
-   * @param contractAddress
    */
-  getContract(chainId: string, contractAddress: string): Promise<Contract>;
+  getContract(args: {
+    chainId: string;
+    contractAddress: string;
+  }): Promise<Contract>;
 }

--- a/src/domain/contracts/contracts.repository.ts
+++ b/src/domain/contracts/contracts.repository.ts
@@ -12,12 +12,14 @@ export class ContractsRepository implements IContractsRepository {
     private readonly validator: ContractsValidator,
   ) {}
 
-  async getContract(
-    chainId: string,
-    contractAddress: string,
-  ): Promise<Contract> {
-    const api = await this.transactionApiManager.getTransactionApi(chainId);
-    const data = await api.getContract(contractAddress);
+  async getContract(args: {
+    chainId: string;
+    contractAddress: string;
+  }): Promise<Contract> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    const data = await api.getContract(args.contractAddress);
     return this.validator.validate(data);
   }
 }

--- a/src/domain/data-decoder/data-decoded.repository.interface.ts
+++ b/src/domain/data-decoder/data-decoded.repository.interface.ts
@@ -6,14 +6,10 @@ export interface IDataDecodedRepository {
   /**
    * Gets the {@link DataDecoded} associated with {@link chainId} the for the {@link data}
    * and the address pointed by {@link to}.
-   *
-   * @param chainId
-   * @param data
-   * @param to
    */
-  getDataDecoded(
-    chainId: string,
-    data: string,
-    to: string,
-  ): Promise<DataDecoded>;
+  getDataDecoded(args: {
+    chainId: string;
+    data: string;
+    to: string;
+  }): Promise<DataDecoded>;
 }

--- a/src/domain/data-decoder/data-decoded.repository.ts
+++ b/src/domain/data-decoder/data-decoded.repository.ts
@@ -12,13 +12,18 @@ export class DataDecodedRepository implements IDataDecodedRepository {
     private readonly validator: DataDecodedValidator,
   ) {}
 
-  async getDataDecoded(
-    chainId: string,
-    data: string,
-    to?: string,
-  ): Promise<DataDecoded> {
-    const api = await this.transactionApiManager.getTransactionApi(chainId);
-    const dataDecoded = await api.getDataDecoded(data, to);
+  async getDataDecoded(args: {
+    chainId: string;
+    data: string;
+    to?: string;
+  }): Promise<DataDecoded> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    const dataDecoded = await api.getDataDecoded({
+      data: args.data,
+      to: args.to,
+    });
     return this.validator.validate(dataDecoded);
   }
 }

--- a/src/domain/delegate/delegate.repository.interface.ts
+++ b/src/domain/delegate/delegate.repository.interface.ts
@@ -4,36 +4,36 @@ import { Delegate } from './entities/delegate.entity';
 export const IDelegateRepository = Symbol('IDelegateRepository');
 
 export interface IDelegateRepository {
-  getDelegates(
-    chainId: string,
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    label?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Delegate>>;
+  getDelegates(args: {
+    chainId: string;
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Delegate>>;
 
-  postDelegate(
-    chainId: string,
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    signature?: string,
-    label?: string,
-  ): Promise<void>;
+  postDelegate(args: {
+    chainId: string;
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    signature?: string;
+    label?: string;
+  }): Promise<void>;
 
-  deleteDelegate(
-    chainId: string,
-    delegate: string,
-    delegator: string,
-    signature: string,
-  ): Promise<unknown>;
+  deleteDelegate(args: {
+    chainId: string;
+    delegate: string;
+    delegator: string;
+    signature: string;
+  }): Promise<unknown>;
 
-  deleteSafeDelegate(
-    chainId: string,
-    delegate: string,
-    safeAddress: string,
-    signature: string,
-  ): Promise<void>;
+  deleteSafeDelegate(args: {
+    chainId: string;
+    delegate: string;
+    safeAddress: string;
+    signature: string;
+  }): Promise<void>;
 }

--- a/src/domain/delegate/delegate.repository.ts
+++ b/src/domain/delegate/delegate.repository.ts
@@ -13,77 +13,76 @@ export class DelegateRepository implements IDelegateRepository {
     private readonly delegateValidator: DelegateValidator,
   ) {}
 
-  async getDelegates(
-    chainId: string,
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    label?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Delegate>> {
+  async getDelegates(args: {
+    chainId: string;
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Delegate>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const page = await transactionService.getDelegates(
-      safeAddress,
-      delegate,
-      delegator,
-      label,
-      limit,
-      offset,
-    );
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getDelegates({
+      safeAddress: args.safeAddress,
+      delegate: args.delegate,
+      delegator: args.delegator,
+      label: args.label,
+      limit: args.limit,
+      offset: args.offset,
+    });
 
     page?.results.map((result) => this.delegateValidator.validate(result));
     return page;
   }
 
-  async postDelegate(
-    chainId: string,
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    signature?: string,
-    label?: string,
-  ): Promise<void> {
+  async postDelegate(args: {
+    chainId: string;
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    signature?: string;
+    label?: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    await transactionService.postDelegate(
-      safeAddress,
-      delegate,
-      delegator,
-      signature,
-      label,
-    );
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    await transactionService.postDelegate({
+      safeAddress: args.safeAddress,
+      delegate: args.delegate,
+      delegator: args.delegator,
+      signature: args.signature,
+      label: args.label,
+    });
   }
 
-  async deleteDelegate(
-    chainId: string,
-    delegate: string,
-    delegator: string,
-    signature: string,
-  ): Promise<unknown> {
+  async deleteDelegate(args: {
+    chainId: string;
+    delegate: string;
+    delegator: string;
+    signature: string;
+  }): Promise<unknown> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const result = await transactionService.deleteDelegate(
-      delegate,
-      delegator,
-      signature,
-    );
-    return result;
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.deleteDelegate({
+      delegate: args.delegate,
+      delegator: args.delegator,
+      signature: args.signature,
+    });
   }
 
-  async deleteSafeDelegate(
-    chainId: string,
-    delegate: string,
-    safeAddress: string,
-    signature: string,
-  ): Promise<void> {
+  async deleteSafeDelegate(args: {
+    chainId: string;
+    delegate: string;
+    safeAddress: string;
+    signature: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    await transactionService.deleteSafeDelegate(
-      delegate,
-      safeAddress,
-      signature,
-    );
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.deleteSafeDelegate({
+      delegate: args.delegate,
+      safeAddress: args.safeAddress,
+      signature: args.signature,
+    });
   }
 }

--- a/src/domain/estimations/estimations.repository.interface.ts
+++ b/src/domain/estimations/estimations.repository.interface.ts
@@ -4,9 +4,9 @@ import { Estimation } from './entities/estimation.entity';
 export const IEstimationsRepository = Symbol('IEstimationsRepository');
 
 export interface IEstimationsRepository {
-  getEstimation(
-    chainId: string,
-    address: string,
-    getEstimationDto: GetEstimationDto,
-  ): Promise<Estimation>;
+  getEstimation(args: {
+    chainId: string;
+    address: string;
+    getEstimationDto: GetEstimationDto;
+  }): Promise<Estimation>;
 }

--- a/src/domain/estimations/estimations.repository.ts
+++ b/src/domain/estimations/estimations.repository.ts
@@ -13,13 +13,15 @@ export class EstimationsRepository implements IEstimationsRepository {
     private readonly validator: EstimationsValidator,
   ) {}
 
-  async getEstimation(
-    chainId: string,
-    address: string,
-    getEstimationDto: GetEstimationDto,
-  ): Promise<Estimation> {
-    const api = await this.transactionApiManager.getTransactionApi(chainId);
-    const data = await api.getEstimation(address, getEstimationDto);
+  async getEstimation(args: {
+    chainId: string;
+    address: string;
+    getEstimationDto: GetEstimationDto;
+  }): Promise<Estimation> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    const data = await api.getEstimation(args);
     return this.validator.validate(data);
   }
 }

--- a/src/domain/exchange/exchange.repository.interface.ts
+++ b/src/domain/exchange/exchange.repository.interface.ts
@@ -3,10 +3,8 @@ export const IExchangeRepository = Symbol('IExchangeRepository');
 export interface IExchangeRepository {
   /**
    * Gets the conversion rate between the currencies {@link to} and {@link from}
-   * @param to
-   * @param from
    */
-  convertRates(to: string, from: string): Promise<number>;
+  convertRates(args: { to: string; from: string }): Promise<number>;
 
   /**
    * Gets the available fiat codes

--- a/src/domain/exchange/exchange.repository.ts
+++ b/src/domain/exchange/exchange.repository.ts
@@ -16,20 +16,20 @@ export class ExchangeRepository implements IExchangeRepository {
     private readonly exchangeFiatCodesValidator: ExchangeFiatCodesValidator,
   ) {}
 
-  async convertRates(to: string, from: string): Promise<number> {
+  async convertRates(args: { to: string; from: string }): Promise<number> {
     const exchangeRates = await this.exchangeApi.getRates();
     this.exchangeRatesValidator.validate(exchangeRates);
 
-    const fromExchangeRate = exchangeRates.rates[from.toUpperCase()];
+    const fromExchangeRate = exchangeRates.rates[args.from.toUpperCase()];
     if (fromExchangeRate === undefined || fromExchangeRate == 0)
       throw new InternalServerErrorException(
-        `Exchange rate for ${from} is not available`,
+        `Exchange rate for ${args.from} is not available`,
       );
 
-    const toExchangeRate = exchangeRates.rates[to.toUpperCase()];
+    const toExchangeRate = exchangeRates.rates[args.to.toUpperCase()];
     if (toExchangeRate === undefined)
       throw new InternalServerErrorException(
-        `Exchange rate for ${to} is not available`,
+        `Exchange rate for ${args.to} is not available`,
       );
 
     return toExchangeRate / fromExchangeRate;

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -5,17 +5,17 @@ import { SafeApp } from '../safe-apps/entities/safe-app.entity';
 export const IConfigApi = Symbol('IConfigApi');
 
 export interface IConfigApi {
-  getChains(limit?: number, offset?: number): Promise<Page<Chain>>;
+  getChains(args: { limit?: number; offset?: number }): Promise<Page<Chain>>;
 
   clearChains(): Promise<void>;
 
   getChain(chainId: string): Promise<Chain>;
 
-  getSafeApps(
-    chainId?: string,
-    clientUrl?: string,
-    url?: string,
-  ): Promise<SafeApp[]>;
+  getSafeApps(args: {
+    chainId?: string;
+    clientUrl?: string;
+    url?: string;
+  }): Promise<SafeApp[]>;
 
   clearSafeApps(): Promise<void>;
 }

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -22,23 +22,23 @@ import { ProposeTransactionDto } from '../transactions/entities/propose-transact
 import { AddConfirmationDto } from '../transactions/entities/add-confirmation.dto.entity';
 
 export interface ITransactionApi {
-  getBalances(
-    safeAddress: string,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Balance[]>;
+  getBalances(args: {
+    safeAddress: string;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Balance[]>;
 
   clearLocalBalances(safeAddress: string): Promise<void>;
 
-  getDataDecoded(data: string, to?: string): Promise<DataDecoded>;
+  getDataDecoded(args: { data: string; to?: string }): Promise<DataDecoded>;
 
-  getCollectibles(
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Page<Collectible>>;
+  getCollectibles(args: {
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Page<Collectible>>;
 
   clearCollectibles(safeAddress: string): Promise<void>;
 
@@ -52,57 +52,57 @@ export interface ITransactionApi {
 
   getContract(contractAddress: string): Promise<Contract>;
 
-  getDelegates(
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    label?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Delegate>>;
+  getDelegates(args: {
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    label?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Delegate>>;
 
-  postDelegate(
-    safeAddress?: string,
-    delegate?: string,
-    delegator?: string,
-    signature?: string,
-    label?: string,
-  ): Promise<void>;
+  postDelegate(args: {
+    safeAddress?: string;
+    delegate?: string;
+    delegator?: string;
+    signature?: string;
+    label?: string;
+  }): Promise<void>;
 
-  deleteDelegate(
-    delegate: string,
-    delegator: string,
-    signature: string,
-  ): Promise<unknown>;
+  deleteDelegate(args: {
+    delegate: string;
+    delegator: string;
+    signature: string;
+  }): Promise<unknown>;
 
-  deleteSafeDelegate(
-    delegate: string,
-    safeAddress: string,
-    signature: string,
-  ): Promise<void>;
+  deleteSafeDelegate(args: {
+    delegate: string;
+    safeAddress: string;
+    signature: string;
+  }): Promise<void>;
 
   getTransfer(transferId: string): Promise<Transfer>;
 
-  getTransfers(
-    safeAddress: string,
-    onlyErc20?: boolean,
-    onlyErc721?: boolean,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>>;
+  getTransfers(args: {
+    safeAddress: string;
+    onlyErc20?: boolean;
+    onlyErc721?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>>;
 
   clearTransfers(safeAddress: string): Promise<void>;
 
-  getIncomingTransfers(
-    safeAddress: string,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    tokenAddress?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>>;
+  getIncomingTransfers(args: {
+    safeAddress: string;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    tokenAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>>;
 
   clearIncomingTransfers(safeAddress: string): Promise<void>;
 
@@ -113,13 +113,13 @@ export interface ITransactionApi {
 
   getModuleTransaction(moduleTransactionId: string): Promise<ModuleTransaction>;
 
-  getModuleTransactions(
-    safeAddress: string,
-    to?: string,
-    module?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<ModuleTransaction>>;
+  getModuleTransactions(args: {
+    safeAddress: string;
+    to?: string;
+    module?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<ModuleTransaction>>;
 
   clearModuleTransactions(safeAddress: string): Promise<void>;
 
@@ -129,33 +129,33 @@ export interface ITransactionApi {
 
   clearMultisigTransaction(safeTransactionHash: string): Promise<void>;
 
-  getMultisigTransactions(
-    safeAddress: string,
-    ordering?: string,
-    executed?: boolean,
-    trusted?: boolean,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    nonce?: string,
-    nonceGte?: number,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>>;
+  getMultisigTransactions(args: {
+    safeAddress: string;
+    ordering?: string;
+    executed?: boolean;
+    trusted?: boolean;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    nonce?: string;
+    nonceGte?: number;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>>;
 
   clearMultisigTransactions(safeAddress): Promise<void>;
 
   getCreationTransaction(safeAddress: string): Promise<CreationTransaction>;
 
-  getAllTransactions(
-    safeAddress: string,
-    ordering?: string,
-    executed?: boolean,
-    queued?: boolean,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>>;
+  getAllTransactions(args: {
+    safeAddress: string;
+    ordering?: string;
+    executed?: boolean;
+    queued?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>>;
 
   clearAllTransactions(safeAddress: string): Promise<void>;
 
@@ -171,7 +171,10 @@ export interface ITransactionApi {
     signatures: string[],
   ): Promise<void>;
 
-  deleteDeviceRegistration(uuid: string, safeAddress: string): Promise<void>;
+  deleteDeviceRegistration(args: {
+    uuid: string;
+    safeAddress: string;
+  }): Promise<void>;
 
   getEstimation(
     address: string,
@@ -180,26 +183,26 @@ export interface ITransactionApi {
 
   getMessageByHash(messageHash: string): Promise<Message>;
 
-  getMessagesBySafe(
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Message>>;
+  getMessagesBySafe(args: {
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Message>>;
 
   postMultisigTransaction(
     address: string,
     data: ProposeTransactionDto,
   ): Promise<unknown>;
 
-  postMessage(
-    safeAddress: string,
-    message: string | unknown,
-    safeAppId: number | null,
-    signature: string,
-  ): Promise<Message>;
+  postMessage(args: {
+    safeAddress: string;
+    message: string | unknown;
+    safeAppId: number | null;
+    signature: string;
+  }): Promise<Message>;
 
-  postMessageSignature(
-    messageHash: string,
-    signature: string,
-  ): Promise<unknown>;
+  postMessageSignature(args: {
+    messageHash: string;
+    signature: string;
+  }): Promise<unknown>;
 }

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -106,10 +106,10 @@ export interface ITransactionApi {
 
   clearIncomingTransfers(safeAddress: string): Promise<void>;
 
-  postConfirmation(
-    safeTxHash: string,
-    addConfirmationDto: AddConfirmationDto,
-  ): Promise<unknown>;
+  postConfirmation(args: {
+    safeTxHash: string;
+    addConfirmationDto: AddConfirmationDto;
+  }): Promise<unknown>;
 
   getModuleTransaction(moduleTransactionId: string): Promise<ModuleTransaction>;
 
@@ -144,7 +144,7 @@ export interface ITransactionApi {
     offset?: number;
   }): Promise<Page<MultisigTransaction>>;
 
-  clearMultisigTransactions(safeAddress): Promise<void>;
+  clearMultisigTransactions(safeAddress: string): Promise<void>;
 
   getCreationTransaction(safeAddress: string): Promise<CreationTransaction>;
 
@@ -161,25 +161,25 @@ export interface ITransactionApi {
 
   getToken(address: string): Promise<Token>;
 
-  getTokens(limit?: number, offset?: number): Promise<Page<Token>>;
+  getTokens(args: { limit?: number; offset?: number }): Promise<Page<Token>>;
 
   getSafesByOwner(ownerAddress: string): Promise<SafeList>;
 
-  postDeviceRegistration(
-    device: Device,
-    safes: string[],
-    signatures: string[],
-  ): Promise<void>;
+  postDeviceRegistration(args: {
+    device: Device;
+    safes: string[];
+    signatures: string[];
+  }): Promise<void>;
 
   deleteDeviceRegistration(args: {
     uuid: string;
     safeAddress: string;
   }): Promise<void>;
 
-  getEstimation(
-    address: string,
-    getEstimationDto: GetEstimationDto,
-  ): Promise<Estimation>;
+  getEstimation(args: {
+    address: string;
+    getEstimationDto: GetEstimationDto;
+  }): Promise<Estimation>;
 
   getMessageByHash(messageHash: string): Promise<Message>;
 
@@ -189,10 +189,10 @@ export interface ITransactionApi {
     offset?: number;
   }): Promise<Page<Message>>;
 
-  postMultisigTransaction(
-    address: string,
-    data: ProposeTransactionDto,
-  ): Promise<unknown>;
+  postMultisigTransaction(args: {
+    address: string;
+    data: ProposeTransactionDto;
+  }): Promise<unknown>;
 
   postMessage(args: {
     safeAddress: string;

--- a/src/domain/messages/messages.repository.interface.ts
+++ b/src/domain/messages/messages.repository.interface.ts
@@ -4,26 +4,29 @@ import { Message } from './entities/message.entity';
 export const IMessagesRepository = Symbol('IMessagesRepository');
 
 export interface IMessagesRepository {
-  getMessageByHash(chainId: string, messageHash: string): Promise<Message>;
+  getMessageByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<Message>;
 
-  getMessagesBySafe(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Message>>;
+  getMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Message>>;
 
-  createMessage(
-    chainId: string,
-    safeAddress: string,
-    message: unknown,
-    safeAppId: number,
-    signature: string,
-  ): Promise<unknown>;
+  createMessage(args: {
+    chainId: string;
+    safeAddress: string;
+    message: unknown;
+    safeAppId: number;
+    signature: string;
+  }): Promise<unknown>;
 
-  updateMessageSignature(
-    chainId: string,
-    messageHash: string,
-    signature: string,
-  ): Promise<unknown>;
+  updateMessageSignature(args: {
+    chainId: string;
+    messageHash: string;
+    signature: string;
+  }): Promise<unknown>;
 }

--- a/src/domain/messages/messages.repository.ts
+++ b/src/domain/messages/messages.repository.ts
@@ -13,59 +13,62 @@ export class MessagesRepository implements IMessagesRepository {
     private readonly messageValidator: MessageValidator,
   ) {}
 
-  async getMessageByHash(
-    chainId: string,
-    messageHash: string,
-  ): Promise<Message> {
+  async getMessageByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<Message> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const message = await transactionService.getMessageByHash(messageHash);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const message = await transactionService.getMessageByHash(args.messageHash);
     return this.messageValidator.validate(message);
   }
 
-  async getMessagesBySafe(
-    chainId: string,
-    safeAddress: string,
-    limit?: number | undefined,
-    offset?: number | undefined,
-  ): Promise<Page<Message>> {
+  async getMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number | undefined;
+    offset?: number | undefined;
+  }): Promise<Page<Message>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const page = await transactionService.getMessagesBySafe(
-      safeAddress,
-      limit,
-      offset,
-    );
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getMessagesBySafe({
+      safeAddress: args.safeAddress,
+      limit: args.limit,
+      offset: args.offset,
+    });
 
     return this.messageValidator.validatePage(page);
   }
 
-  async createMessage(
-    chainId: string,
-    safeAddress: string,
-    message: unknown,
-    safeAppId: number | null,
-    signature: string,
-  ): Promise<unknown> {
+  async createMessage(args: {
+    chainId: string;
+    safeAddress: string;
+    message: unknown;
+    safeAppId: number | null;
+    signature: string;
+  }): Promise<unknown> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.postMessage(
-      safeAddress,
-      message,
-      safeAppId,
-      signature,
-    );
+    return transactionService.postMessage({
+      safeAddress: args.safeAddress,
+      message: args.message,
+      safeAppId: args.safeAppId,
+      signature: args.signature,
+    });
   }
 
-  async updateMessageSignature(
-    chainId: string,
-    messageHash: string,
-    signature: string,
-  ): Promise<unknown> {
+  async updateMessageSignature(args: {
+    chainId: string;
+    messageHash: string;
+    signature: string;
+  }): Promise<unknown> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.postMessageSignature(messageHash, signature);
+    return transactionService.postMessageSignature({
+      messageHash: args.messageHash,
+      signature: args.signature,
+    });
   }
 }

--- a/src/domain/notifications/notifications.repository.interface.ts
+++ b/src/domain/notifications/notifications.repository.interface.ts
@@ -17,13 +17,10 @@ export interface INotificationsRepository {
 
   /**
    * Un-registers a notification target, identified by its client {@link uuid}.
-   * @param chainId
-   * @param uuid
-   * @param safeAddress
    */
-  unregisterDevice(
-    chainId: string,
-    uuid: string,
-    safeAddress: string,
-  ): Promise<void>;
+  unregisterDevice(args: {
+    chainId: string;
+    uuid: string;
+    safeAddress: string;
+  }): Promise<void>;
 }

--- a/src/domain/notifications/notifications.repository.ts
+++ b/src/domain/notifications/notifications.repository.ts
@@ -17,11 +17,11 @@ export class NotificationsRepository implements INotificationsRepository {
     const api = await this.transactionApiManager.getTransactionApi(
       safeRegistration.chainId,
     );
-    await api.postDeviceRegistration(
+    await api.postDeviceRegistration({
       device,
-      safeRegistration.safes,
-      safeRegistration.signatures,
-    );
+      safes: safeRegistration.safes,
+      signatures: safeRegistration.signatures,
+    });
     return safeRegistration;
   }
 

--- a/src/domain/notifications/notifications.repository.ts
+++ b/src/domain/notifications/notifications.repository.ts
@@ -25,12 +25,17 @@ export class NotificationsRepository implements INotificationsRepository {
     return safeRegistration;
   }
 
-  async unregisterDevice(
-    chainId: string,
-    uuid: string,
-    safeAddress: string,
-  ): Promise<void> {
-    const api = await this.transactionApiManager.getTransactionApi(chainId);
-    return api.deleteDeviceRegistration(uuid, safeAddress);
+  async unregisterDevice(args: {
+    chainId: string;
+    uuid: string;
+    safeAddress: string;
+  }): Promise<void> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    return api.deleteDeviceRegistration({
+      uuid: args.uuid,
+      safeAddress: args.safeAddress,
+    });
   }
 }

--- a/src/domain/safe-apps/safe-apps.repository.interface.ts
+++ b/src/domain/safe-apps/safe-apps.repository.interface.ts
@@ -5,16 +5,12 @@ export const ISafeAppsRepository = Symbol('ISafeAppsRepository');
 export interface ISafeAppsRepository {
   /**
    * Gets the {@link SafeApp[]} associated with the {@link chainId}.
-   *
-   * @param chainId filters Safe Apps that are available on that chain.
-   * @param clientUrl filters Safe Apps that are available on that clientUrl.
-   * @param url filters Safe Apps available from that url. It needs to be an exact match.
    */
-  getSafeApps(
-    chainId?: string,
-    clientUrl?: string,
-    url?: string,
-  ): Promise<SafeApp[]>;
+  getSafeApps(args: {
+    chainId?: string;
+    clientUrl?: string;
+    url?: string;
+  }): Promise<SafeApp[]>;
 
   /**
    * Gets the Safe App associated with the chainId and id. If no Safe App is found,

--- a/src/domain/safe-apps/safe-apps.repository.ts
+++ b/src/domain/safe-apps/safe-apps.repository.ts
@@ -12,17 +12,17 @@ export class SafeAppsRepository implements ISafeAppsRepository {
     private readonly validator: SafeAppsValidator,
   ) {}
 
-  async getSafeApps(
-    chainId?: string,
-    clientUrl?: string,
-    url?: string,
-  ): Promise<SafeApp[]> {
-    const safeApps = await this.configApi.getSafeApps(chainId, clientUrl, url);
+  async getSafeApps(args: {
+    chainId?: string;
+    clientUrl?: string;
+    url?: string;
+  }): Promise<SafeApp[]> {
+    const safeApps = await this.configApi.getSafeApps(args);
     return safeApps.map((safeApp) => this.validator.validate(safeApp));
   }
 
   async getSafeAppById(chainId: string, id: number): Promise<SafeApp | null> {
-    const safeApps = await this.configApi.getSafeApps(chainId);
+    const safeApps = await this.configApi.getSafeApps({ chainId });
     const safeApp = safeApps.find((safeApp) => safeApp.id === id);
     return safeApp ? this.validator.validate(safeApp) : null;
   }

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -12,57 +12,63 @@ import { AddConfirmationDto } from '../transactions/entities/add-confirmation.dt
 export const ISafeRepository = Symbol('ISafeRepository');
 
 export interface ISafeRepository {
-  getSafe(chainId: string, address: string): Promise<Safe>;
+  getSafe(args: { chainId: string; address: string }): Promise<Safe>;
 
-  clearSafe(chainId: string, address: string): Promise<void>;
+  clearSafe(args: { chainId: string; address: string }): Promise<void>;
 
-  getCollectibleTransfers(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>>;
+  getCollectibleTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>>;
 
-  clearCollectibleTransfers(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void>;
+  clearCollectibleTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 
-  getIncomingTransfers(
-    chainId: string,
-    safeAddress: string,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    tokenAddress?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>>;
+  getIncomingTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    tokenAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>>;
 
-  clearIncomingTransfers(chainId: string, safeAddress: string): Promise<void>;
+  clearIncomingTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 
-  addConfirmation(
-    chainId: string,
-    safeTxHash: string,
-    addConfirmationDto: AddConfirmationDto,
-  ): Promise<unknown>;
+  addConfirmation(args: {
+    chainId: string;
+    safeTxHash: string;
+    addConfirmationDto: AddConfirmationDto;
+  }): Promise<unknown>;
 
-  getModuleTransaction(
-    chainId: string,
-    moduleTransactionId: string,
-  ): Promise<ModuleTransaction>;
+  getModuleTransaction(args: {
+    chainId: string;
+    moduleTransactionId: string;
+  }): Promise<ModuleTransaction>;
 
-  getModuleTransactions(
-    chainId: string,
-    safeAddress: string,
-    to?: string,
-    module?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<ModuleTransaction>>;
+  getModuleTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+    to?: string;
+    module?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<ModuleTransaction>>;
 
-  clearModuleTransactions(chainId: string, safeAddress: string): Promise<void>;
+  clearModuleTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 
   /**
    * Returns the Safe Transaction Queue in ascending order.
@@ -70,99 +76,92 @@ export interface ISafeRepository {
    * The ascending order is first considered for the nonce.
    * If multiple transactions have the same nonce, then they
    * will be sorted according to the submission date
-   *
-   * @param chainId - the chain id from where to retrieve the transactions from
-   * @param safe - the target safe from where to get the transaction from
-   * @param limit - the maximum number of transactions to be returned
-   * @param offset - the starting point from which to start the pagination
    */
-  getTransactionQueue(
-    chainId: string,
-    safe: Safe,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>>;
+  getTransactionQueue(args: {
+    chainId: string;
+    safe: Safe;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>>;
 
   /**
    * Returns the Safe Transaction Queue sorted by modified status.
    * (from most recently modified to last)
-   *
-   * @param chainId - the chain id from where to retrieve the transactions from
-   * @param safe - the target safe from where to get the transaction from
-   * @param limit - the maximum number of transactions to be returned
-   * @param offset - the starting point from which to start the pagination
    */
-  getTransactionQueueByModified(
-    chainId: string,
-    safe: Safe,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>>;
+  getTransactionQueueByModified(args: {
+    chainId: string;
+    safe: Safe;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>>;
 
-  getTransactionHistoryByExecutionDate(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>>;
+  getTransactionHistoryByExecutionDate(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>>;
 
-  getCreationTransaction(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<CreationTransaction>;
+  getCreationTransaction(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<CreationTransaction>;
 
-  getTransactionHistory(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>>;
+  getTransactionHistory(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>>;
 
-  getMultiSigTransaction(
-    chainId: string,
-    safeTransactionHash: string,
-  ): Promise<MultisigTransaction>;
+  getMultiSigTransaction(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): Promise<MultisigTransaction>;
 
-  clearAllExecutedTransactions(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void>;
+  clearAllExecutedTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 
-  clearMultisigTransaction(
-    chainId: string,
-    safeTransactionHash: string,
-  ): Promise<void>;
+  clearMultisigTransaction(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): Promise<void>;
 
-  clearMultisigTransactions(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void>;
+  clearMultisigTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void>;
 
-  getMultisigTransactions(
-    chainId: string,
-    safeAddress: string,
-    executed?: boolean,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    nonce?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>>;
+  getMultisigTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+    executed?: boolean;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    nonce?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>>;
 
-  getTransfer(chainId: string, transferId: string): Promise<Transfer>;
+  getTransfer(args: { chainId: string; transferId: string }): Promise<Transfer>;
 
-  getSafesByOwner(chainId: string, ownerAddress: string): Promise<SafeList>;
+  getSafesByOwner(args: {
+    chainId: string;
+    ownerAddress: string;
+  }): Promise<SafeList>;
 
-  getLastTransactionSortedByNonce(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<MultisigTransaction | null>;
+  getLastTransactionSortedByNonce(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<MultisigTransaction | null>;
 
-  proposeTransaction(
-    chainId: string,
-    safeAddress: string,
-    proposeTransactionDto: ProposeTransactionDto,
-  ): Promise<unknown>;
+  proposeTransaction(args: {
+    chainId: string;
+    safeAddress: string;
+    proposeTransactionDto: ProposeTransactionDto;
+  }): Promise<unknown>;
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -34,382 +34,382 @@ export class SafeRepository implements ISafeRepository {
     private readonly creationTransactionValidator: CreationTransactionValidator,
   ) {}
 
-  async getSafe(chainId: string, address: string): Promise<Safe> {
+  async getSafe(args: { chainId: string; address: string }): Promise<Safe> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const safe: Safe = await transactionService.getSafe(address);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const safe: Safe = await transactionService.getSafe(args.address);
     return this.safeValidator.validate(safe);
   }
 
-  async clearSafe(chainId: string, address: string): Promise<void> {
+  async clearSafe(args: { chainId: string; address: string }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    return transactionService.clearSafe(address);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.clearSafe(args.address);
   }
 
-  async getCollectibleTransfers(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>> {
+  async getCollectibleTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    const page = await transactionService.getTransfers(
-      safeAddress,
-      undefined,
-      true,
-      limit,
-      offset,
-    );
+    const page = await transactionService.getTransfers({
+      safeAddress: args.safeAddress,
+      onlyErc721: true,
+      limit: args.limit,
+      offset: args.offset,
+    });
     return this.transferValidator.validatePage(page);
   }
 
-  async clearCollectibleTransfers(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
+  async clearCollectibleTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.clearTransfers(safeAddress);
+    return transactionService.clearTransfers(args.safeAddress);
   }
 
-  async getIncomingTransfers(
-    chainId: string,
-    safeAddress: string,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    tokenAddress?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transfer>> {
+  async getIncomingTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    tokenAddress?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transfer>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const page = await transactionService.getIncomingTransfers(
-      safeAddress,
-      executionDateGte,
-      executionDateLte,
-      to,
-      value,
-      tokenAddress,
-      limit,
-      offset,
-    );
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getIncomingTransfers({
+      safeAddress: args.safeAddress,
+      executionDateGte: args.executionDateGte,
+      executionDateLte: args.executionDateLte,
+      to: args.to,
+      value: args.value,
+      tokenAddress: args.tokenAddress,
+      limit: args.limit,
+      offset: args.offset,
+    });
     return this.transferValidator.validatePage(page);
   }
 
-  async clearIncomingTransfers(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
+  async clearIncomingTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.clearIncomingTransfers(safeAddress);
+    return transactionService.clearIncomingTransfers(args.safeAddress);
   }
 
-  async addConfirmation(
-    chainId: string,
-    safeTxHash: string,
-    addConfirmationDto: AddConfirmationDto,
-  ): Promise<void> {
+  async addConfirmation(args: {
+    chainId: string;
+    safeTxHash: string;
+    addConfirmationDto: AddConfirmationDto;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     return transactionService
-      .postConfirmation(safeTxHash, addConfirmationDto)
+      .postConfirmation(args.safeTxHash, args.addConfirmationDto)
       .then(() => {
         return;
       });
   }
 
-  async getModuleTransaction(
-    chainId: string,
-    moduleTransactionId: string,
-  ): Promise<ModuleTransaction> {
+  async getModuleTransaction(args: {
+    chainId: string;
+    moduleTransactionId: string;
+  }): Promise<ModuleTransaction> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     const moduleTransaction = await transactionService.getModuleTransaction(
-      moduleTransactionId,
+      args.moduleTransactionId,
     );
     return this.moduleTransactionValidator.validate(moduleTransaction);
   }
 
-  async getModuleTransactions(
-    chainId: string,
-    safeAddress: string,
-    to?: string,
-    module?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<ModuleTransaction>> {
+  async getModuleTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+    to?: string;
+    module?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<ModuleTransaction>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const page = await transactionService.getModuleTransactions(
-      safeAddress,
-      to,
-      module,
-      limit,
-      offset,
-    );
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getModuleTransactions({
+      safeAddress: args.safeAddress,
+      to: args.to,
+      module: args.module,
+      limit: args.limit,
+      offset: args.offset,
+    });
     return this.moduleTransactionValidator.validatePage(page);
   }
 
-  async clearModuleTransactions(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
+  async clearModuleTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.clearModuleTransactions(safeAddress);
+    return transactionService.clearModuleTransactions(args.safeAddress);
   }
 
-  async getTransactionQueue(
-    chainId: string,
-    safe: Safe,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>> {
-    return this._getTransactionQueue(
-      chainId,
-      safe,
-      'nonce,submissionDate',
-      limit,
-      offset,
-    );
+  async getTransactionQueue(args: {
+    chainId: string;
+    safe: Safe;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>> {
+    return this._getTransactionQueue({
+      chainId: args.chainId,
+      safe: args.safe,
+      ordering: 'nonce,submissionDate',
+      limit: args.limit,
+      offset: args.offset,
+    });
   }
 
-  async getTransactionQueueByModified(
-    chainId: string,
-    safe: Safe,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>> {
-    return this._getTransactionQueue(chainId, safe, '-modified', limit, offset);
+  async getTransactionQueueByModified(args: {
+    chainId: string;
+    safe: Safe;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>> {
+    return this._getTransactionQueue({
+      chainId: args.chainId,
+      safe: args.safe,
+      ordering: '-modified',
+      limit: args.limit,
+      offset: args.offset,
+    });
   }
 
-  private async _getTransactionQueue(
-    chainId: string,
-    safe: Safe,
-    ordering: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>> {
+  private async _getTransactionQueue(args: {
+    chainId: string;
+    safe: Safe;
+    ordering: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     const page: Page<MultisigTransaction> =
-      await transactionService.getMultisigTransactions(
-        safe.address,
-        ordering,
-        false,
-        true,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        safe.nonce,
-        limit,
-        offset,
-      );
+      await transactionService.getMultisigTransactions({
+        safeAddress: args.safe.address,
+        ordering: args.ordering,
+        executed: false,
+        trusted: true,
+        nonceGte: args.safe.nonce,
+        limit: args.limit,
+        offset: args.offset,
+      });
     return this.multisigTransactionValidator.validatePage(page);
   }
 
-  async getCreationTransaction(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<CreationTransaction> {
+  async getCreationTransaction(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<CreationTransaction> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     const createTransaction = await transactionService.getCreationTransaction(
-      safeAddress,
+      args.safeAddress,
     );
     return this.creationTransactionValidator.validate(createTransaction);
   }
 
-  async getTransactionHistoryByExecutionDate(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>> {
-    return this.getAllExecutedTransactions(
-      chainId,
-      safeAddress,
-      'executionDate',
-      limit,
-      offset,
-    );
+  async getTransactionHistoryByExecutionDate(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>> {
+    return this.getAllExecutedTransactions({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+      ordering: 'executionDate',
+      limit: args.limit,
+      offset: args.offset,
+    });
   }
 
-  async getTransactionHistory(
-    chainId: string,
-    safeAddress: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>> {
-    return this.getAllExecutedTransactions(
-      chainId,
-      safeAddress,
-      undefined,
-      limit,
-      offset,
-    );
+  async getTransactionHistory(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>> {
+    return this.getAllExecutedTransactions({
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+      limit: args.limit,
+      offset: args.offset,
+    });
   }
 
-  private async getAllExecutedTransactions(
-    chainId: string,
-    safeAddress: string,
-    ordering?: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Transaction>> {
+  private async getAllExecutedTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+    ordering?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Transaction>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     const page: Page<Transaction> = await transactionService.getAllTransactions(
-      safeAddress,
-      ordering,
-      true,
-      false,
-      limit,
-      offset,
+      {
+        safeAddress: args.safeAddress,
+        ordering: args.ordering,
+        executed: true,
+        queued: false,
+        limit: args.limit,
+        offset: args.offset,
+      },
     );
     return this.transactionTypeValidator.validatePage(page);
   }
 
-  async clearAllExecutedTransactions(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
+  async clearAllExecutedTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.clearAllTransactions(safeAddress);
+    return transactionService.clearAllTransactions(args.safeAddress);
   }
 
-  async clearMultisigTransaction(
-    chainId: string,
-    safeTransactionHash: string,
-  ): Promise<void> {
+  async clearMultisigTransaction(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    return transactionService.clearMultisigTransaction(safeTransactionHash);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.clearMultisigTransaction(
+      args.safeTransactionHash,
+    );
   }
 
-  async getMultiSigTransaction(
-    chainId: string,
-    safeTransactionHash: string,
-  ): Promise<MultisigTransaction> {
+  async getMultiSigTransaction(args: {
+    chainId: string;
+    safeTransactionHash: string;
+  }): Promise<MultisigTransaction> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     const multiSigTransaction = await transactionService.getMultisigTransaction(
-      safeTransactionHash,
+      args.safeTransactionHash,
     );
 
     return this.multisigTransactionValidator.validate(multiSigTransaction);
   }
 
-  async clearMultisigTransactions(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<void> {
+  async clearMultisigTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<void> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    return transactionService.clearMultisigTransactions(safeAddress);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    return transactionService.clearMultisigTransactions(args.safeAddress);
   }
 
-  async getMultisigTransactions(
-    chainId: string,
-    safeAddress: string,
-    executed?: boolean,
-    executionDateGte?: string,
-    executionDateLte?: string,
-    to?: string,
-    value?: string,
-    nonce?: string,
-    nonceGte?: number,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<MultisigTransaction>> {
+  async getMultisigTransactions(args: {
+    chainId: string;
+    safeAddress: string;
+    executed?: boolean;
+    executionDateGte?: string;
+    executionDateLte?: string;
+    to?: string;
+    value?: string;
+    nonce?: string;
+    nonceGte?: number;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<MultisigTransaction>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const page = await transactionService.getMultisigTransactions(
-      safeAddress,
-      '-nonce',
-      executed,
-      true,
-      executionDateGte,
-      executionDateLte,
-      to,
-      value,
-      nonce,
-      nonceGte,
-      limit,
-      offset,
-    );
-
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getMultisigTransactions({
+      safeAddress: args.safeAddress,
+      ordering: '-nonce',
+      executed: args.executed,
+      trusted: true,
+      executionDateGte: args.executionDateGte,
+      executionDateLte: args.executionDateLte,
+      to: args.to,
+      value: args.value,
+      nonce: args.nonce,
+      nonceGte: args.nonceGte,
+      limit: args.limit,
+      offset: args.offset,
+    });
     return this.multisigTransactionValidator.validatePage(page);
   }
 
-  async getTransfer(chainId: string, transferId: string): Promise<Transfer> {
+  async getTransfer(args: {
+    chainId: string;
+    transferId: string;
+  }): Promise<Transfer> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const transfer = await transactionService.getTransfer(transferId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const transfer = await transactionService.getTransfer(args.transferId);
     return this.transferValidator.validate(transfer);
   }
 
-  async getSafesByOwner(
-    chainId: string,
-    ownerAddress: string,
-  ): Promise<SafeList> {
+  async getSafesByOwner(args: {
+    chainId: string;
+    ownerAddress: string;
+  }): Promise<SafeList> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const safeList = await transactionService.getSafesByOwner(ownerAddress);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const safeList = await transactionService.getSafesByOwner(
+      args.ownerAddress,
+    );
 
     return this.safeListValidator.validate(safeList);
   }
 
-  async getLastTransactionSortedByNonce(
-    chainId: string,
-    safeAddress: string,
-  ): Promise<MultisigTransaction | null> {
+  async getLastTransactionSortedByNonce(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<MultisigTransaction | null> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
     const page: Page<Transaction> =
-      await transactionService.getMultisigTransactions(
-        safeAddress,
-        '-nonce',
-        undefined,
-        true,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        1,
-      );
+      await transactionService.getMultisigTransactions({
+        safeAddress: args.safeAddress,
+        ordering: '-nonce',
+        trusted: true,
+        limit: 1,
+      });
 
     return isEmpty(page.results)
       ? null
       : this.multisigTransactionValidator.validate(page.results[0]);
   }
 
-  async proposeTransaction(
-    chainId: string,
-    safeAddress: string,
-    proposeTransactionDto: ProposeTransactionDto,
-  ): Promise<unknown> {
+  async proposeTransaction(args: {
+    chainId: string;
+    safeAddress: string;
+    proposeTransactionDto: ProposeTransactionDto;
+  }): Promise<unknown> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
 
     return transactionService.postMultisigTransaction(
-      safeAddress,
-      proposeTransactionDto,
+      args.safeAddress,
+      args.proposeTransactionDto,
     );
   }
 }

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -57,10 +57,8 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(args.chainId);
 
     const page = await transactionService.getTransfers({
-      safeAddress: args.safeAddress,
+      ...args,
       onlyErc721: true,
-      limit: args.limit,
-      offset: args.offset,
     });
     return this.transferValidator.validatePage(page);
   }
@@ -88,16 +86,7 @@ export class SafeRepository implements ISafeRepository {
   }): Promise<Page<Transfer>> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
-    const page = await transactionService.getIncomingTransfers({
-      safeAddress: args.safeAddress,
-      executionDateGte: args.executionDateGte,
-      executionDateLte: args.executionDateLte,
-      to: args.to,
-      value: args.value,
-      tokenAddress: args.tokenAddress,
-      limit: args.limit,
-      offset: args.offset,
-    });
+    const page = await transactionService.getIncomingTransfers(args);
     return this.transferValidator.validatePage(page);
   }
 
@@ -118,11 +107,9 @@ export class SafeRepository implements ISafeRepository {
   }): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
-    return transactionService
-      .postConfirmation(args.safeTxHash, args.addConfirmationDto)
-      .then(() => {
-        return;
-      });
+    return transactionService.postConfirmation(args).then(() => {
+      return;
+    });
   }
 
   async getModuleTransaction(args: {
@@ -147,13 +134,7 @@ export class SafeRepository implements ISafeRepository {
   }): Promise<Page<ModuleTransaction>> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
-    const page = await transactionService.getModuleTransactions({
-      safeAddress: args.safeAddress,
-      to: args.to,
-      module: args.module,
-      limit: args.limit,
-      offset: args.offset,
-    });
+    const page = await transactionService.getModuleTransactions(args);
     return this.moduleTransactionValidator.validatePage(page);
   }
 
@@ -174,11 +155,8 @@ export class SafeRepository implements ISafeRepository {
     offset?: number;
   }): Promise<Page<MultisigTransaction>> {
     return this._getTransactionQueue({
-      chainId: args.chainId,
-      safe: args.safe,
+      ...args,
       ordering: 'nonce,submissionDate',
-      limit: args.limit,
-      offset: args.offset,
     });
   }
 
@@ -189,11 +167,8 @@ export class SafeRepository implements ISafeRepository {
     offset?: number;
   }): Promise<Page<MultisigTransaction>> {
     return this._getTransactionQueue({
-      chainId: args.chainId,
-      safe: args.safe,
+      ...args,
       ordering: '-modified',
-      limit: args.limit,
-      offset: args.offset,
     });
   }
 
@@ -208,13 +183,11 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const page: Page<MultisigTransaction> =
       await transactionService.getMultisigTransactions({
+        ...args,
         safeAddress: args.safe.address,
-        ordering: args.ordering,
         executed: false,
         trusted: true,
         nonceGte: args.safe.nonce,
-        limit: args.limit,
-        offset: args.offset,
       });
     return this.multisigTransactionValidator.validatePage(page);
   }
@@ -238,11 +211,8 @@ export class SafeRepository implements ISafeRepository {
     offset?: number;
   }): Promise<Page<Transaction>> {
     return this.getAllExecutedTransactions({
-      chainId: args.chainId,
-      safeAddress: args.safeAddress,
+      ...args,
       ordering: 'executionDate',
-      limit: args.limit,
-      offset: args.offset,
     });
   }
 
@@ -252,12 +222,7 @@ export class SafeRepository implements ISafeRepository {
     limit?: number;
     offset?: number;
   }): Promise<Page<Transaction>> {
-    return this.getAllExecutedTransactions({
-      chainId: args.chainId,
-      safeAddress: args.safeAddress,
-      limit: args.limit,
-      offset: args.offset,
-    });
+    return this.getAllExecutedTransactions(args);
   }
 
   private async getAllExecutedTransactions(args: {
@@ -271,12 +236,9 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const page: Page<Transaction> = await transactionService.getAllTransactions(
       {
-        safeAddress: args.safeAddress,
-        ordering: args.ordering,
+        ...args,
         executed: true,
         queued: false,
-        limit: args.limit,
-        offset: args.offset,
       },
     );
     return this.transactionTypeValidator.validatePage(page);
@@ -341,18 +303,9 @@ export class SafeRepository implements ISafeRepository {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const page = await transactionService.getMultisigTransactions({
-      safeAddress: args.safeAddress,
+      ...args,
       ordering: '-nonce',
-      executed: args.executed,
       trusted: true,
-      executionDateGte: args.executionDateGte,
-      executionDateLte: args.executionDateLte,
-      to: args.to,
-      value: args.value,
-      nonce: args.nonce,
-      nonceGte: args.nonceGte,
-      limit: args.limit,
-      offset: args.offset,
     });
     return this.multisigTransactionValidator.validatePage(page);
   }
@@ -388,7 +341,7 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const page: Page<Transaction> =
       await transactionService.getMultisigTransactions({
-        safeAddress: args.safeAddress,
+        ...args,
         ordering: '-nonce',
         trusted: true,
         limit: 1,
@@ -407,9 +360,9 @@ export class SafeRepository implements ISafeRepository {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
 
-    return transactionService.postMultisigTransaction(
-      args.safeAddress,
-      args.proposeTransactionDto,
-    );
+    return transactionService.postMultisigTransaction({
+      address: args.safeAddress,
+      data: args.proposeTransactionDto,
+    });
   }
 }

--- a/src/domain/tokens/token.repository.interface.ts
+++ b/src/domain/tokens/token.repository.interface.ts
@@ -4,11 +4,11 @@ import { Token } from './entities/token.entity';
 export const ITokenRepository = Symbol('ITokenRepository');
 
 export interface ITokenRepository {
-  getToken(chainId: string, address: string): Promise<Token>;
+  getToken(args: { chainId: string; address: string }): Promise<Token>;
 
-  getTokens(
-    chainId: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Token>>;
+  getTokens(args: {
+    chainId: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Token>>;
 }

--- a/src/domain/tokens/token.repository.ts
+++ b/src/domain/tokens/token.repository.ts
@@ -13,21 +13,21 @@ export class TokenRepository implements ITokenRepository {
     private readonly tokenValidator: TokenValidator,
   ) {}
 
-  async getToken(chainId: string, address: string): Promise<Token> {
+  async getToken(args: { chainId: string; address: string }): Promise<Token> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const token = await transactionService.getToken(address);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const token = await transactionService.getToken(args.address);
     return this.tokenValidator.validate(token);
   }
 
-  async getTokens(
-    chainId: string,
-    limit?: number,
-    offset?: number,
-  ): Promise<Page<Token>> {
+  async getTokens(args: {
+    chainId: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<Token>> {
     const transactionService =
-      await this.transactionApiManager.getTransactionApi(chainId);
-    const page = await transactionService.getTokens(limit, offset);
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getTokens(args.limit, args.offset);
 
     return this.tokenValidator.validatePage(page);
   }

--- a/src/domain/tokens/token.repository.ts
+++ b/src/domain/tokens/token.repository.ts
@@ -27,7 +27,7 @@ export class TokenRepository implements ITokenRepository {
   }): Promise<Page<Token>> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
-    const page = await transactionService.getTokens(args.limit, args.offset);
+    const page = await transactionService.getTokens(args);
 
     return this.tokenValidator.validatePage(page);
   }

--- a/src/routes/balances/balances.controller.ts
+++ b/src/routes/balances/balances.controller.ts
@@ -20,13 +20,13 @@ export class BalancesController {
     @Query('trusted') trusted?: boolean,
     @Query('exclude_spam') excludeSpam?: boolean,
   ): Promise<Balances> {
-    return this.balancesService.getBalances(
+    return this.balancesService.getBalances({
       chainId,
       safeAddress,
       fiatCode,
       trusted,
       excludeSpam,
-    );
+    });
   }
 
   @Get('balances/supported-fiat-codes')

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -23,26 +23,21 @@ export class BalancesService {
     private readonly exchangeRepository: IExchangeRepository,
   ) {}
 
-  async getBalances(
-    chainId: string,
-    safeAddress: string,
-    fiatCode: string,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Balances> {
-    const txServiceBalances = await this.balancesRepository.getBalances({
-      chainId,
-      safeAddress,
-      trusted,
-      excludeSpam,
-    });
+  async getBalances(args: {
+    chainId: string;
+    safeAddress: string;
+    fiatCode: string;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Balances> {
+    const txServiceBalances = await this.balancesRepository.getBalances(args);
 
-    const usdToFiatRate: number = await this.exchangeRepository.convertRates(
-      fiatCode,
-      BalancesService.fromRateCurrencyCode,
-    );
+    const usdToFiatRate: number = await this.exchangeRepository.convertRates({
+      to: args.fiatCode,
+      from: BalancesService.fromRateCurrencyCode,
+    });
     const nativeCurrency: NativeCurrency = (
-      await this.chainsRepository.getChain(chainId)
+      await this.chainsRepository.getChain(args.chainId)
     ).nativeCurrency;
 
     // Map balances payload

--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -30,12 +30,12 @@ export class BalancesService {
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Balances> {
-    const txServiceBalances = await this.balancesRepository.getBalances(
+    const txServiceBalances = await this.balancesRepository.getBalances({
       chainId,
       safeAddress,
       trusted,
       excludeSpam,
-    );
+    });
 
     const usdToFiatRate: number = await this.exchangeRepository.convertRates(
       fiatCode,

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -41,14 +41,14 @@ export class CacheHooksService {
       // the pending transaction – clear multisig transaction
       case EventType.PENDING_MULTISIG_TRANSACTION:
         promises.push(
-          this.safeRepository.clearMultisigTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearMultisigTransaction(
-            event.chainId,
-            event.safeTxHash,
-          ),
+          this.safeRepository.clearMultisigTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransaction({
+            chainId: event.chainId,
+            safeTransactionHash: event.safeTxHash,
+          }),
         );
         break;
       // An executed module transaction might affect:
@@ -56,14 +56,14 @@ export class CacheHooksService {
       // - the list of module transactions for the safe
       case EventType.MODULE_TRANSACTION:
         promises.push(
-          this.safeRepository.clearAllExecutedTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearModuleTransactions(
-            event.chainId,
-            event.address,
-          ),
+          this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearModuleTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
       // A new executed multisig transaction affects:
@@ -75,27 +75,30 @@ export class CacheHooksService {
       // - the safe configuration - clear safe info
       case EventType.EXECUTED_MULTISIG_TRANSACTION:
         promises.push(
-          this.collectiblesRepository.clearCollectibles(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearAllExecutedTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearCollectibleTransfers(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearMultisigTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearMultisigTransaction(
-            event.chainId,
-            event.safeTxHash,
-          ),
-          this.safeRepository.clearSafe(event.chainId, event.address),
+          this.collectiblesRepository.clearCollectibles({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearCollectibleTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransaction({
+            chainId: event.chainId,
+            safeTransactionHash: event.safeTxHash,
+          }),
+          this.safeRepository.clearSafe({
+            chainId: event.chainId,
+            address: event.address,
+          }),
         );
         break;
       // A new confirmation for a pending transaction affects:
@@ -103,14 +106,14 @@ export class CacheHooksService {
       // - the pending transaction – clear multisig transaction
       case EventType.NEW_CONFIRMATION:
         promises.push(
-          this.safeRepository.clearMultisigTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearMultisigTransaction(
-            event.chainId,
-            event.safeTxHash,
-          ),
+          this.safeRepository.clearMultisigTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransaction({
+            chainId: event.chainId,
+            safeTransactionHash: event.safeTxHash,
+          }),
         );
         break;
       // Incoming ether affects:
@@ -119,18 +122,18 @@ export class CacheHooksService {
       // - the incoming transfers for that safe
       case EventType.INCOMING_ETHER:
         promises.push(
-          this.balancesRepository.clearLocalBalances(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearAllExecutedTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearIncomingTransfers(
-            event.chainId,
-            event.address,
-          ),
+          this.balancesRepository.clearLocalBalances({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearIncomingTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
       // Outgoing ether affects:
@@ -138,14 +141,14 @@ export class CacheHooksService {
       // - the list of all executed transactions (including transfers) for the safe
       case EventType.OUTGOING_ETHER:
         promises.push(
-          this.balancesRepository.clearLocalBalances(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearAllExecutedTransactions(
-            event.chainId,
-            event.address,
-          ),
+          this.balancesRepository.clearLocalBalances({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
       // An incoming token affects:
@@ -156,26 +159,26 @@ export class CacheHooksService {
       // - the incoming transfers for that safe
       case EventType.INCOMING_TOKEN:
         promises.push(
-          this.balancesRepository.clearLocalBalances(
-            event.chainId,
-            event.address,
-          ),
-          this.collectiblesRepository.clearCollectibles(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearAllExecutedTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearCollectibleTransfers(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearIncomingTransfers(
-            event.chainId,
-            event.address,
-          ),
+          this.balancesRepository.clearLocalBalances({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.collectiblesRepository.clearCollectibles({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearCollectibleTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearIncomingTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
       // An outgoing token affects:
@@ -185,22 +188,22 @@ export class CacheHooksService {
       // - the collectible transfers for that safe
       case EventType.OUTGOING_TOKEN:
         promises.push(
-          this.balancesRepository.clearLocalBalances(
-            event.chainId,
-            event.address,
-          ),
-          this.collectiblesRepository.clearCollectibles(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearAllExecutedTransactions(
-            event.chainId,
-            event.address,
-          ),
-          this.safeRepository.clearCollectibleTransfers(
-            event.chainId,
-            event.address,
-          ),
+          this.balancesRepository.clearLocalBalances({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.collectiblesRepository.clearCollectibles({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearCollectibleTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
     }

--- a/src/routes/collectibles/collectibles.controller.ts
+++ b/src/routes/collectibles/collectibles.controller.ts
@@ -41,13 +41,13 @@ export class CollectiblesController {
     @Query('trusted') trusted?: boolean,
     @Query('exclude_spam') excludeSpam?: boolean,
   ): Promise<Page<Collectible>> {
-    return this.service.getCollectibles(
+    return this.service.getCollectibles({
       chainId,
       safeAddress,
       routeUrl,
       paginationData,
       trusted,
       excludeSpam,
-    );
+    });
   }
 }

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -22,14 +22,14 @@ export class CollectiblesService {
     trusted?: boolean,
     excludeSpam?: boolean,
   ): Promise<Page<Collectible>> {
-    const collectibles = await this.repository.getCollectibles(
+    const collectibles = await this.repository.getCollectibles({
       chainId,
       safeAddress,
-      paginationData.limit,
-      paginationData.offset,
+      limit: paginationData.limit,
+      offset: paginationData.offset,
       trusted,
       excludeSpam,
-    );
+    });
 
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, collectibles.next);
     const previousURL = cursorUrlFromLimitAndOffset(

--- a/src/routes/collectibles/collectibles.service.ts
+++ b/src/routes/collectibles/collectibles.service.ts
@@ -14,26 +14,26 @@ export class CollectiblesService {
     private readonly repository: ICollectiblesRepository,
   ) {}
 
-  async getCollectibles(
-    chainId: string,
-    safeAddress: string,
-    routeUrl: Readonly<URL>,
-    paginationData: PaginationData,
-    trusted?: boolean,
-    excludeSpam?: boolean,
-  ): Promise<Page<Collectible>> {
+  async getCollectibles(args: {
+    chainId: string;
+    safeAddress: string;
+    routeUrl: Readonly<URL>;
+    paginationData: PaginationData;
+    trusted?: boolean;
+    excludeSpam?: boolean;
+  }): Promise<Page<Collectible>> {
     const collectibles = await this.repository.getCollectibles({
-      chainId,
-      safeAddress,
-      limit: paginationData.limit,
-      offset: paginationData.offset,
-      trusted,
-      excludeSpam,
+      ...args,
+      limit: args.paginationData.limit,
+      offset: args.paginationData.offset,
     });
 
-    const nextURL = cursorUrlFromLimitAndOffset(routeUrl, collectibles.next);
+    const nextURL = cursorUrlFromLimitAndOffset(
+      args.routeUrl,
+      collectibles.next,
+    );
     const previousURL = cursorUrlFromLimitAndOffset(
-      routeUrl,
+      args.routeUrl,
       collectibles.previous,
     );
 

--- a/src/routes/common/address-info/address-info.helper.ts
+++ b/src/routes/common/address-info/address-info.helper.ts
@@ -102,11 +102,11 @@ export class AddressInfoHelper {
     switch (source) {
       case 'CONTRACT':
         return this.contractsRepository
-          .getContract(chainId, address)
+          .getContract({ chainId, contractAddress: address })
           .then((c) => new AddressInfo(c.address, c.displayName, c.logoUri));
       case 'TOKEN':
         return this.tokenRepository
-          .getToken(chainId, address)
+          .getToken({ chainId, address })
           .then((t) => new AddressInfo(t.address, t.name, t.logoUri));
       default:
         return Promise.reject('Unknown source');

--- a/src/routes/contracts/contracts.controller.ts
+++ b/src/routes/contracts/contracts.controller.ts
@@ -18,6 +18,6 @@ export class ContractsController {
     @Param('chainId') chainId: string,
     @Param('contractAddress') contractAddress: string,
   ): Promise<Contract> {
-    return this.contractsService.getContract(chainId, contractAddress);
+    return this.contractsService.getContract({ chainId, contractAddress });
   }
 }

--- a/src/routes/contracts/contracts.service.ts
+++ b/src/routes/contracts/contracts.service.ts
@@ -10,10 +10,10 @@ export class ContractsService {
     private readonly contractsRepository: ContractsRepository,
   ) {}
 
-  async getContract(
-    chainId: string,
-    contractAddress: string,
-  ): Promise<Contract> {
-    return this.contractsRepository.getContract({ chainId, contractAddress });
+  async getContract(args: {
+    chainId: string;
+    contractAddress: string;
+  }): Promise<Contract> {
+    return this.contractsRepository.getContract(args);
   }
 }

--- a/src/routes/contracts/contracts.service.ts
+++ b/src/routes/contracts/contracts.service.ts
@@ -14,6 +14,6 @@ export class ContractsService {
     chainId: string,
     contractAddress: string,
   ): Promise<Contract> {
-    return this.contractsRepository.getContract(chainId, contractAddress);
+    return this.contractsRepository.getContract({ chainId, contractAddress });
   }
 }

--- a/src/routes/data-decode/data-decoded.controller.ts
+++ b/src/routes/data-decode/data-decoded.controller.ts
@@ -20,6 +20,9 @@ export class DataDecodedController {
     @Param('chainId') chainId: string,
     @Body(GetDataDecodedDtoValidationPipe) getDataDecodedDto: GetDataDecodedDto,
   ): Promise<DataDecoded> {
-    return this.dataDecodedService.getDataDecoded(chainId, getDataDecodedDto);
+    return this.dataDecodedService.getDataDecoded({
+      chainId,
+      getDataDecodedDto,
+    });
   }
 }

--- a/src/routes/data-decode/data-decoded.service.ts
+++ b/src/routes/data-decode/data-decoded.service.ts
@@ -16,6 +16,6 @@ export class DataDecodedService {
     getDataDecodedDto: GetDataDecodedDto,
   ): Promise<DataDecoded> {
     const { data, to } = getDataDecodedDto;
-    return this.dataDecodedRepository.getDataDecoded(chainId, data, to);
+    return this.dataDecodedRepository.getDataDecoded({ chainId, data, to });
   }
 }

--- a/src/routes/data-decode/data-decoded.service.ts
+++ b/src/routes/data-decode/data-decoded.service.ts
@@ -11,11 +11,14 @@ export class DataDecodedService {
     private readonly dataDecodedRepository: DataDecodedRepository,
   ) {}
 
-  async getDataDecoded(
-    chainId: string,
-    getDataDecodedDto: GetDataDecodedDto,
-  ): Promise<DataDecoded> {
-    const { data, to } = getDataDecodedDto;
-    return this.dataDecodedRepository.getDataDecoded({ chainId, data, to });
+  async getDataDecoded(args: {
+    chainId: string;
+    getDataDecodedDto: GetDataDecodedDto;
+  }): Promise<DataDecoded> {
+    return this.dataDecodedRepository.getDataDecoded({
+      chainId: args.chainId,
+      data: args.getDataDecodedDto.data,
+      to: args.getDataDecodedDto.to,
+    });
   }
 }

--- a/src/routes/delegates/delegates.controller.ts
+++ b/src/routes/delegates/delegates.controller.ts
@@ -66,12 +66,12 @@ export class DelegatesController {
     @Query(GetDelegateDtoValidationPipe) getDelegateDto: GetDelegateDto,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Page<Delegate>> {
-    return this.service.getDelegates(
+    return this.service.getDelegates({
       chainId,
       routeUrl,
       getDelegateDto,
       paginationData,
-    );
+    });
   }
 
   @HttpCode(200)
@@ -80,7 +80,7 @@ export class DelegatesController {
     @Param('chainId') chainId: string,
     @Body(CreateDelegateDtoValidationPipe) createDelegateDto: CreateDelegateDto,
   ): Promise<void> {
-    await this.service.postDelegate(chainId, createDelegateDto);
+    await this.service.postDelegate({ chainId, createDelegateDto });
   }
 
   @Delete('chains/:chainId/delegates/:delegateAddress')
@@ -89,25 +89,22 @@ export class DelegatesController {
     @Param('delegateAddress') delegateAddress: string,
     @Body(DeleteDelegateDtoValidationPipe) deleteDelegateDto: DeleteDelegateDto,
   ): Promise<unknown> {
-    return this.service.deleteDelegate(
+    return this.service.deleteDelegate({
       chainId,
       delegateAddress,
       deleteDelegateDto,
-    );
+    });
   }
 
   @Delete('chains/:chainId/safes/:safeAddress/delegates/:delegateAddress')
   async deleteSafeDelegate(
     @Param('chainId') chainId: string,
-    @Param('safeAddress') safeAddress: string,
-    @Param('delegateAddress') delegateAddress: string,
     @Body(DeleteSafeDelegateDtoValidationPipe)
     deleteSafeDelegateRequest: DeleteSafeDelegateDto,
   ): Promise<unknown> {
-    return this.service.deleteSafeDelegate(
+    return this.service.deleteSafeDelegate({
       chainId,
-      delegateAddress,
       deleteSafeDelegateRequest,
-    );
+    });
   }
 }

--- a/src/routes/delegates/delegates.service.ts
+++ b/src/routes/delegates/delegates.service.ts
@@ -18,25 +18,25 @@ export class DelegatesService {
     private readonly repository: IDelegateRepository,
   ) {}
 
-  async getDelegates(
-    chainId: string,
-    routeUrl: Readonly<URL>,
-    getDelegateDto: GetDelegateDto,
-    paginationData: PaginationData,
-  ): Promise<Page<Delegate>> {
+  async getDelegates(args: {
+    chainId: string;
+    routeUrl: Readonly<URL>;
+    getDelegateDto: GetDelegateDto;
+    paginationData: PaginationData;
+  }): Promise<Page<Delegate>> {
     const delegates = await this.repository.getDelegates({
-      chainId,
-      safeAddress: getDelegateDto.safe,
-      delegate: getDelegateDto.delegate,
-      delegator: getDelegateDto.delegator,
-      label: getDelegateDto.label,
-      limit: paginationData.limit,
-      offset: paginationData.offset,
+      chainId: args.chainId,
+      safeAddress: args.getDelegateDto.safe,
+      delegate: args.getDelegateDto.delegate,
+      delegator: args.getDelegateDto.delegator,
+      label: args.getDelegateDto.label,
+      limit: args.paginationData.limit,
+      offset: args.paginationData.offset,
     });
 
-    const nextURL = cursorUrlFromLimitAndOffset(routeUrl, delegates.next);
+    const nextURL = cursorUrlFromLimitAndOffset(args.routeUrl, delegates.next);
     const previousURL = cursorUrlFromLimitAndOffset(
-      routeUrl,
+      args.routeUrl,
       delegates.previous,
     );
 
@@ -48,43 +48,42 @@ export class DelegatesService {
     };
   }
 
-  async postDelegate(
-    chainId: string,
-    createDelegateDto: CreateDelegateDto,
-  ): Promise<void> {
+  async postDelegate(args: {
+    chainId: string;
+    createDelegateDto: CreateDelegateDto;
+  }): Promise<void> {
     await this.repository.postDelegate({
-      chainId,
-      safeAddress: createDelegateDto.safe,
-      delegate: createDelegateDto.delegate,
-      delegator: createDelegateDto.delegator,
-      signature: createDelegateDto.signature,
-      label: createDelegateDto.label,
+      chainId: args.chainId,
+      safeAddress: args.createDelegateDto.safe,
+      delegate: args.createDelegateDto.delegate,
+      delegator: args.createDelegateDto.delegator,
+      signature: args.createDelegateDto.signature,
+      label: args.createDelegateDto.label,
     });
   }
 
-  async deleteDelegate(
-    chainId: string,
-    delegateAddress: string,
-    deleteDelegateDto: DeleteDelegateDto,
-  ): Promise<unknown> {
+  async deleteDelegate(args: {
+    chainId: string;
+    delegateAddress: string;
+    deleteDelegateDto: DeleteDelegateDto;
+  }): Promise<unknown> {
     return await this.repository.deleteDelegate({
-      chainId,
-      delegate: delegateAddress,
-      delegator: deleteDelegateDto.delegator,
-      signature: deleteDelegateDto.signature,
+      chainId: args.chainId,
+      delegate: args.delegateAddress,
+      delegator: args.deleteDelegateDto.delegator,
+      signature: args.deleteDelegateDto.signature,
     });
   }
 
-  async deleteSafeDelegate(
-    chainId: string,
-    delegateAddress: string,
-    deleteSafeDelegateRequest: DeleteSafeDelegateDto,
-  ): Promise<unknown> {
+  async deleteSafeDelegate(args: {
+    chainId: string;
+    deleteSafeDelegateRequest: DeleteSafeDelegateDto;
+  }): Promise<unknown> {
     return await this.repository.deleteSafeDelegate({
-      chainId,
-      delegate: deleteSafeDelegateRequest.delegate,
-      safeAddress: deleteSafeDelegateRequest.safe,
-      signature: deleteSafeDelegateRequest.signature,
+      chainId: args.chainId,
+      delegate: args.deleteSafeDelegateRequest.delegate,
+      safeAddress: args.deleteSafeDelegateRequest.safe,
+      signature: args.deleteSafeDelegateRequest.signature,
     });
   }
 }

--- a/src/routes/delegates/delegates.service.ts
+++ b/src/routes/delegates/delegates.service.ts
@@ -24,15 +24,15 @@ export class DelegatesService {
     getDelegateDto: GetDelegateDto,
     paginationData: PaginationData,
   ): Promise<Page<Delegate>> {
-    const delegates = await this.repository.getDelegates(
+    const delegates = await this.repository.getDelegates({
       chainId,
-      getDelegateDto.safe,
-      getDelegateDto.delegate,
-      getDelegateDto.delegator,
-      getDelegateDto.label,
-      paginationData.limit,
-      paginationData.offset,
-    );
+      safeAddress: getDelegateDto.safe,
+      delegate: getDelegateDto.delegate,
+      delegator: getDelegateDto.delegator,
+      label: getDelegateDto.label,
+      limit: paginationData.limit,
+      offset: paginationData.offset,
+    });
 
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, delegates.next);
     const previousURL = cursorUrlFromLimitAndOffset(
@@ -52,14 +52,14 @@ export class DelegatesService {
     chainId: string,
     createDelegateDto: CreateDelegateDto,
   ): Promise<void> {
-    await this.repository.postDelegate(
+    await this.repository.postDelegate({
       chainId,
-      createDelegateDto.safe,
-      createDelegateDto.delegate,
-      createDelegateDto.delegator,
-      createDelegateDto.signature,
-      createDelegateDto.label,
-    );
+      safeAddress: createDelegateDto.safe,
+      delegate: createDelegateDto.delegate,
+      delegator: createDelegateDto.delegator,
+      signature: createDelegateDto.signature,
+      label: createDelegateDto.label,
+    });
   }
 
   async deleteDelegate(
@@ -67,12 +67,12 @@ export class DelegatesService {
     delegateAddress: string,
     deleteDelegateDto: DeleteDelegateDto,
   ): Promise<unknown> {
-    return await this.repository.deleteDelegate(
+    return await this.repository.deleteDelegate({
       chainId,
-      delegateAddress,
-      deleteDelegateDto.delegator,
-      deleteDelegateDto.signature,
-    );
+      delegate: delegateAddress,
+      delegator: deleteDelegateDto.delegator,
+      signature: deleteDelegateDto.signature,
+    });
   }
 
   async deleteSafeDelegate(
@@ -80,11 +80,11 @@ export class DelegatesService {
     delegateAddress: string,
     deleteSafeDelegateRequest: DeleteSafeDelegateDto,
   ): Promise<unknown> {
-    return await this.repository.deleteSafeDelegate(
+    return await this.repository.deleteSafeDelegate({
       chainId,
-      deleteSafeDelegateRequest.delegate,
-      deleteSafeDelegateRequest.safe,
-      deleteSafeDelegateRequest.signature,
-    );
+      delegate: deleteSafeDelegateRequest.delegate,
+      safeAddress: deleteSafeDelegateRequest.safe,
+      signature: deleteSafeDelegateRequest.signature,
+    });
   }
 }

--- a/src/routes/estimations/estimations.controller.ts
+++ b/src/routes/estimations/estimations.controller.ts
@@ -21,10 +21,10 @@ export class EstimationsController {
     @Param('address') address: string,
     @Body(GetEstimationDtoValidationPipe) getEstimationDto: GetEstimationDto,
   ): Promise<EstimationResponse> {
-    return this.estimationsService.getEstimation(
+    return this.estimationsService.getEstimation({
       chainId,
       address,
       getEstimationDto,
-    );
+    });
   }
 }

--- a/src/routes/estimations/estimations.service.ts
+++ b/src/routes/estimations/estimations.service.ts
@@ -21,31 +21,24 @@ export class EstimationsService {
    * The next recommended nonce is the maximum between the current Safe nonce and the Safe
    * last transaction nonce plus 1. If there is no last transaction, the Safe nonce is returned.
    *
-   * @param chainId chain id for the estimation.
-   * @param address address of the Safe requesting the estimation.
-   * @param getEstimationDto {@link GetEstimationDto} data.
    * @returns {@link EstimationResponse} containing {@link Estimation}, and both
    * current and recommended next nonce values
    */
-  async getEstimation(
-    chainId: string,
-    address: string,
-    getEstimationDto: GetEstimationDto,
-  ): Promise<EstimationResponse> {
-    const estimation = await this.estimationsRepository.getEstimation(
-      chainId,
-      address,
-      getEstimationDto,
-    );
+  async getEstimation(args: {
+    chainId: string;
+    address: string;
+    getEstimationDto: GetEstimationDto;
+  }): Promise<EstimationResponse> {
+    const estimation = await this.estimationsRepository.getEstimation(args);
     const safe = await this.safeRepository.getSafe({
-      chainId,
-      address: address,
+      chainId: args.chainId,
+      address: args.address,
     });
-    const recommendedNonce = await this.getEstimationRecommendedNonce(
-      chainId,
-      address,
-      safe.nonce,
-    );
+    const recommendedNonce = await this.getEstimationRecommendedNonce({
+      chainId: args.chainId,
+      safeAddress: args.address,
+      safeNonce: safe.nonce,
+    });
     return new EstimationResponse(
       safe.nonce,
       recommendedNonce,
@@ -57,24 +50,21 @@ export class EstimationsService {
    * Gets the maximum between the current Safe nonce and the last transaction nonce plus 1.
    * If there is no last transaction, the Safe nonce is returned.
    *
-   * @param chainId chain id for the estimation.
-   * @param safeAddress address of the Safe requesting the estimation.
-   * @param safeNonce nonce of the Safe requesting the estimation.
    * @returns recommended nonce for next transaction.
    */
-  private async getEstimationRecommendedNonce(
-    chainId: string,
-    safeAddress: string,
-    safeNonce: number,
-  ): Promise<number> {
+  private async getEstimationRecommendedNonce(args: {
+    chainId: string;
+    safeAddress: string;
+    safeNonce: number;
+  }): Promise<number> {
     const lastTransaction =
       await this.safeRepository.getLastTransactionSortedByNonce({
-        chainId,
-        safeAddress,
+        chainId: args.chainId,
+        safeAddress: args.safeAddress,
       });
 
     return lastTransaction
-      ? Math.max(safeNonce, lastTransaction.nonce + 1)
-      : safeNonce;
+      ? Math.max(args.safeNonce, lastTransaction.nonce + 1)
+      : args.safeNonce;
   }
 }

--- a/src/routes/estimations/estimations.service.ts
+++ b/src/routes/estimations/estimations.service.ts
@@ -37,7 +37,10 @@ export class EstimationsService {
       address,
       getEstimationDto,
     );
-    const safe = await this.safeRepository.getSafe(chainId, address);
+    const safe = await this.safeRepository.getSafe({
+      chainId,
+      address: address,
+    });
     const recommendedNonce = await this.getEstimationRecommendedNonce(
       chainId,
       address,
@@ -65,10 +68,10 @@ export class EstimationsService {
     safeNonce: number,
   ): Promise<number> {
     const lastTransaction =
-      await this.safeRepository.getLastTransactionSortedByNonce(
+      await this.safeRepository.getLastTransactionSortedByNonce({
         chainId,
         safeAddress,
-      );
+      });
 
     return lastTransaction
       ? Math.max(safeNonce, lastTransaction.nonce + 1)

--- a/src/routes/messages/messages.controller.ts
+++ b/src/routes/messages/messages.controller.ts
@@ -28,7 +28,7 @@ export class MessagesController {
     @Param('chainId') chainId: string,
     @Param('messageHash') messageHash: string,
   ): Promise<Message> {
-    return this.messagesService.getMessageByHash(chainId, messageHash);
+    return this.messagesService.getMessageByHash({ chainId, messageHash });
   }
 
   @ApiOkResponse({ type: MessagePage })
@@ -40,12 +40,12 @@ export class MessagesController {
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Page<DateLabel | MessageItem>> {
-    return this.messagesService.getMessagesBySafe(
+    return this.messagesService.getMessagesBySafe({
       chainId,
       safeAddress,
       paginationData,
       routeUrl,
-    );
+    });
   }
 
   @HttpCode(200)
@@ -55,11 +55,11 @@ export class MessagesController {
     @Param('safeAddress') safeAddress: string,
     @Body(CreateMessageDtoValidationPipe) createMessageDto: CreateMessageDto,
   ): Promise<unknown> {
-    return this.messagesService.createMessage(
+    return this.messagesService.createMessage({
       chainId,
       safeAddress,
       createMessageDto,
-    );
+    });
   }
 
   @HttpCode(200)
@@ -70,10 +70,10 @@ export class MessagesController {
     @Body(UpdateMessageSignatureDtoValidationPipe)
     updateMessageSignatureDto: UpdateMessageSignatureDto,
   ): Promise<unknown> {
-    return this.messagesService.updateMessageSignature(
+    return this.messagesService.updateMessageSignature({
       chainId,
       messageHash,
       updateMessageSignatureDto,
-    );
+    });
   }
 }

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -31,11 +31,14 @@ export class MessagesService {
     chainId: string,
     messageHash: string,
   ): Promise<Message> {
-    const message = await this.messagesRepository.getMessageByHash(
+    const message = await this.messagesRepository.getMessageByHash({
       chainId,
       messageHash,
-    );
-    const safe = await this.safeRepository.getSafe(chainId, message.safe);
+    });
+    const safe = await this.safeRepository.getSafe({
+      chainId,
+      address: message.safe,
+    });
     return this.messageMapper.mapMessage(chainId, message, safe);
   }
 
@@ -45,13 +48,16 @@ export class MessagesService {
     paginationData: PaginationData,
     routeUrl: Readonly<URL>,
   ): Promise<Page<DateLabel | MessageItem>> {
-    const safe = await this.safeRepository.getSafe(chainId, safeAddress);
-    const page = await this.messagesRepository.getMessagesBySafe(
+    const safe = await this.safeRepository.getSafe({
+      chainId,
+      address: safeAddress,
+    });
+    const page = await this.messagesRepository.getMessagesBySafe({
       chainId,
       safeAddress,
-      paginationData.limit,
-      paginationData.offset,
-    );
+      limit: paginationData.limit,
+      offset: paginationData.offset,
+    });
     const nextURL = cursorUrlFromLimitAndOffset(routeUrl, page.next);
     const previousURL = cursorUrlFromLimitAndOffset(routeUrl, page.previous);
     const groups = this.getOrderedGroups(page.results);
@@ -118,13 +124,13 @@ export class MessagesService {
     safeAddress: string,
     createMessageDto: CreateMessageDto,
   ): Promise<unknown> {
-    return await this.messagesRepository.createMessage(
+    return await this.messagesRepository.createMessage({
       chainId,
       safeAddress,
-      createMessageDto.message,
-      createMessageDto.safeAppId,
-      createMessageDto.signature,
-    );
+      message: createMessageDto.message,
+      safeAppId: createMessageDto.safeAppId,
+      signature: createMessageDto.signature,
+    });
   }
 
   async updateMessageSignature(
@@ -132,10 +138,10 @@ export class MessagesService {
     messageHash: string,
     updateMessageSignatureDto: UpdateMessageSignatureDto,
   ): Promise<unknown> {
-    return await this.messagesRepository.updateMessageSignature(
+    return await this.messagesRepository.updateMessageSignature({
       chainId,
       messageHash,
-      updateMessageSignatureDto.signature,
-    );
+      signature: updateMessageSignatureDto.signature,
+    });
   }
 }

--- a/src/routes/messages/messages.service.ts
+++ b/src/routes/messages/messages.service.ts
@@ -27,45 +27,45 @@ export class MessagesService {
     private readonly messageMapper: MessageMapper,
   ) {}
 
-  async getMessageByHash(
-    chainId: string,
-    messageHash: string,
-  ): Promise<Message> {
-    const message = await this.messagesRepository.getMessageByHash({
-      chainId,
-      messageHash,
-    });
+  async getMessageByHash(args: {
+    chainId: string;
+    messageHash: string;
+  }): Promise<Message> {
+    const message = await this.messagesRepository.getMessageByHash(args);
     const safe = await this.safeRepository.getSafe({
-      chainId,
+      chainId: args.chainId,
       address: message.safe,
     });
-    return this.messageMapper.mapMessage(chainId, message, safe);
+    return this.messageMapper.mapMessage(args.chainId, message, safe);
   }
 
-  async getMessagesBySafe(
-    chainId: string,
-    safeAddress: string,
-    paginationData: PaginationData,
-    routeUrl: Readonly<URL>,
-  ): Promise<Page<DateLabel | MessageItem>> {
+  async getMessagesBySafe(args: {
+    chainId: string;
+    safeAddress: string;
+    paginationData: PaginationData;
+    routeUrl: Readonly<URL>;
+  }): Promise<Page<DateLabel | MessageItem>> {
     const safe = await this.safeRepository.getSafe({
-      chainId,
-      address: safeAddress,
+      chainId: args.chainId,
+      address: args.safeAddress,
     });
     const page = await this.messagesRepository.getMessagesBySafe({
-      chainId,
-      safeAddress,
-      limit: paginationData.limit,
-      offset: paginationData.offset,
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+      limit: args.paginationData.limit,
+      offset: args.paginationData.offset,
     });
-    const nextURL = cursorUrlFromLimitAndOffset(routeUrl, page.next);
-    const previousURL = cursorUrlFromLimitAndOffset(routeUrl, page.previous);
+    const nextURL = cursorUrlFromLimitAndOffset(args.routeUrl, page.next);
+    const previousURL = cursorUrlFromLimitAndOffset(
+      args.routeUrl,
+      page.previous,
+    );
     const groups = this.getOrderedGroups(page.results);
 
     const labelledGroups = await Promise.all(
       groups.map(async ([timestamp, messages]) => {
         const messageItems = await this.messageMapper.mapMessageItems(
-          chainId,
+          args.chainId,
           messages,
           safe,
         );
@@ -119,29 +119,29 @@ export class MessagesService {
     );
   }
 
-  async createMessage(
-    chainId: string,
-    safeAddress: string,
-    createMessageDto: CreateMessageDto,
-  ): Promise<unknown> {
+  async createMessage(args: {
+    chainId: string;
+    safeAddress: string;
+    createMessageDto: CreateMessageDto;
+  }): Promise<unknown> {
     return await this.messagesRepository.createMessage({
-      chainId,
-      safeAddress,
-      message: createMessageDto.message,
-      safeAppId: createMessageDto.safeAppId,
-      signature: createMessageDto.signature,
+      chainId: args.chainId,
+      safeAddress: args.safeAddress,
+      message: args.createMessageDto.message,
+      safeAppId: args.createMessageDto.safeAppId,
+      signature: args.createMessageDto.signature,
     });
   }
 
-  async updateMessageSignature(
-    chainId: string,
-    messageHash: string,
-    updateMessageSignatureDto: UpdateMessageSignatureDto,
-  ): Promise<unknown> {
+  async updateMessageSignature(args: {
+    chainId: string;
+    messageHash: string;
+    updateMessageSignatureDto: UpdateMessageSignatureDto;
+  }): Promise<unknown> {
     return await this.messagesRepository.updateMessageSignature({
-      chainId,
-      messageHash,
-      signature: updateMessageSignatureDto.signature,
+      chainId: args.chainId,
+      messageHash: args.messageHash,
+      signature: args.updateMessageSignatureDto.signature,
     });
   }
 }

--- a/src/routes/notifications/notifications.controller.ts
+++ b/src/routes/notifications/notifications.controller.ts
@@ -30,10 +30,10 @@ export class NotificationsController {
     @Param('uuid') uuid: string,
     @Param('safeAddress') safeAddress: string,
   ): Promise<void> {
-    return this.notificationsService.unregisterDevice(
+    return this.notificationsService.unregisterDevice({
       chainId,
       uuid,
       safeAddress,
-    );
+    });
   }
 }

--- a/src/routes/notifications/notifications.service.ts
+++ b/src/routes/notifications/notifications.service.ts
@@ -90,11 +90,11 @@ export class NotificationsService {
     uuid: string,
     safeAddress: string,
   ): Promise<void> {
-    return this.notificationsRepository.unregisterDevice(
+    return this.notificationsRepository.unregisterDevice({
       chainId,
       uuid,
       safeAddress,
-    );
+    });
   }
 
   private isServerError(

--- a/src/routes/notifications/notifications.service.ts
+++ b/src/routes/notifications/notifications.service.ts
@@ -80,21 +80,13 @@ export class NotificationsService {
    * Un-registers a device notification target.
    * The uuid is expected to be managed by the client. Its value should be equal
    * to the one provided when the client called {@link registerDevice}.
-   *
-   * @param chainId chain id to use.
-   * @param uuid the same uuid provided when the device was registered.
-   * @param safeAddress safe address of the un-registration target.
    */
-  async unregisterDevice(
-    chainId: string,
-    uuid: string,
-    safeAddress: string,
-  ): Promise<void> {
-    return this.notificationsRepository.unregisterDevice({
-      chainId,
-      uuid,
-      safeAddress,
-    });
+  async unregisterDevice(args: {
+    chainId: string;
+    uuid: string;
+    safeAddress: string;
+  }): Promise<void> {
+    return this.notificationsRepository.unregisterDevice(args);
   }
 
   private isServerError(

--- a/src/routes/owners/owners.controller.ts
+++ b/src/routes/owners/owners.controller.ts
@@ -17,6 +17,6 @@ export class OwnersController {
     @Param('chainId') chainId: string,
     @Param('ownerAddress') ownerAddress: string,
   ): Promise<SafeList> {
-    return this.ownersService.getSafesByOwner(chainId, ownerAddress);
+    return this.ownersService.getSafesByOwner({ chainId, ownerAddress });
   }
 }

--- a/src/routes/owners/owners.service.ts
+++ b/src/routes/owners/owners.service.ts
@@ -10,10 +10,10 @@ export class OwnersService {
     private readonly safeRepository: SafeRepository,
   ) {}
 
-  async getSafesByOwner(
-    chainId: string,
-    ownerAddress: string,
-  ): Promise<SafeList> {
-    return this.safeRepository.getSafesByOwner({ chainId, ownerAddress });
+  async getSafesByOwner(args: {
+    chainId: string;
+    ownerAddress: string;
+  }): Promise<SafeList> {
+    return this.safeRepository.getSafesByOwner(args);
   }
 }

--- a/src/routes/owners/owners.service.ts
+++ b/src/routes/owners/owners.service.ts
@@ -14,6 +14,6 @@ export class OwnersService {
     chainId: string,
     ownerAddress: string,
   ): Promise<SafeList> {
-    return this.safeRepository.getSafesByOwner(chainId, ownerAddress);
+    return this.safeRepository.getSafesByOwner({ chainId, ownerAddress });
   }
 }

--- a/src/routes/safe-apps/safe-apps.controller.ts
+++ b/src/routes/safe-apps/safe-apps.controller.ts
@@ -20,6 +20,6 @@ export class SafeAppsController {
     @Query('clientUrl') clientUrl?: string,
     @Query('url') url?: string,
   ): Promise<SafeApp[]> {
-    return this.safeAppsService.getSafeApps(chainId, clientUrl, url);
+    return this.safeAppsService.getSafeApps({ chainId, clientUrl, url });
   }
 }

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -18,11 +18,11 @@ export class SafeAppsService {
     clientUrl?: string,
     url?: string,
   ): Promise<SafeApp[]> {
-    const result = await this.safeAppsRepository.getSafeApps(
+    const result = await this.safeAppsRepository.getSafeApps({
       chainId,
       clientUrl,
       url,
-    );
+    });
 
     return result.map(
       (safeApp) =>

--- a/src/routes/safe-apps/safe-apps.service.ts
+++ b/src/routes/safe-apps/safe-apps.service.ts
@@ -13,16 +13,12 @@ export class SafeAppsService {
     private readonly safeAppsRepository: SafeAppsRepository,
   ) {}
 
-  async getSafeApps(
-    chainId: string,
-    clientUrl?: string,
-    url?: string,
-  ): Promise<SafeApp[]> {
-    const result = await this.safeAppsRepository.getSafeApps({
-      chainId,
-      clientUrl,
-      url,
-    });
+  async getSafeApps(args: {
+    chainId: string;
+    clientUrl?: string;
+    url?: string;
+  }): Promise<SafeApp[]> {
+    const result = await this.safeAppsRepository.getSafeApps(args);
 
     return result.map(
       (safeApp) =>

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -15,6 +15,6 @@ export class SafesController {
     @Param('chainId') chainId: string,
     @Param('safeAddress') safeAddress: string,
   ): Promise<SafeState> {
-    return this.service.getSafeInfo(chainId, safeAddress);
+    return this.service.getSafeInfo({ chainId, safeAddress });
   }
 }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -31,7 +31,7 @@ export class SafesService {
   async getSafeInfo(chainId: string, safeAddress: string): Promise<SafeState> {
     const [safe, { recommendedMasterCopyVersion }, supportedMasterCopies] =
       await Promise.all([
-        this.safeRepository.getSafe(chainId, safeAddress),
+        this.safeRepository.getSafe({ chainId, address: safeAddress }),
         this.chainsRepository.getChain(chainId),
         this.chainsRepository.getMasterCopies(chainId),
       ]);
@@ -109,12 +109,12 @@ export class SafesService {
     safeAddress: string,
   ): Promise<Date | null> {
     const lastCollectibleTransfer =
-      await this.safeRepository.getCollectibleTransfers(
+      await this.safeRepository.getCollectibleTransfers({
         chainId,
         safeAddress,
-        1,
-        0,
-      );
+        limit: 1,
+        offset: 0,
+      });
 
     return lastCollectibleTransfer.results[0]?.executionDate ?? null;
   }
@@ -124,7 +124,11 @@ export class SafesService {
     safe: Safe,
   ): Promise<Date | null> {
     const lastQueuedTransaction =
-      await this.safeRepository.getTransactionQueueByModified(chainId, safe, 1);
+      await this.safeRepository.getTransactionQueueByModified({
+        chainId,
+        safe,
+        limit: 1,
+      });
 
     return lastQueuedTransaction.results[0]?.modified ?? null;
   }
@@ -134,11 +138,11 @@ export class SafesService {
     safeAddress: string,
   ): Promise<Date | null> {
     const lastExecutedTransaction = (
-      await this.safeRepository.getTransactionHistoryByExecutionDate(
+      await this.safeRepository.getTransactionHistoryByExecutionDate({
         chainId,
         safeAddress,
-        1,
-      )
+        limit: 1,
+      })
     ).results[0];
 
     if (!lastExecutedTransaction) return null;
@@ -162,10 +166,10 @@ export class SafesService {
     chainId: string,
     safeAddress: string,
   ): Promise<Date | null> {
-    const messages = await this.messagesRepository.getMessagesBySafe(
+    const messages = await this.messagesRepository.getMessagesBySafe({
       chainId,
       safeAddress,
-    );
+    });
 
     if (messages.results.length === 0) {
       return null;

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -28,12 +28,18 @@ export class SafesService {
     private readonly messagesRepository: MessagesRepository,
   ) {}
 
-  async getSafeInfo(chainId: string, safeAddress: string): Promise<SafeState> {
+  async getSafeInfo(args: {
+    chainId: string;
+    safeAddress: string;
+  }): Promise<SafeState> {
     const [safe, { recommendedMasterCopyVersion }, supportedMasterCopies] =
       await Promise.all([
-        this.safeRepository.getSafe({ chainId, address: safeAddress }),
-        this.chainsRepository.getChain(chainId),
-        this.chainsRepository.getMasterCopies(chainId),
+        this.safeRepository.getSafe({
+          chainId: args.chainId,
+          address: args.safeAddress,
+        }),
+        this.chainsRepository.getChain(args.chainId),
+        this.chainsRepository.getMasterCopies(args.chainId),
       ]);
 
     const versionState = this.computeVersionState(
@@ -51,29 +57,31 @@ export class SafesService {
       transactionHistoryTag,
       messagesTag,
     ] = await Promise.all([
-      this.addressInfoHelper.getOrDefault(chainId, safe.masterCopy, [
+      this.addressInfoHelper.getOrDefault(args.chainId, safe.masterCopy, [
         'CONTRACT',
       ]),
       safe.fallbackHandler === NULL_ADDRESS
         ? Promise.resolve(null)
-        : this.addressInfoHelper.getOrDefault(chainId, safe.fallbackHandler, [
-            'CONTRACT',
-          ]),
+        : this.addressInfoHelper.getOrDefault(
+            args.chainId,
+            safe.fallbackHandler,
+            ['CONTRACT'],
+          ),
       safe.guard === NULL_ADDRESS
         ? Promise.resolve(null)
-        : this.addressInfoHelper.getOrDefault(chainId, safe.guard, [
+        : this.addressInfoHelper.getOrDefault(args.chainId, safe.guard, [
             'CONTRACT',
           ]),
-      this.getCollectiblesTag(chainId, safeAddress),
-      this.getQueuedTransactionTag(chainId, safe),
-      this.executedTransactionTag(chainId, safeAddress),
-      this.modifiedMessageTag(chainId, safeAddress),
+      this.getCollectiblesTag(args.chainId, args.safeAddress),
+      this.getQueuedTransactionTag(args.chainId, safe),
+      this.executedTransactionTag(args.chainId, args.safeAddress),
+      this.modifiedMessageTag(args.chainId, args.safeAddress),
     ]);
 
     let moduleAddressesInfo: AddressInfo[] | null = null;
     if (safe.modules) {
       const moduleInfoCollection: Array<AddressInfo> =
-        await this.addressInfoHelper.getCollection(chainId, safe.modules, [
+        await this.addressInfoHelper.getCollection(args.chainId, safe.modules, [
           'CONTRACT',
         ]);
       moduleAddressesInfo =
@@ -82,7 +90,7 @@ export class SafesService {
 
     return new SafeState(
       new AddressInfo(safe.address),
-      chainId,
+      args.chainId,
       safe.nonce,
       safe.threshold,
       safe.owners.map((ownerAddress) => new AddressInfo(ownerAddress)),

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -3,8 +3,8 @@ import { SafeAppsRepository } from '../../../../domain/safe-apps/safe-apps.repos
 import { ISafeAppsRepository } from '../../../../domain/safe-apps/safe-apps.repository.interface';
 import { MultisigTransaction } from '../../../../domain/safe/entities/multisig-transaction.entity';
 import {
-  LoggingService,
   ILoggingService,
+  LoggingService,
 } from '../../../../logging/logging.interface';
 import { SafeAppInfo } from '../../entities/safe-app-info.entity';
 
@@ -27,11 +27,10 @@ export class SafeAppInfoMapper {
     const originUrl = this.getOriginUrl(transaction);
     if (!originUrl) return null;
 
-    const [safeApp] = await this.safeAppsRepository.getSafeApps(
+    const [safeApp] = await this.safeAppsRepository.getSafeApps({
       chainId,
-      undefined,
-      originUrl,
-    );
+      clientUrl: originUrl,
+    });
     if (!safeApp) {
       this.loggingService.info(
         `No Safe Apps matching the origin url ${originUrl} (safeTxHash: ${transaction.safeTxHash})`,

--- a/src/routes/transactions/mappers/common/transaction-data.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-data.mapper.ts
@@ -83,7 +83,10 @@ export class TransactionDataMapper {
 
     let contract: Contract;
     try {
-      contract = await this.contractRepository.getContract(chainId, to);
+      contract = await this.contractRepository.getContract({
+        chainId,
+        contractAddress: to,
+      });
     } catch (err) {
       return false;
     }

--- a/src/routes/transactions/mappers/common/transaction-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/transaction-info.mapper.ts
@@ -101,7 +101,7 @@ export class MultisigTransactionInfoMapper {
 
     if (this.isValidTokenTransfer(transaction)) {
       const token = await this.tokenRepository
-        .getToken(chainId, transaction.to)
+        .getToken({ chainId, address: transaction.to })
         .catch(() => null);
 
       switch (token?.type) {

--- a/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/routes/transactions/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -49,7 +49,7 @@ export class MultisigTransactionExecutionDetailsMapper {
     const [gasTokenInfo, executor, refundReceiver, rejectors] =
       await Promise.all([
         gasToken != NULL_ADDRESS
-          ? this.tokenRepository.getToken(chainId, gasToken)
+          ? this.tokenRepository.getToken({ chainId, address: gasToken })
           : Promise.resolve(null),
         transaction.executor
           ? this.addressInfoHelper.getOrDefault(chainId, transaction.executor, [
@@ -102,16 +102,13 @@ export class MultisigTransactionExecutionDetailsMapper {
     chainId: string,
     transaction: MultisigTransaction,
   ): Promise<AddressInfo[]> {
-    const rejectionTxsPage = await this.safeRepository.getMultisigTransactions(
-      chainId,
-      transaction.safe,
-      undefined,
-      undefined,
-      undefined,
-      transaction.safe,
-      '0',
-      transaction.nonce.toString(),
-    );
+    const rejectionTxsPage = await this.safeRepository.getMultisigTransactions({
+      chainId: chainId,
+      safeAddress: transaction.safe,
+      to: transaction.safe,
+      value: '0',
+      nonce: transaction.nonce.toString(),
+    });
 
     // This only considers one page of nonce-sharing transactions, which
     // would cover the vast majority of the cases. If needed, could be

--- a/src/routes/transactions/mappers/transaction-preview.mapper.ts
+++ b/src/routes/transactions/mappers/transaction-preview.mapper.ts
@@ -31,11 +31,11 @@ export class TransactionPreviewMapper {
     let dataDecoded;
     try {
       if (previewTransactionDto.data !== null) {
-        dataDecoded = await this.dataDecodedRepository.getDataDecoded(
+        dataDecoded = await this.dataDecodedRepository.getDataDecoded({
           chainId,
-          previewTransactionDto.data,
-          previewTransactionDto.to,
-        );
+          data: previewTransactionDto.data,
+          to: previewTransactionDto.to,
+        });
       }
     } catch (error) {
       this.loggingService.info(

--- a/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
+++ b/src/routes/transactions/mappers/transfers/transfer-info.mapper.ts
@@ -98,6 +98,6 @@ export class TransferInfoMapper {
     if (!tokenAddress) {
       throw Error('Invalid token address for transfer');
     }
-    return this.tokenRepository.getToken(chainId, tokenAddress);
+    return this.tokenRepository.getToken({ chainId, address: tokenAddress });
   }
 }

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -48,7 +48,7 @@ export class TransactionsController {
     @Param('chainId') chainId: string,
     @Param('id') id: string,
   ): Promise<TransactionDetails> {
-    return this.transactionsService.getById(chainId, id);
+    return this.transactionsService.getById({ chainId, txId: id });
   }
 
   @ApiOkResponse({ type: MultisigTransactionPage })
@@ -72,7 +72,7 @@ export class TransactionsController {
     @Query('nonce') nonce?: string,
     @Query('executed') executed?: boolean,
   ): Promise<Partial<Page<MultisigTransaction>>> {
-    return this.transactionsService.getMultisigTransactions(
+    return this.transactionsService.getMultisigTransactions({
       chainId,
       routeUrl,
       paginationData,
@@ -83,7 +83,7 @@ export class TransactionsController {
       value,
       nonce,
       executed,
-    );
+    });
   }
 
   @ApiOkResponse({ type: ModuleTransactionPage })
@@ -99,14 +99,14 @@ export class TransactionsController {
     @Query('to') to?: string,
     @Query('module') module?: string,
   ): Promise<Page<ModuleTransaction>> {
-    return this.transactionsService.getModuleTransactions(
+    return this.transactionsService.getModuleTransactions({
       chainId,
       routeUrl,
       safeAddress,
       to,
       module,
       paginationData,
-    );
+    });
   }
 
   @HttpCode(200)
@@ -118,11 +118,11 @@ export class TransactionsController {
     @Body(AddConfirmationDtoValidationPipe)
     addConfirmationDto: AddConfirmationDto,
   ): Promise<TransactionDetails> {
-    return this.transactionsService.addConfirmation(
+    return this.transactionsService.addConfirmation({
       chainId,
       safeTxHash,
       addConfirmationDto,
-    );
+    });
   }
 
   @ApiOkResponse({ type: IncomingTransferPage })
@@ -144,7 +144,7 @@ export class TransactionsController {
     @Query('value') value?: string,
     @Query('token_address') tokenAddress?: string,
   ): Promise<Partial<Page<IncomingTransfer>>> {
-    return this.transactionsService.getIncomingTransfers(
+    return this.transactionsService.getIncomingTransfers({
       chainId,
       routeUrl,
       safeAddress,
@@ -154,7 +154,7 @@ export class TransactionsController {
       value,
       tokenAddress,
       paginationData,
-    );
+    });
   }
 
   @ApiOkResponse({ type: TransactionPreview })
@@ -166,11 +166,11 @@ export class TransactionsController {
     @Body(PreviewTransactionDtoValidationPipe)
     previewTransactionDto: PreviewTransactionDto,
   ): Promise<TransactionPreview> {
-    return this.transactionsService.previewTransaction(
+    return this.transactionsService.previewTransaction({
       chainId,
       safeAddress,
       previewTransactionDto,
-    );
+    });
   }
 
   @ApiOkResponse({ type: QueuedItemPage })
@@ -184,12 +184,12 @@ export class TransactionsController {
     @Param('safeAddress') safeAddress: string,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Partial<Page<QueuedItem>>> {
-    return this.transactionsService.getTransactionQueue(
+    return this.transactionsService.getTransactionQueue({
       chainId,
       routeUrl,
       safeAddress,
       paginationData,
-    );
+    });
   }
 
   @ApiOkResponse({ type: TransactionItemPage })
@@ -204,13 +204,13 @@ export class TransactionsController {
     @Query('timezone_offset', new DefaultValuePipe(0), ParseIntPipe)
     timezoneOffset: number,
   ): Promise<Partial<TransactionItemPage>> {
-    return this.transactionsService.getTransactionHistory(
+    return this.transactionsService.getTransactionHistory({
       chainId,
       routeUrl,
       safeAddress,
       paginationData,
       timezoneOffset,
-    );
+    });
   }
 
   @HttpCode(200)
@@ -222,10 +222,10 @@ export class TransactionsController {
     @Body(ProposeTransactionDtoValidationPipe)
     proposeTransactionDto: ProposeTransactionDto,
   ): Promise<TransactionDetails> {
-    return this.transactionsService.proposeTransaction(
+    return this.transactionsService.proposeTransaction({
       chainId,
       safeAddress,
       proposeTransactionDto,
-    );
+    });
   }
 }


### PR DESCRIPTION
- Replace the arguments of some functions with an interface containing those same arguments.
- The advantage of this approach is that we can now use the anonymous interface names to specify the value of each argument (similar to named arguments).
- Methods that were sharing the same type in multiple arguments were also converted – e.g., having `foo(chainId: string, safeAddress: string)` can cause issues if the order of the parameters change or the callee calls `foo(safeAddress, chainId)` (which is a valid call).
- Similarly, functions which had optional values can be a source of errors by the callee – e.g., having `bar(chainId: string, a?: number, c?: number)` and later introducing a new version of `bar` such as `bar(chainId: string, a?: number, b?: number, c?: number)` would not require any changes by the callers (although `c` is now being used as `b`)