### PR TITLE
Fix: tx queue - pass trusted query param

### DIFF
--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -151,6 +151,7 @@ export class SafeRepository implements ISafeRepository {
     safe: Safe;
     limit?: number;
     offset?: number;
+    trusted?: boolean;
   }): Promise<Page<MultisigTransaction>> {
     return this._getTransactionQueue({
       ...args,
@@ -176,6 +177,7 @@ export class SafeRepository implements ISafeRepository {
     ordering: string;
     limit?: number;
     offset?: number;
+    trusted?: boolean;
   }): Promise<Page<MultisigTransaction>> {
     const transactionService =
       await this.transactionApiManager.getTransactionApi(args.chainId);
@@ -184,7 +186,6 @@ export class SafeRepository implements ISafeRepository {
         ...args,
         safeAddress: args.safe.address,
         executed: false,
-        trusted: true,
         nonceGte: args.safe.nonce,
       });
     return this.multisigTransactionValidator.validatePage(page);

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -480,9 +480,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .build();
     const safeAppsResponse = [
       safeAppBuilder()
-        .with('url', faker.internet.url({ appendSlash: false }))
-        .with('iconUrl', faker.internet.url({ appendSlash: false }))
-        .with('name', faker.word.words())
         .build(),
     ];
     const transactions: MultisigTransaction[] = [

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -468,4 +468,111 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         });
       });
   });
+
+  it('should get an "untrusted" queue', async () => {
+    const chainId = faker.string.numeric();
+    const safeAddress = faker.finance.ethereumAddress();
+    const chainResponse = chainBuilder().build();
+    const contractResponse = contractBuilder().build();
+    const safeResponse = safeBuilder()
+      .with('address', safeAddress)
+      .with('nonce', 1)
+      .build();
+    const safeAppsResponse = [
+      safeAppBuilder()
+        .with('url', faker.internet.url({ appendSlash: false }))
+        .with('iconUrl', faker.internet.url({ appendSlash: false }))
+        .with('name', faker.word.words())
+        .build(),
+    ];
+    const transactions: MultisigTransaction[] = [
+      multisigToJson(
+        multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('safeTxHash', faker.finance.ethereumAddress())
+          .with('nonce', 1)
+          .with('dataDecoded', null)
+          .build(),
+      ) as MultisigTransaction,
+      multisigToJson(
+        multisigTransactionBuilder()
+          .with('safe', safeAddress)
+          .with('isExecuted', false)
+          .with('safeTxHash', faker.finance.ethereumAddress())
+          .with('nonce', 2)
+          .with('dataDecoded', null)
+          .build(),
+      ) as MultisigTransaction,
+    ];
+    networkService.get.mockImplementation((url: string, query) => {
+      const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chainId}`;
+      const getSafeAppsUrl = `${safeConfigUrl}/api/v1/safe-apps/`;
+      const getMultisigTransactionsUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}/multisig-transactions/`;
+      const getSafeUrl = `${chainResponse.transactionService}/api/v1/safes/${safeAddress}`;
+      const getContractUrlPattern = `${chainResponse.transactionService}/api/v1/contracts/`;
+      if (url === getChainUrl) {
+        return Promise.resolve({ data: chainResponse });
+      }
+      if (url === getMultisigTransactionsUrl) {
+        expect(query.params.trusted).toBe(false);
+
+        return Promise.resolve({
+          data: {
+            count: 2,
+            next: null,
+            previous: null,
+            results: transactions,
+          },
+        });
+      }
+      if (url === getSafeUrl) {
+        return Promise.resolve({ data: safeResponse });
+      }
+      if (url === getSafeAppsUrl) {
+        return Promise.resolve({ data: safeAppsResponse });
+      }
+      if (url.includes(getContractUrlPattern)) {
+        return Promise.resolve({ data: contractResponse });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .get(
+        `/v1/chains/${chainId}/safes/${safeAddress}/transactions/queued/?trusted=false`,
+      )
+      .expect(200)
+      .then(({ body }) => {
+        expect(body).toEqual({
+          count: 4,
+          next: null,
+          previous: null,
+          results: [
+            {
+              label: 'Next',
+              type: 'LABEL',
+            },
+            {
+              type: 'TRANSACTION',
+              transaction: expect.objectContaining({
+                id: `multisig_${safeAddress}_${transactions[0].safeTxHash}`,
+              }),
+              conflictType: 'None',
+            },
+            {
+              label: 'Queued',
+              type: 'LABEL',
+            },
+            {
+              type: 'TRANSACTION',
+              transaction: expect.objectContaining({
+                id: `multisig_${safeAddress}_${transactions[1].safeTxHash}`,
+              }),
+              conflictType: 'None',
+            },
+          ],
+        });
+      });
+  });
 });

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -487,7 +487,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigTransactionBuilder()
           .with('safe', safeAddress)
           .with('isExecuted', false)
