### PR TITLE
fix: improve swagger types

### DIFF
--- a/src/routes/chains/entities/gas-price-fixed-eip-1559.entity.ts
+++ b/src/routes/chains/entities/gas-price-fixed-eip-1559.entity.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { GasPriceFixedEIP1559 as DomainGasPriceFixedEIP1559 } from '@/domain/chains/entities/gas-price-fixed-eip-1559.entity';
 
 export class GasPriceFixedEIP1559 implements DomainGasPriceFixedEIP1559 {
-  @ApiProperty()
+  @ApiProperty({ enum: ['fixed1559'] })
   type!: 'fixed1559';
   @ApiProperty()
   maxFeePerGas!: string;

--- a/src/routes/chains/entities/gas-price-fixed.entity.ts
+++ b/src/routes/chains/entities/gas-price-fixed.entity.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { GasPriceFixed as DomainGasPriceFixed } from '@/domain/chains/entities/gas-price-fixed.entity';
 
 export class GasPriceFixed implements DomainGasPriceFixed {
-  @ApiProperty()
+  @ApiProperty({ enum: ['fixed'] })
   type!: 'fixed';
   @ApiProperty()
   weiValue!: string;

--- a/src/routes/chains/entities/gas-price-oracle.entity.ts
+++ b/src/routes/chains/entities/gas-price-oracle.entity.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { GasPriceOracle as DomainGasPriceOracle } from '@/domain/chains/entities/gas-price-oracle.entity';
 
 export class GasPriceOracle implements DomainGasPriceOracle {
-  @ApiProperty()
+  @ApiProperty({ enum: ['oracle'] })
   type!: 'oracle';
   @ApiProperty()
   gasParameter!: string;


### PR DESCRIPTION
## Summary
The auto generated types in the store package in the monorepo were defined like:
```ts
export type GasPriceOracle = {
  type: string
  gasParameter: string
  gweiFactor: string
  uri: string
}
export type GasPriceFixed = {
  type: string
  weiValue: string
}
export type GasPriceFixedEip1559 = {
  type: string
  maxFeePerGas: string
  maxPriorityFeePerGas: string
}
```

obviously in the CGW codebase it was a literal type: 'oracle', 'fixed', 'eip...'. 

## Changes
Swagger needed more love and guidance
