### PR TITLE
Decrease the usage of all-transactions endpoint

### DIFF
--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -23,10 +23,7 @@ export interface ISafeRepository {
     offset?: number;
   }): Promise<Page<Transfer>>;
 
-  clearCollectibleTransfers(args: {
-    chainId: string;
-    safeAddress: string;
-  }): Promise<void>;
+  clearTransfers(args: { chainId: string; safeAddress: string }): Promise<void>;
 
   getIncomingTransfers(args: {
     chainId: string;

--- a/src/domain/safe/safe.repository.interface.ts
+++ b/src/domain/safe/safe.repository.interface.ts
@@ -95,13 +95,6 @@ export interface ISafeRepository {
     offset?: number;
   }): Promise<Page<MultisigTransaction>>;
 
-  getTransactionHistoryByExecutionDate(args: {
-    chainId: string;
-    safeAddress: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<Page<Transaction>>;
-
   getCreationTransaction(args: {
     chainId: string;
     safeAddress: string;
@@ -148,6 +141,12 @@ export interface ISafeRepository {
   }): Promise<Page<MultisigTransaction>>;
 
   getTransfer(args: { chainId: string; transferId: string }): Promise<Transfer>;
+
+  getTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number;
+  }): Promise<Page<Transfer>>;
 
   getSafesByOwner(args: {
     chainId: string;

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -63,7 +63,7 @@ export class SafeRepository implements ISafeRepository {
     return this.transferValidator.validatePage(page);
   }
 
-  async clearCollectibleTransfers(args: {
+  async clearTransfers(args: {
     chainId: string;
     safeAddress: string;
   }): Promise<void> {

--- a/src/domain/safe/safe.repository.ts
+++ b/src/domain/safe/safe.repository.ts
@@ -203,18 +203,6 @@ export class SafeRepository implements ISafeRepository {
     return this.creationTransactionValidator.validate(createTransaction);
   }
 
-  async getTransactionHistoryByExecutionDate(args: {
-    chainId: string;
-    safeAddress: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<Page<Transaction>> {
-    return this.getAllExecutedTransactions({
-      ...args,
-      ordering: 'executionDate',
-    });
-  }
-
   async getTransactionHistory(args: {
     chainId: string;
     safeAddress: string;
@@ -317,6 +305,17 @@ export class SafeRepository implements ISafeRepository {
       await this.transactionApiManager.getTransactionApi(args.chainId);
     const transfer = await transactionService.getTransfer(args.transferId);
     return this.transferValidator.validate(transfer);
+  }
+
+  async getTransfers(args: {
+    chainId: string;
+    safeAddress: string;
+    limit?: number | undefined;
+  }): Promise<Page<Transfer>> {
+    const transactionService =
+      await this.transactionApiManager.getTransactionApi(args.chainId);
+    const page = await transactionService.getTransfers(args);
+    return this.transferValidator.validatePage(page);
   }
 
   async getSafesByOwner(args: {

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -130,6 +130,14 @@ export class CacheHooksService {
             chainId: event.chainId,
             safeAddress: event.address,
           }),
+          this.safeRepository.clearMultisigTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
           this.safeRepository.clearIncomingTransfers({
             chainId: event.chainId,
             safeAddress: event.address,
@@ -139,6 +147,7 @@ export class CacheHooksService {
       // Outgoing ether affects:
       // - the balance of the safe - clear safe balance
       // - the list of all executed transactions for the safe
+      // - queued transactions and history – clear multisig transactions
       // - the transfers for that safe
       case EventType.OUTGOING_ETHER:
         promises.push(
@@ -147,6 +156,10 @@ export class CacheHooksService {
             safeAddress: event.address,
           }),
           this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransactions({
             chainId: event.chainId,
             safeAddress: event.address,
           }),
@@ -160,6 +173,7 @@ export class CacheHooksService {
       // - the balance of the safe - clear safe balance
       // - the collectibles that the safe has
       // - the list of all executed transactions (including transfers) for the safe
+      // - queued transactions and history – clear multisig transactions
       // - the transfers for that safe
       // - the incoming transfers for that safe
       case EventType.INCOMING_TOKEN:
@@ -173,6 +187,10 @@ export class CacheHooksService {
             safeAddress: event.address,
           }),
           this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransactions({
             chainId: event.chainId,
             safeAddress: event.address,
           }),
@@ -190,6 +208,7 @@ export class CacheHooksService {
       // - the balance of the safe - clear safe balance
       // - the collectibles that the safe has
       // - the list of all executed transactions (including transfers) for the safe
+      // - queued transactions and history – clear multisig transactions
       // - the transfers for that safe
       case EventType.OUTGOING_TOKEN:
         promises.push(
@@ -202,6 +221,10 @@ export class CacheHooksService {
             safeAddress: event.address,
           }),
           this.safeRepository.clearAllExecutedTransactions({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
+          this.safeRepository.clearMultisigTransactions({
             chainId: event.chainId,
             safeAddress: event.address,
           }),

--- a/src/routes/cache-hooks/cache-hooks.service.ts
+++ b/src/routes/cache-hooks/cache-hooks.service.ts
@@ -69,7 +69,7 @@ export class CacheHooksService {
       // A new executed multisig transaction affects:
       // - the collectibles that the safe has
       // - the list of all executed transactions for the safe
-      // - the collectible transfers for that safe
+      // - the transfers for that safe
       // - queued transactions and history – clear multisig transactions
       // - the transaction executed – clear multisig transaction
       // - the safe configuration - clear safe info
@@ -83,7 +83,7 @@ export class CacheHooksService {
             chainId: event.chainId,
             safeAddress: event.address,
           }),
-          this.safeRepository.clearCollectibleTransfers({
+          this.safeRepository.clearTransfers({
             chainId: event.chainId,
             safeAddress: event.address,
           }),
@@ -138,7 +138,8 @@ export class CacheHooksService {
         break;
       // Outgoing ether affects:
       // - the balance of the safe - clear safe balance
-      // - the list of all executed transactions (including transfers) for the safe
+      // - the list of all executed transactions for the safe
+      // - the transfers for that safe
       case EventType.OUTGOING_ETHER:
         promises.push(
           this.balancesRepository.clearLocalBalances({
@@ -149,13 +150,17 @@ export class CacheHooksService {
             chainId: event.chainId,
             safeAddress: event.address,
           }),
+          this.safeRepository.clearTransfers({
+            chainId: event.chainId,
+            safeAddress: event.address,
+          }),
         );
         break;
       // An incoming token affects:
       // - the balance of the safe - clear safe balance
       // - the collectibles that the safe has
       // - the list of all executed transactions (including transfers) for the safe
-      // - the collectible transfers for that safe
+      // - the transfers for that safe
       // - the incoming transfers for that safe
       case EventType.INCOMING_TOKEN:
         promises.push(
@@ -171,7 +176,7 @@ export class CacheHooksService {
             chainId: event.chainId,
             safeAddress: event.address,
           }),
-          this.safeRepository.clearCollectibleTransfers({
+          this.safeRepository.clearTransfers({
             chainId: event.chainId,
             safeAddress: event.address,
           }),
@@ -185,7 +190,7 @@ export class CacheHooksService {
       // - the balance of the safe - clear safe balance
       // - the collectibles that the safe has
       // - the list of all executed transactions (including transfers) for the safe
-      // - the collectible transfers for that safe
+      // - the transfers for that safe
       case EventType.OUTGOING_TOKEN:
         promises.push(
           this.balancesRepository.clearLocalBalances({
@@ -200,7 +205,7 @@ export class CacheHooksService {
             chainId: event.chainId,
             safeAddress: event.address,
           }),
-          this.safeRepository.clearCollectibleTransfers({
+          this.safeRepository.clearTransfers({
             chainId: event.chainId,
             safeAddress: event.address,
           }),

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -12,10 +12,6 @@ import {
   multisigTransactionBuilder,
   toJson as multisigTransactionToJson,
 } from '../../domain/safe/entities/__tests__/multisig-transaction.builder';
-import {
-  ethereumTransactionBuilder,
-  toJson as ethereumTransactionToJson,
-} from '../../domain/safe/entities/__tests__/ethereum-transaction.builder';
 import { faker } from '@faker-js/faker';
 import {
   erc721TransferBuilder,
@@ -41,7 +37,7 @@ import { RequestScopedLoggingModule } from '../../logging/logging.module';
 import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
-describe.skip('Safes Controller (Unit)', () => {
+describe('Safes Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
   let networkService;
@@ -325,7 +321,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -346,8 +342,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -383,7 +379,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -404,8 +400,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -434,26 +430,7 @@ describe.skip('Safes Controller (Unit)', () => {
       .build();
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
-    const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder()
-      .with('results', [
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-18T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-16T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-14T03:52:02Z'))
-            .build(),
-        ),
-      ])
-      .build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -473,9 +450,29 @@ describe.skip('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-18T03:52:02Z'))
+                    .build(),
+                ),
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-16T03:52:02Z'))
+                    .build(),
+                ),
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-14T03:52:02Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -504,29 +501,7 @@ describe.skip('Safes Controller (Unit)', () => {
       .build();
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
-    const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder()
-      .with('results', [
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', null)
-            .with('submissionDate', new Date('2020-09-17T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-16T03:52:02Z'))
-            .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-14T03:52:02Z'))
-            .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
-            .build(),
-        ),
-      ])
-      .build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -546,9 +521,32 @@ describe.skip('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', null)
+                    .with('submissionDate', new Date('2020-09-17T03:52:02Z'))
+                    .build(),
+                ),
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-16T03:52:02Z'))
+                    .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+                    .build(),
+                ),
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-14T03:52:02Z'))
+                    .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -576,29 +574,7 @@ describe.skip('Safes Controller (Unit)', () => {
       .with('address', safeInfo.fallbackHandler)
       .build();
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
-    const collectibleTransfers = pageBuilder().build();
-    const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder()
-      .with('results', [
-        ethereumTransactionToJson(
-          ethereumTransactionBuilder()
-            .with('executionDate', new Date('2020-09-17T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-16T03:52:02Z'))
-            .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-14T03:52:02Z'))
-            .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
-            .build(),
-        ),
-      ])
-      .build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -616,11 +592,32 @@ describe.skip('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
           return Promise.resolve({ data: guardInfo });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                erc721TransferToJson(
+                  erc721TransferBuilder()
+                    .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-16T03:52:02Z'))
+                    .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -648,29 +645,6 @@ describe.skip('Safes Controller (Unit)', () => {
       .with('address', safeInfo.fallbackHandler)
       .build();
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
-    const collectibleTransfers = pageBuilder().build();
-    const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder()
-      .with('results', [
-        moduleTransactionToJson(
-          moduleTransactionBuilder()
-            .with('executionDate', new Date('2020-09-17T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-16T03:52:02Z'))
-            .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
-            .build(),
-        ),
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2020-09-14T03:52:02Z'))
-            .with('submissionDate', new Date('2020-09-14T03:52:02Z'))
-            .build(),
-        ),
-      ])
-      .build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -688,11 +662,34 @@ describe.skip('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
           return Promise.resolve({ data: guardInfo });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({
+            data: pageBuilder().build(),
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2020-09-16T03:52:02Z'))
+                    .with('submissionDate', new Date('2020-09-16T03:52:02Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                moduleTransactionToJson(
+                  moduleTransactionBuilder()
+                    .with('executionDate', new Date('2020-09-17T03:52:02Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -722,7 +719,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
 
     const messages = pageBuilder()
       .with('results', [
@@ -762,8 +759,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -800,7 +797,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -827,8 +824,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -875,7 +872,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -896,8 +893,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -927,7 +924,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -948,8 +945,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -974,7 +971,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -996,8 +993,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -1027,7 +1024,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -1048,8 +1045,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -1075,7 +1072,7 @@ describe.skip('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -1097,8 +1094,8 @@ describe.skip('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }

--- a/src/routes/safes/safes.controller.spec.ts
+++ b/src/routes/safes/safes.controller.spec.ts
@@ -41,7 +41,7 @@ import { RequestScopedLoggingModule } from '../../logging/logging.module';
 import { NetworkModule } from '../../datasources/network/network.module';
 import { NetworkService } from '../../datasources/network/network.service.interface';
 
-describe('Safes Controller (Unit)', () => {
+describe.skip('Safes Controller (Unit)', () => {
   let app: INestApplication;
   let safeConfigUrl;
   let networkService;
@@ -92,30 +92,10 @@ describe('Safes Controller (Unit)', () => {
       .build();
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
 
-    const collectibleTransfers = pageBuilder()
+    const moduleTransactions = pageBuilder()
       .with('results', [
-        erc721TransferToJson(
-          erc721TransferBuilder()
-            .with('executionDate', new Date('2016-09-19T02:55:04+0000'))
-            .build(),
-        ),
-      ])
-      .build();
-
-    const queuedTransactions = pageBuilder()
-      .with('results', [
-        multisigTransactionToJson(
-          multisigTransactionBuilder()
-            .with('modified', new Date('2049-01-30T14:23:07Z'))
-            .build(),
-        ),
-      ])
-      .build();
-
-    const allTransactions = pageBuilder()
-      .with('results', [
-        ethereumTransactionToJson(
-          ethereumTransactionBuilder()
+        moduleTransactionToJson(
+          moduleTransactionBuilder()
             .with('executionDate', new Date('2073-03-12T12:29:06Z'))
             .build(),
         ),
@@ -147,11 +127,31 @@ describe('Safes Controller (Unit)', () => {
         case `${chain.transactionService}/api/v1/contracts/${guardInfo.address}`:
           return Promise.resolve({ data: guardInfo });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/transfers/`:
-          return Promise.resolve({ data: collectibleTransfers });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                erc721TransferToJson(
+                  erc721TransferBuilder()
+                    .with('executionDate', new Date('2016-09-19T02:55:04+0000'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
-          return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+          return Promise.resolve({
+            data: pageBuilder()
+              .with('results', [
+                multisigTransactionToJson(
+                  multisigTransactionBuilder()
+                    .with('modified', new Date('2049-01-30T14:23:07Z'))
+                    .build(),
+                ),
+              ])
+              .build(),
+          });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -216,7 +216,7 @@ describe('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -237,8 +237,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }
@@ -270,7 +270,7 @@ describe('Safes Controller (Unit)', () => {
     const guardInfo = contractBuilder().with('address', safeInfo.guard).build();
     const collectibleTransfers = pageBuilder().build();
     const queuedTransactions = pageBuilder().build();
-    const allTransactions = pageBuilder().build();
+    const moduleTransactions = pageBuilder().build();
     const messages = pageBuilder().build();
 
     networkService.get.mockImplementation((url) => {
@@ -291,8 +291,8 @@ describe('Safes Controller (Unit)', () => {
           return Promise.resolve({ data: collectibleTransfers });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/multisig-transactions/`:
           return Promise.resolve({ data: queuedTransactions });
-        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/all-transactions/`:
-          return Promise.resolve({ data: allTransactions });
+        case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/module-transactions/`:
+          return Promise.resolve({ data: moduleTransactions });
         case `${chain.transactionService}/api/v1/safes/${safeInfo.address}/messages/`:
           return Promise.resolve({ data: messages });
       }

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -11,6 +11,9 @@ import { NULL_ADDRESS } from '../common/constants';
 import { MessagesRepository } from '../../domain/messages/messages.repository';
 import { IMessagesRepository } from '../../domain/messages/messages.repository.interface';
 import { max } from 'lodash';
+import { MultisigTransaction } from '../../domain/safe/entities/multisig-transaction.entity';
+import { ModuleTransaction } from '../../domain/safe/entities/module-transaction.entity';
+import { Transfer } from '../../domain/safe/entities/transfer.entity';
 
 @Injectable()
 export class SafesService {
@@ -172,8 +175,9 @@ export class SafesService {
     ]);
 
     const dates = txPages
-      .flatMap(({ results }): (MultisigTransaction | ModuleTransaction | Transfer)[] =>
-        results
+      .flatMap(
+        ({ results }): (MultisigTransaction | ModuleTransaction | Transfer)[] =>
+          results,
       )
       .map((tx) => {
         const isMultisig = 'safeTxHash' in tx && tx.safeTxHash !== undefined;

--- a/src/routes/safes/safes.service.ts
+++ b/src/routes/safes/safes.service.ts
@@ -172,7 +172,9 @@ export class SafesService {
     ]);
 
     const dates = txPages
-      .flatMap(({ results }) => [...results])
+      .flatMap(({ results }): (MultisigTransaction | ModuleTransaction | Transfer)[] =>
+        results
+      )
       .map((tx) => {
         const isMultisig = 'safeTxHash' in tx && tx.safeTxHash !== undefined;
         return isMultisig ? tx.modified ?? tx.submissionDate : tx.executionDate;


### PR DESCRIPTION
Closes #630 

This PR aims to decrease the usage of the Transaction Service `all-transactions` endpoint in favor of several calls to `/multisig-transactions`, `/module-transactions`, and `/transfers`. The changes include:

- Remove now unused `SafeRepository` functions, create a new function, and rename other functions.
- Adjust cache invalidations to clear the `MultisigTransactions` and `Transfers` when one of `[INCOMING_ETHER, OUTGOING_ETHER, INCOMING_TOKEN, OUTGOING_TOKEN]` events happen. This was previously covered by `clearAllExecutedTransactions` but that's not the case anymore since we are using other endpoints.
- Adjusts the tests in `safes.controller.spec.ts` accordingly.
- Adjusts the function which calculates the `txHistoryTag` to use the three endpoints.