-          .with('safeTxHash', faker.finance.ethereumAddress())
           .with('nonce', 1)
           .with('dataDecoded', null)
           .build(),

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -495,7 +495,6 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
         multisigTransactionBuilder()
           .with('safe', safeAddress)
           .with('isExecuted', false)
-          .with('safeTxHash', faker.finance.ethereumAddress())
           .with('nonce', 2)
           .with('dataDecoded', null)
           .build(),

--- a/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-queued-transactions-by-safe.transactions.controller.spec.ts
@@ -478,10 +478,7 @@ describe('List queued transactions by Safe - Transactions Controller (Unit)', ()
       .with('address', safeAddress)
       .with('nonce', 1)
       .build();
-    const safeAppsResponse = [
-      safeAppBuilder()
-        .build(),
-    ];
+    const safeAppsResponse = [safeAppBuilder().build()];
     const transactions: MultisigTransaction[] = [
       multisigToJson(
         multisigTransactionBuilder()

--- a/src/routes/transactions/transactions.controller.ts
+++ b/src/routes/transactions/transactions.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   HttpCode,
   Param,
+  ParseBoolPipe,
   ParseIntPipe,
   Post,
   Query,
@@ -183,12 +184,15 @@ export class TransactionsController {
     @RouteUrlDecorator() routeUrl: URL,
     @Param('safeAddress') safeAddress: string,
     @PaginationDataDecorator() paginationData: PaginationData,
+    @Query('trusted', new DefaultValuePipe(true), ParseBoolPipe)
+    trusted: boolean,
   ): Promise<Partial<Page<QueuedItem>>> {
     return this.transactionsService.getTransactionQueue({
       chainId,
       routeUrl,
       safeAddress,
       paginationData,
+      trusted,
     });
   }
 

--- a/src/routes/transactions/transactions.service.ts
+++ b/src/routes/transactions/transactions.service.ts
@@ -307,6 +307,7 @@ export class TransactionsService {
     routeUrl: Readonly<URL>;
     safeAddress: string;
     paginationData: PaginationData;
+    trusted?: boolean;
   }): Promise<Page<QueuedItem>> {
     const pagination = this.getAdjustedPaginationForQueue(args.paginationData);
     const safeInfo = await this.safeRepository.getSafe({
@@ -318,6 +319,7 @@ export class TransactionsService {
       safe: safeInfo,
       limit: pagination.limit,
       offset: pagination.offset,
+      trusted: args.trusted,
     });
 
     const nextURL = buildNextPageURL(args.routeUrl, transactions.count);


### PR DESCRIPTION
Resolves https://github.com/safe-global/safe-wallet-web/issues/2329

We fetch an "untrusted" queue for pending transactions in 1/X Safes. Without this fix, `queued?trusted=false` would have no effect and it would fetch the regular, "trusted", queue.

The `trusted` query parameter should be passed to tx-service.