### PR TITLE
Fix: pass Safe Apps origin as url, not clientUrl

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,9 @@ async function bootstrap() {
     app.get<IConfigurationService>(IConfigurationService);
   const applicationPort: string =
     configurationService.getOrThrow('applicationPort');
+
+  app.enableCors();
+
   await app.listen(applicationPort);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,6 @@ async function bootstrap() {
   const applicationPort: string =
     configurationService.getOrThrow('applicationPort');
 
-  app.enableCors();
-
   await app.listen(applicationPort);
 }
 

--- a/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
+++ b/src/routes/transactions/mappers/common/safe-app-info.mapper.ts
@@ -29,7 +29,7 @@ export class SafeAppInfoMapper {
 
     const [safeApp] = await this.safeAppsRepository.getSafeApps({
       chainId,
-      clientUrl: originUrl,
+      url: originUrl,
     });
     if (!safeApp) {
       this.loggingService.info(


### PR DESCRIPTION
Tx-service sends an origin for each Safe App transaction, which contains the URL of the Safe App that created a tx. This URL needs to be passed to the config-service in the URL field, not clientUrl.