### PR TITLE
Validate token payload before signing it

### DIFF
--- a/src/domain/auth/auth.repository.ts
+++ b/src/domain/auth/auth.repository.ts
@@ -24,8 +24,8 @@ export class AuthRepository implements IAuthRepository {
       notBefore?: number;
     },
   ): string {
-    // TODO: Verify payload before signing it
-    return this.jwtService.sign(payload, options);
+    const authPayloadDto = AuthPayloadDtoSchema.parse(payload);
+    return this.jwtService.sign(authPayloadDto, options);
   }
 
   verifyToken(accessToken: string): AuthPayloadDto {


### PR DESCRIPTION
## Summary

A signed JWT token includes a payload. In our case, we sign an `AuthPayloadDto`. Although we are relying on types to ensure that the payload passed to `signToken` is correct, it does not mean that the content is definitively valid.

This adds validation of the payload passed to `AuthRepository['signToken']`, ensuring that it contains valid values.

## Changes

- Parse the payload-to-be-signed against the `AuthPayloadDtoSchema`