### PR TITLE
chore: allow_cors through config service

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -38,8 +38,10 @@ export default (): ReturnType<typeof configuration> => ({
   },
   application: {
     isProduction: faker.datatype.boolean(),
+    isDevelopment: faker.datatype.boolean(),
     runMigrations: true,
     port: faker.internet.port().toString(),
+    allowCors: faker.datatype.boolean(),
   },
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -66,10 +66,12 @@ export default () => ({
   },
   application: {
     isProduction: process.env.CGW_ENV === 'production',
+    isDevelopment: process.env.CGW_ENV === 'development',
     // Enables/disables the execution of migrations on startup.
     // Defaults to true.
     runMigrations: process.env.RUN_MIGRATIONS?.toLowerCase() !== 'false',
     port: process.env.APPLICATION_PORT || '3000',
+    allowCors: process.env.ALLOW_CORS?.toLowerCase() === 'true',
   },
   auth: {
     token: process.env.AUTH_TOKEN,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ async function bootstrap(): Promise<void> {
     configurationService.getOrThrow('application.port');
 
   if (
-    process.env.ALLOW_CORS === 'TRUE' &&
-    process.env.CGW_ENV === 'development'
+    configurationService.getOrThrow('application.allowCors') &&
+    configurationService.getOrThrow('application.isDevelopment')
   ) {
     app.enableCors();
   }


### PR DESCRIPTION
## Summary

Introduce a new configuration variable to `allow_cors` for running the service in local environment.

## Changes

If the environment is `development` and `allow_cors` is set, enable CORS
