### PR TITLE
feat: Add `oauth2TokenTtlBufferInSeconds` configuration option

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -252,6 +252,7 @@ export default (): ReturnType<typeof configuration> => ({
       privateKey: faker.string.alphanumeric(),
     },
     getSubscribersBySafeTtlMilliseconds: faker.number.int({ min: 1, max: 100 }),
+    oauth2TokenTtlBufferInSeconds: faker.number.int({ min: 30, max: 100 }),
   },
   redis: {
     user: process.env.REDIS_USER,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -390,6 +390,10 @@ export default () => ({
       process.env.PUSH_NOTIFICATIONS_GET_SUBSCRIBERS_BY_SAFE_TTL_MILLISECONDS ||
       60 * 1_000
     ),
+    oauth2TokenTtlBufferInSeconds: parseInt(
+      process.env.PUSH_NOTIFICATIONS_API_OAUTH2_TOKEN_TTL_BUFFER_IN_SECONDS ??
+        `${120}`,
+    ),
   },
   redis: {
     user: process.env.REDIS_USER,

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -31,6 +31,11 @@ export const RootConfigurationSchema = z
     PUSH_NOTIFICATIONS_API_PROJECT: z.string(),
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: z.string().email(),
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY: z.string(),
+    PUSH_NOTIFICATIONS_API_OAUTH2_TOKEN_TTL_BUFFER_IN_SECONDS: z
+      .number({ coerce: true })
+      .min(1)
+      .max(3599)
+      .optional(),
     RELAY_PROVIDER_API_KEY_OPTIMISM: z.string(),
     RELAY_PROVIDER_API_KEY_BSC: z.string(),
     RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN: z.string(),

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.spec.ts
@@ -26,6 +26,7 @@ describe('FirebaseCloudMessagingApiService', () => {
   let pushNotificationsProject: string;
   let pushNotificationsServiceAccountClientEmail: string;
   let pushNotificationsServiceAccountPrivateKey: string;
+  let oauth2TokenTtlBufferInSeconds: number;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -34,6 +35,7 @@ describe('FirebaseCloudMessagingApiService', () => {
     pushNotificationsProject = faker.word.noun();
     pushNotificationsServiceAccountClientEmail = faker.internet.email();
     pushNotificationsServiceAccountPrivateKey = faker.string.alphanumeric();
+    oauth2TokenTtlBufferInSeconds = faker.number.int({ min: 30, max: 100 });
 
     const fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set(
@@ -51,6 +53,10 @@ describe('FirebaseCloudMessagingApiService', () => {
     fakeConfigurationService.set(
       'pushNotifications.serviceAccount.privateKey',
       pushNotificationsServiceAccountPrivateKey,
+    );
+    fakeConfigurationService.set(
+      'pushNotifications.oauth2TokenTtlBufferInSeconds',
+      oauth2TokenTtlBufferInSeconds,
     );
 
     fakeCacheService = new FakeCacheService();

--- a/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
+++ b/src/datasources/push-notifications-api/firebase-cloud-messaging-api.service.ts
@@ -28,7 +28,6 @@ import { getFirstAvailable } from '@/domain/common/utils/array';
 export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
   private static readonly OAuth2TokenUrl =
     'https://oauth2.googleapis.com/token';
-  private static readonly OAuth2TokenTtlBufferInSeconds = 5;
   private static readonly Scope =
     'https://www.googleapis.com/auth/firebase.messaging';
 
@@ -40,6 +39,8 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
     'data.error_description',
     'data.error.message',
   ];
+
+  private static OAuth2TokenTtlBufferInSeconds: number;
 
   private readonly baseUrl: string;
   private readonly project: string;
@@ -69,6 +70,10 @@ export class FirebaseCloudMessagingApiService implements IPushNotificationsApi {
     this.privateKey = this.configurationService.getOrThrow<string>(
       'pushNotifications.serviceAccount.privateKey',
     );
+    FirebaseCloudMessagingApiService.OAuth2TokenTtlBufferInSeconds =
+      this.configurationService.getOrThrow<number>(
+        'pushNotifications.oauth2TokenTtlBufferInSeconds',
+      );
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR introduces a new configuration option for `oauth2TokenTtlBufferInSeconds`, allowing for dynamic adjustment of the `OAuth2` token TTL buffer based on environment variables.

## Changes
- Added support for the `oauth2TokenTtlBufferInSeconds` configuration option.
- Adjusted unit tests.
- Included validation to ensure the buffer value is a positive integer within a valid range.
