### PR TITLE
feat(cache): add optional `expireDeviatePercent` parameter to cache service interface

### DIFF
--- a/src/datasources/cache/cache.service.interface.ts
+++ b/src/datasources/cache/cache.service.interface.ts
@@ -9,6 +9,7 @@ export interface ICacheService {
     cacheDir: CacheDir,
     value: string,
     expireTimeSeconds: number | undefined,
+    expireDeviatePercent?: number,
   ): Promise<void>;
 
   hGet(cacheDir: CacheDir): Promise<string | undefined>;
@@ -18,11 +19,13 @@ export interface ICacheService {
   increment(
     cacheKey: string,
     expireTimeSeconds: number | undefined,
+    expireDeviatePercent?: number,
   ): Promise<number>;
 
   setCounter(
     key: string,
     value: number,
     expireTimeSeconds: number | undefined,
+    expireDeviatePercent?: number,
   ): Promise<void>;
 }


### PR DESCRIPTION
## Summary
This PR adds `expireDeviatePercent` to the interface implemented by the cache service.

## Changes
- Added `expireDeviatePercent` to the `ICacheService` interface. 