### PR TITLE
fix: add Swagger type definitions for recipient analysis

### DIFF
--- a/src/modules/safe-shield/entities/dtos/recipient-analysis.dto.ts
+++ b/src/modules/safe-shield/entities/dtos/recipient-analysis.dto.ts
@@ -1,0 +1,141 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { getStringEnumKeys } from '@/domain/common/utils/enum';
+import { Severity } from '../severity.entity';
+import type {
+  AnalysisResult,
+  AnalysisStatus,
+  RecipientAnalysisResult,
+} from '../analysis-result.entity';
+import type { GroupedAnalysisResults } from '../analysis-responses.entity';
+import { RecipientStatus } from '@/modules/safe-shield/entities/recipient-status.entity';
+import { BridgeStatus } from '@/modules/safe-shield/entities/bridge-status.entity';
+
+/**
+ * Generic DTO for a single analysis result.
+ *
+ * @template T - The specific status type (extends AnalysisStatus)
+ */
+export class AnalysisResultDto<T extends AnalysisStatus>
+  implements AnalysisResult<T>
+{
+  @ApiProperty({
+    description: 'Severity level indicating the importance and risk',
+    enum: getStringEnumKeys(Severity),
+    example: 'INFO',
+  })
+  severity!: keyof typeof Severity;
+
+  @ApiProperty({
+    description: 'Specific status code identifying the type of finding',
+    example: 'NEW_RECIPIENT',
+  })
+  type!: T;
+
+  @ApiProperty({
+    description: 'User-facing title of the finding',
+    example: 'New recipient',
+  })
+  title!: string;
+
+  @ApiProperty({
+    description:
+      'Detailed description explaining the finding and its implications',
+    example: 'This is the first time you are interacting with this recipient',
+  })
+  description!: string;
+}
+
+/**
+ * DTO for recipient interaction analysis result.
+ */
+export class RecipientInteractionResultDto extends AnalysisResultDto<RecipientStatus> {
+  @ApiProperty({
+    description: 'Recipient interaction status code',
+    enum: RecipientStatus,
+    example: 'NEW_RECIPIENT',
+  })
+  type!: RecipientStatus;
+}
+
+/**
+ * DTO for bridge analysis result.
+ */
+export class BridgeResultDto extends AnalysisResultDto<BridgeStatus> {
+  @ApiProperty({
+    description: 'Bridge compatibility status code',
+    enum: BridgeStatus,
+    example: 'MISSING_OWNERSHIP',
+  })
+  type!: BridgeStatus;
+}
+
+/**
+ * DTO for single recipient analysis response.
+ *
+ * This DTO is used by the analyzeRecipient endpoint which only returns
+ * recipient interaction status (not bridge analysis).
+ */
+export class RecipientInteractionAnalysisDto {
+  @ApiProperty({
+    description:
+      'Analysis results related to recipient interaction history. ' +
+      'Shows whether this is a new or recurring recipient.',
+    type: [RecipientInteractionResultDto],
+    example: [
+      {
+        severity: 'INFO',
+        type: 'NEW_RECIPIENT',
+        title: 'New recipient',
+        description:
+          'This is the first time you are interacting with this recipient',
+      },
+    ],
+  })
+  RECIPIENT_INTERACTION!: Array<RecipientInteractionResultDto>;
+}
+
+/**
+ * DTO for full recipient analysis response.
+ *
+ * This DTO mirrors GroupedAnalysisResults<RecipientAnalysisResult> for Swagger documentation.
+ * Results are grouped by status group and sorted by severity (CRITICAL first).
+ * Used by endpoints that return both recipient interaction and bridge analysis.
+ */
+export class RecipientAnalysisDto
+  implements GroupedAnalysisResults<RecipientAnalysisResult>
+{
+  @ApiProperty({
+    description:
+      'Analysis results related to recipient interaction history. ' +
+      'Shows whether this is a new or recurring recipient.',
+    type: [RecipientInteractionResultDto],
+    required: false,
+    example: [
+      {
+        severity: 'INFO',
+        type: 'NEW_RECIPIENT',
+        title: 'New recipient',
+        description:
+          'This is the first time you are interacting with this recipient',
+      },
+    ],
+  })
+  RECIPIENT_INTERACTION?: Array<RecipientInteractionResultDto>;
+
+  @ApiProperty({
+    description:
+      'Analysis results for cross-chain bridge operations. ' +
+      'Identifies compatibility issues, ownership problems, or unsupported networks.',
+    type: [BridgeResultDto],
+    required: false,
+    example: [
+      {
+        severity: 'WARN',
+        type: 'MISSING_OWNERSHIP',
+        title: 'No ownership on target chain',
+        description: 'You do not have ownership of a Safe on the target chain',
+      },
+    ],
+  })
+  BRIDGE?: Array<BridgeResultDto>;
+}

