### PR TITLE
fix: wrong message status type in swagger

### DIFF
--- a/src/routes/messages/entities/message.entity.ts
+++ b/src/routes/messages/entities/message.entity.ts
@@ -17,7 +17,7 @@ export enum MessageStatus {
 export class Message {
   @ApiProperty()
   messageHash: `0x${string}`;
-  @ApiProperty()
+  @ApiProperty({ enum: MessageStatus })
   status: MessageStatus;
   @ApiPropertyOptional({ type: String, nullable: true })
   logoUri: string | null;


### PR DESCRIPTION
## Summary
The swagger definition was claiming that message status is a string, but it is actually an enum of NEEDS_CONFIRMATION and Confirmed
## Changes
