### PR TITLE
Change campaigns leaderboard datasource URL

### DIFF
--- a/src/datasources/locking-api/locking-api.service.spec.ts
+++ b/src/datasources/locking-api/locking-api.service.spec.ts
@@ -15,6 +15,7 @@ import { getAddress } from 'viem';
 import { rankBuilder } from '@/domain/locking/entities/__tests__/rank.builder';
 import { campaignBuilder } from '@/domain/locking/entities/__tests__/campaign.builder';
 import { holderBuilder } from '@/domain/locking/entities/__tests__/holder.builder';
+import { Holder } from '@/domain/locking/entities/holder.entity';
 
 const networkService = {
   get: jest.fn(),
@@ -265,22 +266,22 @@ describe('LockingApi', () => {
     });
   });
 
-  describe('getLeaderboardV2', () => {
-    it('should get leaderboard v2', async () => {
+  describe('getCampaignLeaderboard', () => {
+    it('should get leaderboard by campaign', async () => {
       const campaignId = faker.string.uuid();
-      const leaderboardV2Page = pageBuilder()
+      const holderPage = pageBuilder<Holder>()
         .with('results', [holderBuilder().build(), holderBuilder().build()])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: leaderboardV2Page,
+        data: holderPage,
         status: 200,
       });
 
-      const result = await service.getLeaderboardV2({ campaignId });
+      const result = await service.getCampaignLeaderboard({ campaignId });
 
-      expect(result).toEqual(leaderboardV2Page);
+      expect(result).toEqual(holderPage);
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v2/leaderboard/${campaignId}`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaignId}/leaderboard`,
         networkRequest: {
           params: {
             limit: undefined,
@@ -294,18 +295,18 @@ describe('LockingApi', () => {
       const limit = faker.number.int();
       const offset = faker.number.int();
       const campaignId = faker.string.uuid();
-      const leaderboardV2Page = pageBuilder()
+      const holderPage = pageBuilder<Holder>()
         .with('results', [holderBuilder().build(), holderBuilder().build()])
         .build();
       mockNetworkService.get.mockResolvedValueOnce({
-        data: leaderboardV2Page,
+        data: holderPage,
         status: 200,
       });
 
-      await service.getLeaderboardV2({ campaignId, limit, offset });
+      await service.getCampaignLeaderboard({ campaignId, limit, offset });
 
       expect(mockNetworkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v2/leaderboard/${campaignId}`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaignId}/leaderboard`,
         networkRequest: {
           params: {
             limit,
@@ -319,7 +320,7 @@ describe('LockingApi', () => {
       const status = faker.internet.httpStatusCode({ types: ['serverError'] });
       const campaignId = faker.string.uuid();
       const error = new NetworkResponseError(
-        new URL(`${lockingBaseUri}/api/v2/leaderboard/${campaignId}`),
+        new URL(`${lockingBaseUri}/api/v1/campaigns/${campaignId}/leaderboard`),
         {
           status,
         } as Response,
@@ -329,9 +330,9 @@ describe('LockingApi', () => {
       );
       mockNetworkService.get.mockRejectedValueOnce(error);
 
-      await expect(service.getLeaderboardV2({ campaignId })).rejects.toThrow(
-        new DataSourceError('Unexpected error', status),
-      );
+      await expect(
+        service.getCampaignLeaderboard({ campaignId }),
+      ).rejects.toThrow(new DataSourceError('Unexpected error', status));
 
       expect(mockNetworkService.get).toHaveBeenCalledTimes(1);
     });

--- a/src/datasources/locking-api/locking-api.service.ts
+++ b/src/datasources/locking-api/locking-api.service.ts
@@ -88,13 +88,13 @@ export class LockingApi implements ILockingApi {
     }
   }
 
-  async getLeaderboardV2(args: {
+  async getCampaignLeaderboard(args: {
     campaignId: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<Holder>> {
     try {
-      const url = `${this.baseUri}/api/v2/leaderboard/${args.campaignId}`;
+      const url = `${this.baseUri}/api/v1/campaigns/${args.campaignId}/leaderboard`;
       const { data } = await this.networkService.get<Page<Holder>>({
         url,
         networkRequest: {

--- a/src/domain/interfaces/locking-api.interface.ts
+++ b/src/domain/interfaces/locking-api.interface.ts
@@ -21,7 +21,7 @@ export interface ILockingApi {
     offset?: number;
   }): Promise<Page<Rank>>;
 
-  getLeaderboardV2(args: {
+  getCampaignLeaderboard(args: {
     campaignId: string;
     limit?: number;
     offset?: number;

--- a/src/domain/locking/locking.repository.interface.ts
+++ b/src/domain/locking/locking.repository.interface.ts
@@ -21,7 +21,7 @@ export interface ILockingRepository {
     offset?: number;
   }): Promise<Page<Rank>>;
 
-  getLeaderBoardByCampaignId(args: {
+  getCampaignLeaderboard(args: {
     campaignId: string;
     limit?: number;
     offset?: number;

--- a/src/domain/locking/locking.repository.ts
+++ b/src/domain/locking/locking.repository.ts
@@ -50,12 +50,12 @@ export class LockingRepository implements ILockingRepository {
     return RankPageSchema.parse(page);
   }
 
-  async getLeaderBoardByCampaignId(args: {
+  async getCampaignLeaderboard(args: {
     campaignId: string;
     limit?: number;
     offset?: number;
   }): Promise<Page<Holder>> {
-    const page = await this.lockingApi.getLeaderboardV2(args);
+    const page = await this.lockingApi.getCampaignLeaderboard(args);
     return HolderPageSchema.parse(page);
   }
 

--- a/src/routes/locking/locking.controller.spec.ts
+++ b/src/routes/locking/locking.controller.spec.ts
@@ -230,7 +230,7 @@ describe('Locking (Unit)', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v2/leaderboard/${campaign.campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
             return Promise.resolve({ data: holderPage, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -259,7 +259,7 @@ describe('Locking (Unit)', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v2/leaderboard/${campaign.campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
             return Promise.resolve({ data: holderPage, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -287,7 +287,7 @@ describe('Locking (Unit)', () => {
         .build();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v2/leaderboard/${campaign.campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
             return Promise.resolve({ data: holderPage, status: 200 });
           default:
             return Promise.reject(`No matching rule for url: ${url}`);
@@ -307,7 +307,7 @@ describe('Locking (Unit)', () => {
         });
 
       expect(networkService.get).toHaveBeenCalledWith({
-        url: `${lockingBaseUri}/api/v2/leaderboard/${campaign.campaignId}`,
+        url: `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`,
         networkRequest: {
           params: {
             limit,
@@ -325,7 +325,7 @@ describe('Locking (Unit)', () => {
       const errorMessage = faker.word.words();
       networkService.get.mockImplementation(({ url }) => {
         switch (url) {
-          case `${lockingBaseUri}/api/v2/leaderboard/${campaign.campaignId}`:
+          case `${lockingBaseUri}/api/v1/campaigns/${campaign.campaignId}/leaderboard`:
             return Promise.reject(
               new NetworkResponseError(
                 new URL(url),

--- a/src/routes/locking/locking.controller.ts
+++ b/src/routes/locking/locking.controller.ts
@@ -50,12 +50,12 @@ export class LockingController {
     type: String,
   })
   @Get('/campaigns/:campaignId/leaderboard')
-  async getLeaderBoardByCampaignId(
+  async getCampaignLeaderboard(
     @Param('campaignId') campaignId: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<HolderPage> {
-    return this.lockingService.getLeaderBoardByCampaignId({
+    return this.lockingService.getCampaignLeaderboard({
       campaignId,
       routeUrl,
       paginationData,

--- a/src/routes/locking/locking.service.ts
+++ b/src/routes/locking/locking.service.ts
@@ -69,12 +69,12 @@ export class LockingService {
     };
   }
 
-  async getLeaderBoardByCampaignId(args: {
+  async getCampaignLeaderboard(args: {
     campaignId: string;
     routeUrl: URL;
     paginationData: PaginationData;
   }): Promise<Page<Holder>> {
-    const result = await this.lockingRepository.getLeaderBoardByCampaignId({
+    const result = await this.lockingRepository.getCampaignLeaderboard({
       campaignId: args.campaignId,
       limit: args.paginationData.limit,
       offset: args.paginationData.offset,


### PR DESCRIPTION
## Summary
The Safe Locking Service implementation changed recently, and the leaderboard by campaign endpoint is not under the `v2` prefix anymore. 

These changes can be seen here (approval is pending): https://github.com/safe-global/safe-locking-service/pull/100/files#diff-d790dada13951d227666cb46aa0ccc89033037f7a7a5e1ed86e9bbfbbe0ef65b

This PR modifies the datasource endpoints and renames functions/variables accordingly.

## Changes
- Changes the campaign leaderboard datasource URL from `/v2/leaderboard/:campaignId` to `/v1/campaigns/:campaignId/leaderboard`
- Renames datasource functions accordingly.
