### PR TITLE
fix: make the memory cache global

### DIFF
--- a/src/datasources/network/network.module.ts
+++ b/src/datasources/network/network.module.ts
@@ -17,6 +17,8 @@ export type FetchClient = <T>(
   options: RequestInit,
 ) => Promise<NetworkResponse<T>>;
 
+const cache: Record<string, Promise<NetworkResponse<unknown>>> = {};
+
 /**
  * Use this factory to create a {@link FetchClient} instance
  * that can be used to make HTTP requests.
@@ -81,8 +83,6 @@ function createCachedRequestFunction(
   ) => Promise<NetworkResponse<T>>,
   loggingService: ILoggingService,
 ) {
-  const cache: Record<string, Promise<NetworkResponse<unknown>>> = {};
-
   return async <T>(
     url: string,
     options: RequestInit,


### PR DESCRIPTION
## Summary
This PR fixes a bug where the in-memory cache for the in-flight requests was scoped locally, causing duplicate fetches or inconsistent cache hits. The cache is now made global to ensure shared access across requests and consistent behavior.


## Changes
- Refactored in-memory cache to be a shared/global instance
