### PR TITLE
Remove health, flush and hooks controllers from Swagger

### DIFF
--- a/src/routes/cache-hooks/cache-hooks.controller.ts
+++ b/src/routes/cache-hooks/cache-hooks.controller.ts
@@ -10,11 +10,13 @@ import { OutgoingToken } from './entities/outgoing-token.entity';
 import { IncomingEther } from './entities/incoming-ether.entity';
 import { OutgoingEther } from './entities/outgoing-ether.entity';
 import { ModuleTransaction } from './entities/module-transaction.entity';
+import { ApiExcludeController } from '@nestjs/swagger';
 
 @Controller({
   path: '',
   version: '1',
 })
+@ApiExcludeController()
 export class CacheHooksController {
   constructor(private readonly service: CacheHooksService) {}
 

--- a/src/routes/flush/flush.controller.ts
+++ b/src/routes/flush/flush.controller.ts
@@ -1,15 +1,15 @@
 import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiExcludeController, ApiOkResponse } from '@nestjs/swagger';
 import { BasicAuthGuard } from '../common/auth/basic-auth.guard';
 import { InvalidationPatternDto } from './entities/invalidation-pattern.dto.entity';
 import { FlushService } from './flush.service';
 import { InvalidationPatternDtoValidationPipe } from './pipes/invalidation-pattern.dto.validation.pipe';
 
-@ApiTags('flush')
 @Controller({
   path: '',
   version: '2',
 })
+@ApiExcludeController()
 export class FlushController {
   constructor(private readonly flushService: FlushService) {}
 

--- a/src/routes/health/health.controller.ts
+++ b/src/routes/health/health.controller.ts
@@ -1,10 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { ApiExcludeController, ApiOkResponse } from '@nestjs/swagger';
 import { Health, HealthStatus } from './entities/health.entity';
 import { HealthService } from './health.service';
 
-@ApiTags('health')
 @Controller({ path: 'health' })
+@ApiExcludeController()
 export class HealthController {
   constructor(private readonly service: HealthService) {}
 


### PR DESCRIPTION
Removes the endpoints listed under `HealthController`, `FlushController` and `CacheHooksController` from Swagger as these endpoints are used mostly for internal purposes and are not required to be listed on the Swagger interface.