### PR TITLE
fix: swagger NotificationType was empty object

### DIFF
--- a/src/domain/notifications/v2/notifications.repository.interface.ts
+++ b/src/domain/notifications/v2/notifications.repository.interface.ts
@@ -2,7 +2,7 @@ import type { UpsertSubscriptionsDto } from '@/domain/notifications/v2/entities/
 import type { FirebaseNotification } from '@/datasources/push-notifications-api/entities/firebase-notification.entity';
 import type { UUID } from 'crypto';
 import type { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
-import type { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
+import type { NotificationTypeResponseDto } from '@/routes/notifications/v2/entities/notification-type-response.dto.entity';
 import type { Address } from 'viem';
 
 export const INotificationsRepositoryV2 = Symbol('INotificationsRepositoryV2');
@@ -26,7 +26,7 @@ export interface INotificationsRepositoryV2 {
     deviceUuid: UUID;
     chainId: string;
     safeAddress: Address;
-  }): Promise<Array<NotificationType>>;
+  }): Promise<Array<NotificationTypeResponseDto>>;
 
   getSubscribersBySafe(args: {
     chainId: string;

--- a/src/domain/notifications/v2/notifications.repository.ts
+++ b/src/domain/notifications/v2/notifications.repository.ts
@@ -16,6 +16,7 @@ import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { NotificationSubscription } from '@/datasources/notifications/entities/notification-subscription.entity.db';
 import { NotificationDevice } from '@/datasources/notifications/entities/notification-devices.entity.db';
 import { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
+import { NotificationTypeResponseDto } from '@/routes/notifications/v2/entities/notification-type-response.dto.entity';
 import { EntityManager, In, IsNull } from 'typeorm';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { NotificationSubscriptionNotificationType } from '@/datasources/notifications/entities/notification-subscription-notification-type.entity.db';
@@ -316,7 +317,7 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
     deviceUuid: UUID;
     chainId: string;
     safeAddress: Address;
-  }): Promise<Array<NotificationType>> {
+  }): Promise<Array<NotificationTypeResponseDto>> {
     if (!args.authPayload.signer_address) {
       throw new UnauthorizedException();
     }

--- a/src/routes/notifications/v2/entities/notification-type-response.dto.entity.ts
+++ b/src/routes/notifications/v2/entities/notification-type-response.dto.entity.ts
@@ -1,0 +1,19 @@
+import { NotificationType as NotificationTypeEnum } from '@/domain/notifications/v2/entities/notification.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { z } from 'zod';
+
+export const NotificationTypeResponseSchema = z.object({
+  name: z.nativeEnum(NotificationTypeEnum),
+});
+
+export class NotificationTypeResponseDto
+  implements z.infer<typeof NotificationTypeResponseSchema>
+{
+  @ApiProperty({
+    type: NotificationTypeEnum,
+    enum: NotificationTypeEnum,
+    enumName: 'NotificationTypeEnum',
+    description: 'The notification type name',
+  })
+  name!: NotificationTypeEnum;
+}

--- a/src/routes/notifications/v2/notifications.controller.ts
+++ b/src/routes/notifications/v2/notifications.controller.ts
@@ -32,7 +32,7 @@ import {
 } from '@nestjs/swagger';
 import { UUID } from 'crypto';
 import { OptionalAuthGuard } from '@/routes/auth/guards/optional-auth.guard';
-import { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
+import { NotificationTypeResponseDto } from '@/routes/notifications/v2/entities/notification-type-response.dto.entity';
 import { DeleteAllSubscriptionsDtoSchema } from '@/domain/notifications/v2/entities/delete-all-subscriptions.dto.entity';
 import { DeleteAllSubscriptionsDto } from '@/routes/notifications/v2/entities/delete-all-subscriptions.dto.entity';
 import type { Address } from 'viem';
@@ -104,7 +104,7 @@ export class NotificationsControllerV2 {
     description: 'Safe contract address (0x prefixed hex string)',
   })
   @ApiOkResponse({
-    type: [NotificationType],
+    type: [NotificationTypeResponseDto],
     description:
       'List of notification types the device is subscribed to for this Safe',
   })
@@ -122,7 +122,7 @@ export class NotificationsControllerV2 {
     @Param('safeAddress', new ValidationPipe(AddressSchema))
     safeAddress: Address,
     @Auth() authPayload: AuthPayload,
-  ): Promise<Array<NotificationType>> {
+  ): Promise<Array<NotificationTypeResponseDto>> {
     return this.notificationsService.getSafeSubscription({
       authPayload,
       deviceUuid,

--- a/src/routes/notifications/v2/notifications.service.ts
+++ b/src/routes/notifications/v2/notifications.service.ts
@@ -2,7 +2,7 @@ import { AuthPayload } from '@/domain/auth/entities/auth-payload.entity';
 import { UpsertSubscriptionsDto } from '@/domain/notifications/v2/entities/upsert-subscriptions.dto.entity';
 import { Inject, Injectable } from '@nestjs/common';
 import { UUID } from 'crypto';
-import { NotificationType } from '@/datasources/notifications/entities/notification-type.entity.db';
+import { NotificationTypeResponseDto } from '@/routes/notifications/v2/entities/notification-type-response.dto.entity';
 import { INotificationsRepositoryV2 } from '@/domain/notifications/v2/notifications.repository.interface';
 import type { Address } from 'viem';
 
@@ -27,7 +27,7 @@ export class NotificationsServiceV2 {
     deviceUuid: UUID;
     chainId: string;
     safeAddress: Address;
-  }): Promise<Array<NotificationType>> {
+  }): Promise<Array<NotificationTypeResponseDto>> {
     return await this.notificationsRepository.getSafeSubscription(args);
   }
 


### PR DESCRIPTION
## Summary
The NotificationType in swagger was an empty object as we didn't export any API property on the TypeOrm object

## Changes
The return type for getSafeSubscription was wrong. It was implying that we are returning the whole NotificationType, where in reality we were just retuning the name prop. 