### PR TITLE
fix: prevent scientific notation in large balances

### DIFF
--- a/src/routes/balances/balances.service.ts
+++ b/src/routes/balances/balances.service.ts
@@ -23,6 +23,13 @@ export class BalancesService {
     private readonly exchangeRepository: IExchangeRepository,
   ) {}
 
+  getNumberString(value: number): string {
+    // Prevent scientific notation
+    return value.toLocaleString('fullwide', {
+      useGrouping: false,
+    });
+  }
+
   async getBalances(
     chainId: string,
     safeAddress: string,
@@ -61,7 +68,7 @@ export class BalancesService {
     });
 
     return <Balances>{
-      fiatTotal: totalFiat.toString(),
+      fiatTotal: this.getNumberString(totalFiat),
       items: balances,
     };
   }
@@ -98,9 +105,9 @@ export class BalancesService {
         address: tokenAddress,
         ...tokenMetaData,
       },
-      balance: txBalance.balance.toString(),
-      fiatBalance: fiatBalance.toString(),
-      fiatConversion: fiatConversion.toString(),
+      balance: txBalance.balance,
+      fiatBalance: this.getNumberString(fiatBalance),
+      fiatConversion: this.getNumberString(fiatConversion),
     };
   }
 


### PR DESCRIPTION
Resolves #613

This prevents large balances from being returned in scientific notation.

An [example Safe on the Transaction Service](https://safe-transaction-polygon.safe.global/api/v1/safes/0x828d55AaF0fE916879C7dCf0E3278D1E8dbEDDd3/balances/usd/) should no longer return the `fiatTotal` or individual `fiatBalance`/`fiatConversion` with exponents, but the full number as a string: `/v1/chains/137/safes/0x828d55AaF0fE916879C7dCf0E3278D1E8dbEDDd3/balances/usd`.