### PR TITLE
Make safe version nullable

### DIFF
--- a/src/domain/safe/entities/safe.entity.ts
+++ b/src/domain/safe/entities/safe.entity.ts
@@ -7,5 +7,5 @@ export interface Safe {
   nonce: number;
   owners: string[];
   threshold: number;
-  version: string;
+  version: string | null;
 }

--- a/src/domain/safe/entities/schemas/safe.schema.ts
+++ b/src/domain/safe/entities/schemas/safe.schema.ts
@@ -1,10 +1,9 @@
-import { JSONSchemaType } from 'ajv';
-import { Safe } from '../safe.entity';
+import { Schema } from 'ajv';
 
 export const SAFE_SCHEMA_ID =
   'https://safe-client.safe.global/schemas/safe/safe.json';
 
-export const safeSchema: JSONSchemaType<Safe> = {
+export const safeSchema: Schema = {
   $id: SAFE_SCHEMA_ID,
   type: 'object',
   properties: {
@@ -22,7 +21,7 @@ export const safeSchema: JSONSchemaType<Safe> = {
     },
     fallbackHandler: { type: 'string' },
     guard: { type: 'string' },
-    version: { type: 'string' },
+    version: { type: 'string', nullable: true, default: null },
   },
   required: [
     'address',
@@ -32,6 +31,5 @@ export const safeSchema: JSONSchemaType<Safe> = {
     'masterCopy',
     'fallbackHandler',
     'guard',
-    'version',
   ],
 };

--- a/src/routes/safes/entities/safe-info.entity.ts
+++ b/src/routes/safes/entities/safe-info.entity.ts
@@ -20,13 +20,13 @@ export class SafeState {
   readonly owners: AddressInfo[];
   @ApiProperty()
   readonly implementation: AddressInfo;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   readonly modules: AddressInfo[] | null;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   readonly fallbackHandler: AddressInfo | null;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: AddressInfo, nullable: true })
   readonly guard: AddressInfo | null;
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({ type: String, nullable: true })
   readonly version: string | null;
   @ApiProperty({ enum: Object.values(MasterCopyVersionState) })
   readonly implementationVersionState: MasterCopyVersionState;

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -255,6 +255,59 @@ describe('Safes Controller (Unit)', () => {
       );
   });
 
+  it('Version State is UNKNOWN when safe has null safe version', async () => {
+    const chain = chainBuilder().build();
+    const masterCopies = [masterCopyBuilder().build()];
+    const masterCopyInfo = contractBuilder().build();
+    const safeInfo = safeBuilder()
+      .with('masterCopy', masterCopyInfo.address)
+      .with('version', null)
+      .build();
+    const fallbackHandlerInfo = contractBuilder()
+      .with('address', safeInfo.fallbackHandler)
+      .build();
+    const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
+    const collectibleTransfers = pageBuilder().build();
+    const queuedTransactions = pageBuilder().build();
+    const allTransactions = pageBuilder().build();
+    const messages = pageBuilder().build();
+
+    networkService.get.mockImplementation((url) => {
+      switch (url) {
+        case `${safeConfigUrl}/api/v1/chains/${chain.chainId}`:
+          return Promise.resolve({ data: chain });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}`:
+          return Promise.resolve({ data: safeInfo });
+        case `${chain.transactionService}/api/v1/about/master-copies/`:
+          return Promise.resolve({ data: masterCopies });
+        case `${chain.transactionService}/api/v1/contracts/${masterCopyInfo.address}`:
+          return Promise.resolve({ data: masterCopyInfo });
+        case `${chain.transactionService}/api/v1/contracts/${fallbackHandlerInfo.address}`:
+          return Promise.resolve({ data: fallbackHandlerInfo });
+        case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
+          return Promise.resolve({ data: guardInfo });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
+          return Promise.resolve({ data: collectibleTransfers });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
+          return Promise.resolve({ data: queuedTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
+          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
+          return Promise.resolve({ data: messages });
+      }
+      return Promise.reject(`No matching rule for url: ${url}`);
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chain.chainId}/safes/${safeInfo.address}`)
+      .expect(200)
+      .expect((response) =>
+        expect(response.body).toMatchObject({
+          implementationVersionState: 'UNKNOWN',
+        }),
+      );
+  });
+
   it('Version State is UNKNOWN when chain has an invalid recommended safe version', async () => {
     const chain = chainBuilder()
       .with('recommendedMasterCopyVersion', 'vI.N.V.A.L.I.D')

--- a/src/routes/safes/safes.controller.ts
+++ b/src/routes/safes/safes.controller.ts
@@ -1,4 +1,4 @@
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { Controller, Get, Param } from '@nestjs/common';
 import { SafesService } from './safes.service';
 import { SafeState } from './entities/safe-info.entity';
@@ -10,6 +10,7 @@ import { SafeState } from './entities/safe-info.entity';
 export class SafesController {
   constructor(private readonly service: SafesService) {}
 
+  @ApiOkResponse({ type: SafeState })
   @Get('chains/:chainId/safes/:safeAddress')
   async getSafe(
     @Param('chainId') chainId: string,

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -196,7 +196,8 @@ export class SafesService {
     supportedMasterCopies: MasterCopy[],
   ): MasterCopyVersionState {
     // If the safe version or the recommended safe version is not valid we return UNKNOWN
-    if (!semver.valid(safe.version)) return MasterCopyVersionState.UNKNOWN;
+    if (safe.version === null || !semver.valid(safe.version))
+      return MasterCopyVersionState.UNKNOWN;
     if (!semver.valid(recommendedSafeVersion))
       return MasterCopyVersionState.UNKNOWN;
     // If the master copy of this safe is not part of the collection


### PR DESCRIPTION
Closes #629 

This PR:
- Adds support for having `null` as Safes `version` attribute, avoiding returning a _validation error_  which crashes the Web UI (nullable `version` field [was the case in the Rust implementation](https://github.com/safe-global/safe-client-gateway/blob/eb481938a49c29b979fe98a5577f719f42a2b2eb/src/providers/info.rs#L64)).
- Modifies the OpenAPI definition accordingly.
- Adapts the code to return `UNKNOWN` for the `implementationVersionState` field when `version` is `null`, [as the Rust implementation does](https://github.com/safe-global/safe-client-gateway/blob/eb481938a49c29b979fe98a5577f719f42a2b2eb/src/routes/safes/converters.rs).