### PR TITLE
feat: test non-admins cannot delete organization Safes

### DIFF
--- a/src/routes/organizations/organization-safes.service.ts
+++ b/src/routes/organizations/organization-safes.service.ts
@@ -86,7 +86,7 @@ export class OrganizationSafesService {
     }
   }
 
-  public async assertOrganizationAdmin(
+  private async assertOrganizationAdmin(
     organizationId: Organization['id'],
     signerAddress: `0x${string}`,
   ): Promise<void> {
@@ -112,7 +112,7 @@ export class OrganizationSafesService {
     }
   }
 
-  public async assertOrganizationMembership(
+  private async assertOrganizationMembership(
     organizationId: Organization['id'],
     signerAddress: `0x${string}`,
   ): Promise<void> {


### PR DESCRIPTION
## Changes
- Adds a missing test checking non-admin members cannot remove Safes from an organization.
