### PR TITLE
fix: Invert positions feature flag to be enabled by default

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,8 +35,8 @@
 # The API Key to be used. If none is set, balances cannot be retrieved using this provider.
 # ZERION_API_KEY=
 
-# Zerion Positions feature
-# FF_ZERION_POSITIONS=
+# Disables Zerion Positions feature
+# FF_ZERION_POSITIONS_DISABLED=
 
 # Push Notifications Provider - Firebase Cloud Messaging
 # Firebase API URL

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -278,7 +278,8 @@ export default () => ({
     email: process.env.FF_EMAIL?.toLowerCase() === 'true',
     zerionBalancesChainIds:
       process.env.FF_ZERION_BALANCES_CHAIN_IDS?.split(',') ?? [],
-    zerionPositions: process.env.FF_ZERION_POSITIONS?.toLowerCase() === 'true',
+    zerionPositions:
+      process.env.FF_ZERION_POSITIONS_DISABLED?.toLowerCase() !== 'true',
     debugLogs: process.env.FF_DEBUG_LOGS?.toLowerCase() === 'true',
     configHooksDebugLogs:
       process.env.FF_CONFIG_HOOKS_DEBUG_LOGS?.toLowerCase() === 'true',


### PR DESCRIPTION
## Summary

Changes `FF_ZERION_POSITIONS` to `FF_ZERION_POSITIONS_DISABLED` and inverts the logic so the feature is turned on by default and can be turned off via env variable
