### PR TITLE
feat: add notification device unregistration route

### DIFF
--- a/src/datasources/transaction-api/transaction-api.service.ts
+++ b/src/datasources/transaction-api/transaction-api.service.ts
@@ -754,7 +754,16 @@ export class TransactionApi implements ITransactionApi {
     }
   }
 
-  async deleteDeviceRegistration(args: {
+  async deleteDeviceRegistration(uuid: string): Promise<void> {
+    try {
+      const url = `${this.baseUrl}/api/v1/notifications/devices/${uuid}`;
+      await this.networkService.delete(url);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async deleteSafeRegistration(args: {
     uuid: string;
     safeAddress: string;
   }): Promise<void> {

--- a/src/domain/interfaces/transaction-api.interface.ts
+++ b/src/domain/interfaces/transaction-api.interface.ts
@@ -171,7 +171,9 @@ export interface ITransactionApi {
     signatures: string[];
   }): Promise<void>;
 
-  deleteDeviceRegistration(args: {
+  deleteDeviceRegistration(uuid: string): Promise<void>;
+
+  deleteSafeRegistration(args: {
     uuid: string;
     safeAddress: string;
   }): Promise<void>;

--- a/src/domain/notifications/notifications.repository.interface.ts
+++ b/src/domain/notifications/notifications.repository.interface.ts
@@ -16,9 +16,15 @@ export interface INotificationsRepository {
   ): Promise<SafeRegistration>;
 
   /**
-   * Un-registers a notification target, identified by its client {@link uuid}.
+   * Un-registers a device notification target, identified by its client {@link uuid}.
    */
-  unregisterDevice(args: {
+  unregisterDevice(args: { chainId: string; uuid: string }): Promise<void>;
+
+  /**
+   * Un-registers a Safe notification target, identified by its client {@link uuid} and
+   * Safe {@link safeAddress}.
+   */
+  unregisterSafe(args: {
     chainId: string;
     uuid: string;
     safeAddress: string;

--- a/src/domain/notifications/notifications.repository.ts
+++ b/src/domain/notifications/notifications.repository.ts
@@ -28,12 +28,22 @@ export class NotificationsRepository implements INotificationsRepository {
   async unregisterDevice(args: {
     chainId: string;
     uuid: string;
+  }): Promise<void> {
+    const api = await this.transactionApiManager.getTransactionApi(
+      args.chainId,
+    );
+    return api.deleteDeviceRegistration(args.uuid);
+  }
+
+  async unregisterSafe(args: {
+    chainId: string;
+    uuid: string;
     safeAddress: string;
   }): Promise<void> {
     const api = await this.transactionApiManager.getTransactionApi(
       args.chainId,
     );
-    return api.deleteDeviceRegistration({
+    return api.deleteSafeRegistration({
       uuid: args.uuid,
       safeAddress: args.safeAddress,
     });

--- a/src/routes/notifications/notifications.controller.ts
+++ b/src/routes/notifications/notifications.controller.ts
@@ -24,13 +24,21 @@ export class NotificationsController {
     return this.notificationsService.registerDevice(registerDeviceDto);
   }
 
-  @Delete('chains/:chainId/notifications/devices/:uuid/safes/:safeAddress')
+  @Delete('chains/:chainId/notifications/devices/:uuid')
   async unregisterDevice(
+    @Param('chainId') chainId: string,
+    @Param('uuid') uuid: string,
+  ): Promise<void> {
+    return this.notificationsService.unregisterDevice({ chainId, uuid });
+  }
+
+  @Delete('chains/:chainId/notifications/devices/:uuid/safes/:safeAddress')
+  async unregisterSafe(
     @Param('chainId') chainId: string,
     @Param('uuid') uuid: string,
     @Param('safeAddress') safeAddress: string,
   ): Promise<void> {
-    return this.notificationsService.unregisterDevice({
+    return this.notificationsService.unregisterSafe({
       chainId,
       uuid,
       safeAddress,

--- a/src/routes/notifications/notifications.service.ts
+++ b/src/routes/notifications/notifications.service.ts
@@ -84,9 +84,21 @@ export class NotificationsService {
   async unregisterDevice(args: {
     chainId: string;
     uuid: string;
-    safeAddress: string;
   }): Promise<void> {
     return this.notificationsRepository.unregisterDevice(args);
+  }
+
+  /**
+   * Un-registers a Safe notification target.
+   * The uuid is expected to be managed by the client. Its value should be equal
+   * to the one provided when the client called {@link unregisterSafe}.
+   */
+  async unregisterSafe(args: {
+    chainId: string;
+    uuid: string;
+    safeAddress: string;
+  }): Promise<void> {
+    return this.notificationsRepository.unregisterSafe(args);
   }
 
   private isServerError(


### PR DESCRIPTION
This adds a new, fully-tested route (`/chains/:chainId/notifications/devices/:uuid`) to unregister notification devices. We were previously unregistering Safes individually.

All prior functionality has been renamed accordingly to `deleteSafeRegistration` and `unregisterSafe`, with `deleteDeviceRegistration` and `unregisterDevice` now handling the entire unregistration notificatification devices.