### PR TITLE
Fix tests for multisig transaction notes

### DIFF
--- a/src/domain/common/utils/utils.ts
+++ b/src/domain/common/utils/utils.ts
@@ -2,9 +2,11 @@ import { createHash } from 'crypto';
 import type { BinaryLike } from 'crypto';
 import type { Address } from 'viem';
 
-// We use the maximum value in order to preserve all decimals
+// Node.js v20 restricts `maximumFractionDigits` to a maximum of 20.
+// Use the highest supported value to preserve decimals while avoiding
+// a runtime `RangeError`.
 // @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-const MAX_MAXIMUM_FRACTION_DIGITS = 100;
+const MAX_MAXIMUM_FRACTION_DIGITS = 20;
 
 const formatter = new Intl.NumberFormat('en-US', {
   // Prevent scientific notation

--- a/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
+++ b/src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts
@@ -349,7 +349,7 @@ describe('List multisig transactions by Safe - Transactions Controller (Unit)', 
       .build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/multisig-transactions/`;
+      const getMultisigTransactionsUrl = `${chain.transactionService}/api/v2/safes/${safe.address}/multisig-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${token.address}`;
       if (url === getChainUrl) {

--- a/src/routes/transactions/transactions-history.controller.spec.ts
+++ b/src/routes/transactions/transactions-history.controller.spec.ts
@@ -782,7 +782,7 @@ describe('Transactions History Controller (Unit)', () => {
       .build();
     networkService.get.mockImplementation(({ url }) => {
       const getChainUrl = `${safeConfigUrl}/api/v1/chains/${chain.chainId}`;
-      const getAllTransactionsUrl = `${chain.transactionService}/api/v1/safes/${safe.address}/all-transactions/`;
+      const getAllTransactionsUrl = `${chain.transactionService}/api/v2/safes/${safe.address}/all-transactions/`;
       const getSafeUrl = `${chain.transactionService}/api/v1/safes/${safe.address}`;
       const getTokenUrl = `${chain.transactionService}/api/v1/tokens/${multisigTransaction.to}`;
       if (url === getChainUrl) {


### PR DESCRIPTION
## Summary
- avoid Intl.NumberFormat RangeError on Node 20 by lowering maximum fraction digits
- update transaction tests to use Safe Transaction Service v2 endpoints

## Testing
- `npm test -- src/routes/transactions/transactions-history.controller.spec.ts src/routes/transactions/__tests__/controllers/list-multisig-transactions-by-safe.transactions.controller.spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_68c2d3d2ea80832f95d55b41310864c7