### PR TITLE
Fix Chain and Safe App cache patterns

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -359,7 +359,7 @@ export class CacheRouter {
   }
 
   static getChainsCachePattern(): string {
-    return `*_${CacheRouter.CHAIN_KEY}$`;
+    return `*_${CacheRouter.CHAIN_KEY}`;
   }
 
   static getSafeAppsCacheDir(args: {
@@ -374,7 +374,7 @@ export class CacheRouter {
   }
 
   static getSafeAppsCachePattern(): string {
-    return `*_${CacheRouter.SAFE_APPS_KEY}$`;
+    return `*_${CacheRouter.SAFE_APPS_KEY}`;
   }
 
   static getExchangeFiatCodesCacheDir(): CacheDir {

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -179,7 +179,7 @@ describe('ConfigApi', () => {
     await service.clearChains();
 
     expect(mockCacheService.deleteByKey).toBeCalledWith('chains');
-    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_chain$');
+    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_chain');
     expect(mockCacheService.deleteByKey).toBeCalledTimes(1);
     expect(mockCacheService.deleteByKeyPattern).toBeCalledTimes(1);
   });
@@ -187,7 +187,7 @@ describe('ConfigApi', () => {
   it('clear safe apps should trigger delete on cache service', async () => {
     await service.clearSafeApps();
 
-    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_safe_apps$');
+    expect(mockCacheService.deleteByKeyPattern).toBeCalledWith('*_safe_apps');
     expect(mockCacheService.deleteByKeyPattern).toBeCalledTimes(1);
     expect(mockCacheService.deleteByKey).toBeCalledTimes(0);
   });


### PR DESCRIPTION
Closes #627 

This PR:
- Updates the `Chains` cache pattern from `*_chains$` to `*_chains`.
- Updates the `Chains` cache pattern from `*_safe_apps$` to `*_safe_apps`.

With this change, the `unlink` function will be executed over the cached `chains` and `safe apps` when a cache flush is triggered.