### PR TITLE
Add Telegram To Safe Apps Social Link Types

### DIFF
--- a/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
+++ b/src/domain/safe-apps/entities/schemas/safe-app.schema.ts
@@ -18,6 +18,7 @@ export enum SafeAppSocialProfilePlatforms {
   Discord = 'DISCORD',
   GitHub = 'GITHUB',
   Twitter = 'TWITTER',
+  Telegram = 'TELEGRAM',
   Unknown = 'UNKNOWN',
 }
 


### PR DESCRIPTION
## Summary
This pull request (PR) introduces the addition of Telegram as a supported social link type in the Safe Apps platform.

## Changes
- Added Telegram to Safe apps social links.