### PR TITLE
Remove Promise.then() mapping calls

### DIFF
--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -60,7 +60,6 @@ export class ConfigApi implements IConfigApi {
       this.cacheService.deleteByKey(CacheRouter.getChainsCacheKey()),
       this.cacheService.deleteByKeyPattern(pattern),
     ]);
-    return;
   }
 
   async getChain(chainId: string): Promise<Chain> {

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -54,15 +54,13 @@ export class ConfigApi implements IConfigApi {
     }
   }
 
-  clearChains(): Promise<void> {
+  async clearChains(): Promise<void> {
     const pattern = CacheRouter.getChainsCachePattern();
-
-    return Promise.all([
+    await Promise.all([
       this.cacheService.deleteByKey(CacheRouter.getChainsCacheKey()),
       this.cacheService.deleteByKeyPattern(pattern),
-    ]).then(() => {
-      return;
-    });
+    ]);
+    return;
   }
 
   async getChain(chainId: string): Promise<Chain> {

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -145,14 +145,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  clearCollectibles(safeAddress: string): Promise<void> {
+  async clearCollectibles(safeAddress: string): Promise<void> {
     const key = CacheRouter.getCollectiblesKey({
       chainId: this.chainId,
       safeAddress,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,
@@ -215,9 +214,8 @@ export class TransactionApi implements ITransactionApi {
       chainId: this.chainId,
       safeAddress,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,
@@ -383,14 +381,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  clearTransfers(safeAddress: string): Promise<void> {
+  async clearTransfers(safeAddress: string): Promise<void> {
     const key = CacheRouter.getTransfersCacheKey({
       chainId: this.chainId,
       safeAddress,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   async getIncomingTransfers(args: {
@@ -431,15 +428,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  clearIncomingTransfers(safeAddress: string): Promise<void> {
+  async clearIncomingTransfers(safeAddress: string): Promise<void> {
     const key = CacheRouter.getIncomingTransfersCacheKey({
       chainId: this.chainId,
       safeAddress,
     });
-
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   async postConfirmation(args: {
@@ -511,14 +506,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  clearModuleTransactions(safeAddress: string): Promise<void> {
+  async clearModuleTransactions(safeAddress: string): Promise<void> {
     const key = CacheRouter.getModuleTransactionsCacheKey({
       chainId: this.chainId,
       safeAddress,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   async getMultisigTransactions(args: {
@@ -573,9 +567,8 @@ export class TransactionApi implements ITransactionApi {
       chainId: this.chainId,
       safeAddress,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   async getMultisigTransaction(
@@ -599,14 +592,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  clearMultisigTransaction(safeTransactionHash: string): Promise<void> {
+  async clearMultisigTransaction(safeTransactionHash: string): Promise<void> {
     const key = CacheRouter.getMultisigTransactionCacheKey({
       chainId: this.chainId,
       safeTransactionHash,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,
@@ -667,14 +659,13 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  clearAllTransactions(safeAddress: string): Promise<void> {
+  async clearAllTransactions(safeAddress: string): Promise<void> {
     const key = CacheRouter.getAllTransactionsKey({
       chainId: this.chainId,
       safeAddress,
     });
-    return this.cacheService.deleteByKey(key).then(() => {
-      return;
-    });
+    await this.cacheService.deleteByKey(key);
+    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,

--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -151,7 +151,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,
@@ -215,7 +214,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,
@@ -387,7 +385,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   async getIncomingTransfers(args: {
@@ -434,7 +431,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   async postConfirmation(args: {
@@ -512,7 +508,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   async getMultisigTransactions(args: {
@@ -568,7 +563,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   async getMultisigTransaction(
@@ -598,7 +592,6 @@ export class TransactionApi implements ITransactionApi {
       safeTransactionHash,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,
@@ -665,7 +658,6 @@ export class TransactionApi implements ITransactionApi {
       safeAddress,
     });
     await this.cacheService.deleteByKey(key);
-    return;
   }
 
   // Important: there is no hook which invalidates this endpoint,

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -107,9 +107,7 @@ export class SafeRepository implements ISafeRepository {
   }): Promise<void> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
-    return transactionService.postConfirmation(args).then(() => {
-      return;
-    });
+    await transactionService.postConfirmation(args);
   }
 
   async getModuleTransaction(args: {


### PR DESCRIPTION
Removes `Promise.then()` calls that were used in order to map the result of a promise to `void`. Instead, we await for the promise and return from the function (this is more consistent with the way that we handle promises in other functions).