### PR TITLE
refactor(Safe Shield): rename `KNOWN_RECIPIENT` to `RECURRING_RECIPIENT`

### DIFF
--- a/src/modules/safe-shield/entities/__tests__/builders/analysis-result.builder.ts
+++ b/src/modules/safe-shield/entities/__tests__/builders/analysis-result.builder.ts
@@ -12,8 +12,8 @@ import {
  */
 export function recipientAnalysisResultBuilder(): IBuilder<RecipientAnalysisResult> {
   return new Builder<RecipientAnalysisResult>()
-    .with('severity', 'INFO')
-    .with('type', 'KNOWN_RECIPIENT')
+    .with('severity', 'OK')
+    .with('type', 'RECURRING_RECIPIENT')
     .with('title', faker.lorem.sentence())
     .with('description', faker.lorem.paragraph());
 }

--- a/src/modules/safe-shield/entities/__tests__/status-entities.spec.ts
+++ b/src/modules/safe-shield/entities/__tests__/status-entities.spec.ts
@@ -14,7 +14,7 @@ describe('Status Entities', () => {
     it('should have all expected values', () => {
       expect(RecipientStatus).toHaveLength(2);
       expect(RecipientStatus).toContain('NEW_RECIPIENT');
-      expect(RecipientStatus).toContain('KNOWN_RECIPIENT');
+      expect(RecipientStatus).toContain('RECURRING_RECIPIENT');
     });
 
     it.each(RecipientStatus)('should validate with schema = %s', (value) => {

--- a/src/modules/safe-shield/entities/recipient-status.entity.ts
+++ b/src/modules/safe-shield/entities/recipient-status.entity.ts
@@ -11,7 +11,7 @@ export const RecipientStatus = [
   'NEW_RECIPIENT',
 
   /** This recipient has been interacted with before */
-  'KNOWN_RECIPIENT',
+  'RECURRING_RECIPIENT',
 ] as const;
 
 /**

--- a/src/modules/safe-shield/recipient-analysis/__tests__/recipient-analysis.service.spec.ts
+++ b/src/modules/safe-shield/recipient-analysis/__tests__/recipient-analysis.service.spec.ts
@@ -249,10 +249,10 @@ describe('RecipientAnalysisService', () => {
       expect(Object.keys(result)).toContain(recipient1);
       expect(Object.keys(result)).toContain(recipient2);
 
-      // Check that one recipient is KNOWN_RECIPIENT (5 interactions) and the other is NEW_RECIPIENT (0 interactions)
+      // Check that one recipient is RECURRING_RECIPIENT (5 interactions) and the other is NEW_RECIPIENT (0 interactions)
       const results = Object.values(result);
       const knownRecipientResult = results.find(
-        (r) => r?.RECIPIENT_INTERACTION?.[0]?.type === 'KNOWN_RECIPIENT',
+        (r) => r?.RECIPIENT_INTERACTION?.[0]?.type === 'RECURRING_RECIPIENT',
       );
       const newRecipientResult = results.find(
         (r) => r?.RECIPIENT_INTERACTION?.[0]?.type === 'NEW_RECIPIENT',
@@ -262,7 +262,7 @@ describe('RecipientAnalysisService', () => {
         RECIPIENT_INTERACTION: [
           {
             severity: 'OK',
-            type: 'KNOWN_RECIPIENT',
+            type: 'RECURRING_RECIPIENT',
             title: 'Recurring recipient',
             description: 'You have interacted with this address 5 times.',
           },
@@ -628,7 +628,7 @@ describe('RecipientAnalysisService', () => {
   });
 
   describe('analyzeInteractions', () => {
-    it('should return KNOWN_RECIPIENT when interactions > 0', async () => {
+    it('should return RECURRING_RECIPIENT when interactions > 0', async () => {
       const interactionCount = faker.number.int({ min: 2, max: 10 });
       (mockTransactionApi.getTransfers as jest.Mock).mockResolvedValue(
         mockTransferPage(interactionCount),
@@ -642,7 +642,7 @@ describe('RecipientAnalysisService', () => {
 
       expect(result).toEqual({
         severity: 'OK',
-        type: 'KNOWN_RECIPIENT',
+        type: 'RECURRING_RECIPIENT',
         title: 'Recurring recipient',
         description: `You have interacted with this address ${interactionCount} times.`,
       });
@@ -742,7 +742,7 @@ describe('RecipientAnalysisService', () => {
 
       expect(result).toEqual({
         severity: 'OK',
-        type: 'KNOWN_RECIPIENT',
+        type: 'RECURRING_RECIPIENT',
         title: 'Recurring recipient',
         description: `You have interacted with this address ${largeInteractionCount} times.`,
       });
@@ -1247,7 +1247,7 @@ describe('RecipientAnalysisService', () => {
       // Should return recipient analysis result
       expect(Object.keys(result)).toContain(differentRecipient);
       expect(result[differentRecipient]?.RECIPIENT_INTERACTION?.[0]?.type).toBe(
-        'KNOWN_RECIPIENT',
+        'RECURRING_RECIPIENT',
       );
     });
 

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.constants.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.constants.ts
@@ -11,7 +11,7 @@ export const SEVERITY_MAPPING: Record<
   keyof typeof Severity
 > = {
   NEW_RECIPIENT: 'INFO',
-  KNOWN_RECIPIENT: 'OK',
+  RECURRING_RECIPIENT: 'OK',
   INCOMPATIBLE_SAFE: 'CRITICAL',
   MISSING_OWNERSHIP: 'WARN',
   UNSUPPORTED_NETWORK: 'WARN',
@@ -24,7 +24,7 @@ export const SEVERITY_MAPPING: Record<
  */
 export const TITLE_MAPPING: Record<RecipientStatus | BridgeStatus, string> = {
   NEW_RECIPIENT: 'New recipient',
-  KNOWN_RECIPIENT: 'Recurring recipient',
+  RECURRING_RECIPIENT: 'Recurring recipient',
   INCOMPATIBLE_SAFE: 'Incompatible Safe version',
   MISSING_OWNERSHIP: 'Missing ownership',
   UNSUPPORTED_NETWORK: 'Unsupported network',
@@ -42,7 +42,7 @@ export const DESCRIPTION_MAPPING: Record<
   Record<BridgeStatus, () => string> = {
   NEW_RECIPIENT: () =>
     'You are interacting with this address for the first time.',
-  KNOWN_RECIPIENT: (interactions: number) =>
+  RECURRING_RECIPIENT: (interactions: number) =>
     `You have interacted with this address ${interactions} time${interactions > 1 ? 's' : ''}.`,
   INCOMPATIBLE_SAFE: () =>
     'This Safe account cannot be created on the destination chain. You will not be able to claim ownership of the same address. Funds sent may be inaccessible.',

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
@@ -192,7 +192,7 @@ export class RecipientAnalysisService {
 
     const transferPage = TransferPageSchema.parse(page);
     const interactions = transferPage.count ?? 0;
-    const type = interactions > 0 ? 'KNOWN_RECIPIENT' : 'NEW_RECIPIENT';
+    const type = interactions > 0 ? 'RECURRING_RECIPIENT' : 'NEW_RECIPIENT';
 
     return this.mapToAnalysisResult(type, interactions);
   }


### PR DESCRIPTION
This updates the terminology used for recipient status to improve clarity. 

```
KNOWN_RECIPIENT -> RECURRING_RECIPIENT
```

The term has been renamed to:
- avoid conflicting naming with the client-side address book check where `KNOWN_RECIPIENT` is used for a recipient address being in the address book
- align the status name with its corresponding user-facing wording

No functional changes were introduced; this is purely a terminology update.