--- a/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
+++ b/src/modules/safe-shield/recipient-analysis/recipient-analysis.service.ts
@@ -1,9 +1,6 @@
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { TransferPageSchema } from '@/domain/safe/entities/transfer.entity';
-import type {
-  AnalysisResult,
-  RecipientAnalysisResult,
-} from '@/modules/safe-shield/entities/analysis-result.entity';
+import type { AnalysisResult } from '@/modules/safe-shield/entities/analysis-result.entity';
 import { Inject, Injectable } from '@nestjs/common';
 import { getAddress, Hex, zeroAddress, type Address } from 'viem';
 import { IChainsRepository } from '@/domain/chains/chains.repository.interface';
@@ -179,7 +176,7 @@ export class RecipientAnalysisService {
     chainId: string;
     safeAddress: Address;
     recipient: Address;
-  }): Promise<RecipientAnalysisResult> {
+  }): Promise<AnalysisResult<RecipientStatus>> {
     const transactionApi = await this.transactionApiManager.getApi(
       args.chainId,
     );

--- a/src/modules/safe-shield/safe-shield.controller.ts
+++ b/src/modules/safe-shield/safe-shield.controller.ts
@@ -9,8 +9,7 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import type { Address } from 'viem';
 import { SafeShieldService } from './safe-shield.service';
-import type { GroupedAnalysisResults } from './entities/analysis-responses.entity';
-import type { RecipientAnalysisResult } from './entities/analysis-result.entity';
+import { RecipientInteractionAnalysisDto } from './entities/dtos/recipient-analysis.dto';
 
 /**
  * Controller for Safe Shield security analysis endpoints.
@@ -49,7 +48,8 @@ export class SafeShieldController {
     description: 'Recipient address to analyze',
   })
   @ApiOkResponse({
-    description: 'Recipient analysis results grouped by status group',
+    description: 'Recipient interaction analysis results',
+    type: RecipientInteractionAnalysisDto,
   })
   @HttpCode(HttpStatus.OK)
   @Get('chains/:chainId/security/:safeAddress/recipient/:recipientAddress')
@@ -59,7 +59,7 @@ export class SafeShieldController {
     safeAddress: Address,
     @Param('recipientAddress', new ValidationPipe(AddressSchema))
     recipientAddress: Address,
-  ): Promise<GroupedAnalysisResults<RecipientAnalysisResult>> {
+  ): Promise<RecipientInteractionAnalysisDto> {
     return await this.safeShieldService.analyzeRecipient({
       chainId,
       safeAddress,

--- a/src/modules/safe-shield/safe-shield.service.spec.ts
+++ b/src/modules/safe-shield/safe-shield.service.spec.ts
@@ -23,6 +23,8 @@ import { dataDecodedBuilder } from '@/domain/data-decoder/v2/entities/__tests__/
 import { recipientAnalysisResultBuilder } from '@/modules/safe-shield/entities/__tests__/builders/analysis-result.builder';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import * as utils from './utils/transaction-mapping.utils';
+import type { AnalysisResult } from '@/modules/safe-shield/entities/analysis-result.entity';
+import type { RecipientStatus } from '@/modules/safe-shield/entities/recipient-status.entity';
 
 // Utility function for generating Wei values
 const generateRandomWeiAmount = (): bigint =>
@@ -513,7 +515,8 @@ describe('SafeShieldService', () => {
 
   describe('analyzeRecipient', () => {
     it('should analyze a single recipient address', async () => {
-      const mockInteractionResult = recipientAnalysisResultBuilder().build();
+      const mockInteractionResult =
+        recipientAnalysisResultBuilder().build() as AnalysisResult<RecipientStatus>;
 
       mockRecipientAnalysisService.analyzeInteractions.mockResolvedValue(
         mockInteractionResult,

--- a/src/modules/safe-shield/safe-shield.service.ts
+++ b/src/modules/safe-shield/safe-shield.service.ts
@@ -6,7 +6,6 @@ import { type Address, type Hex } from 'viem';
 import type {
   ContractAnalysisResponse,
   RecipientAnalysisResponse,
-  GroupedAnalysisResults,
 } from './entities/analysis-responses.entity';
 import type { DecodedTransactionData } from '@/modules/safe-shield/entities/transaction-data.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
@@ -14,7 +13,7 @@ import { mapDecodedTransactions } from './utils/transaction-mapping.utils';
 import { TransactionsService } from '@/routes/transactions/transactions.service';
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import type { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
-import type { RecipientAnalysisResult } from './entities/analysis-result.entity';
+import { RecipientInteractionAnalysisDto } from './entities/dtos/recipient-analysis.dto';
 
 /**
  * Main orchestration service for Safe Shield transaction analysis.
@@ -96,7 +95,7 @@ export class SafeShieldService {
     chainId: string;
     safeAddress: Address;
     recipientAddress: Address;
-  }): Promise<GroupedAnalysisResults<RecipientAnalysisResult>> {
+  }): Promise<RecipientInteractionAnalysisDto> {
     const interactionResult =
       await this.recipientAnalysisService.analyzeInteractions({
         chainId,


### PR DESCRIPTION
## Summary

addition to [COR-568](https://linear.app/safe-global/issue/COR-568/live-recipient-analysis-endpoint)

Adds the proper Swagger type definitions for recipient analysis endpoint

