### PR TITLE
Use checksummed addresses in safeBuilder

### DIFF
--- a/src/domain/safe/entities/__tests__/safe.builder.ts
+++ b/src/domain/safe/entities/__tests__/safe.builder.ts
@@ -1,16 +1,17 @@
 import { faker } from '@faker-js/faker';
 import { Builder, IBuilder } from '@/__tests__/builder';
 import { Safe } from '@/domain/safe/entities/safe.entity';
+import { getAddress } from 'viem';
 
 export function safeBuilder(): IBuilder<Safe> {
   return new Builder<Safe>()
-    .with('address', faker.finance.ethereumAddress())
+    .with('address', getAddress(faker.finance.ethereumAddress()))
     .with('nonce', faker.number.int())
     .with('threshold', faker.number.int())
-    .with('owners', [faker.finance.ethereumAddress()])
-    .with('masterCopy', faker.finance.ethereumAddress())
+    .with('owners', [getAddress(faker.finance.ethereumAddress())])
+    .with('masterCopy', getAddress(faker.finance.ethereumAddress()))
     .with('modules', null)
-    .with('fallbackHandler', faker.finance.ethereumAddress())
-    .with('guard', faker.finance.ethereumAddress())
+    .with('fallbackHandler', getAddress(faker.finance.ethereumAddress()))
+    .with('guard', getAddress(faker.finance.ethereumAddress()))
     .with('version', faker.system.semver());
 }


### PR DESCRIPTION
This is preliminary work to support https://github.com/safe-global/safe-client-gateway/issues/1190

Some routes, such as the Alert Controller routes, receive data from third parties which might include non-checksummed addresses.

The processing for some of these routes might include converting non-checksummed addresses to checksummed ones. If the Safe Builder doesn't provide checksummed addresses by default, we'd have to know if we should mock third party routes with a checksummed address or not.

With this new default, we provide support for mocking datasource calls that use checksummed addresses and non-checksummed ones (without having to change all the mocks that use the Safe address from the builder).