### PR TITLE
Remove workaround to bypass error when safe address is not defined

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -281,7 +281,7 @@ export class TransactionApi implements ITransactionApi {
     try {
       const url = `${this.baseUrl}/api/v1/delegates/`;
       await this.networkService.post(url, {
-        safe: args.safeAddress ?? null, // TODO: this is a workaround while https://github.com/safe-global/safe-transaction-service/issues/1521 is not fixed.
+        safe: args.safeAddress,
         delegate: args.delegate,
         delegator: args.delegator,
         signature: args.signature,


### PR DESCRIPTION
This PR reverts the workaround done when fixing https://github.com/safe-global/safe-client-gateway-nest/pull/491

The fix for the original issue is now completed so the workaround (explicitly send `null` when `safeAddress` is not defined to the Transaction Service) is not necessary anymore: https://github.com/safe-global/safe-transaction-service/issues/1521