### PR TITLE
feat: send typed data to threat analysis

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
 import type { Address, Hash } from 'viem';
-import type { ThreatAnalysisRequestBody } from '@/modules/safe-shield/entities/analysis-requests.entity';
 
 export class CacheRouter {
   private static readonly ACCOUNT_DATA_SETTINGS_KEY = 'account_data_settings';
@@ -915,18 +914,24 @@ export class CacheRouter {
    * Gets cache directory for threat analysis results.
    *
    * @param {string} args.chainId - Chain ID
-   * @param {ThreatAnalysisRequestBody} args.requestData - Request data to be hashed
+   * @param {string} args.safeAddress - Safe address
+   * @param {string} args.walletAddress - Signer address
+   * @param {string} args.message - JSON representation of typed data
+   * @param {string} args.origin - Request origin (optional)
    * @returns {CacheDir} - Cache directory
    */
   static getThreatAnalysisCacheDir(args: {
     chainId: string;
-    requestData: ThreatAnalysisRequestBody;
+    safeAddress: Address;
+    walletAddress: Address;
+    message: string;
+    origin?: string;
   }): CacheDir {
     const requestHash = crypto.createHash('sha256');
-    requestHash.update(JSON.stringify(args.requestData));
+    requestHash.update(args.message);
     return new CacheDir(
-      `${args.chainId}_${CacheRouter.THREAT_ANALYSIS_KEY}`,
-      requestHash.digest('hex'),
+      `${args.chainId}_${CacheRouter.THREAT_ANALYSIS_KEY}_${args.safeAddress}`,
+      `${args.walletAddress}_${requestHash.digest('hex')}_${args.origin}`,
     );
   }
 }

--- a/src/modules/safe-shield/entities/__tests__/builders/analysis-requests.builder.ts
+++ b/src/modules/safe-shield/entities/__tests__/builders/analysis-requests.builder.ts
@@ -4,9 +4,10 @@ import { Builder } from '@/__tests__/builder';
 import type {
   RecipientAnalysisRequestBody,
   ContractAnalysisRequestBody,
-  ThreatAnalysisRequestBody,
+  ThreatAnalysisRequest,
 } from '../../analysis-requests.entity';
 import { type Hex, getAddress } from 'viem';
+import { typedDataBuilder } from '@/routes/messages/entities/__tests__/typed-data.builder';
 
 /**
  * Builder for RecipientAnalysisRequestBody
@@ -28,20 +29,19 @@ export function contractAnalysisRequestBodyBuilder(): IBuilder<ContractAnalysisR
 }
 
 /**
- * Builder for ThreatAnalysisRequestBody
+ * Builder for ThreatAnalysisRequest
  */
-export function threatAnalysisRequestBodyBuilder(): IBuilder<ThreatAnalysisRequestBody> {
-  return new Builder<ThreatAnalysisRequestBody>()
-    .with('to', getAddress(faker.finance.ethereumAddress()))
-    .with('value', faker.string.numeric())
-    .with('data', faker.string.hexadecimal({ length: 128 }) as Hex)
-    .with('operation', faker.helpers.arrayElement([0, 1]))
-    .with('safeTxGas', faker.string.numeric())
-    .with('baseGas', faker.string.numeric())
-    .with('gasPrice', faker.string.numeric())
-    .with('gasToken', getAddress(faker.finance.ethereumAddress()))
-    .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
-    .with('nonce', faker.string.numeric())
+export function threatAnalysisRequestBuilder(): IBuilder<ThreatAnalysisRequest> {
+  return new Builder<ThreatAnalysisRequest>()
+    .with(
+      'data',
+      typedDataBuilder()
+        .with('message', {
+          [faker.lorem.word()]: faker.number.int(),
+          [faker.lorem.word()]: getAddress(faker.finance.ethereumAddress()),
+        })
+        .build(),
+    )
     .with('walletAddress', getAddress(faker.finance.ethereumAddress()))
     .with('origin', faker.internet.url());
 }

--- a/src/modules/safe-shield/entities/analysis-requests.entity.ts
+++ b/src/modules/safe-shield/entities/analysis-requests.entity.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { TypedDataSchema } from '@/domain/messages/entities/typed-data.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
-import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
 /**
  * Request body schema for recipient analysis endpoint.
@@ -42,52 +42,21 @@ export const ContractAnalysisRequestBodySchema = z.object({
 });
 
 /**
- * Request body schema for threat analysis endpoint.
+ * Request body schema for EIP-712 typed data threat analysis endpoint.
  *
- * Contains complete Safe transaction parameters for comprehensive
- * threat analysis including malicious pattern detection and
- * Safe-specific security risks.
+ *
+ * Contains complete Safe transaction parameters or a message to be signed
+ * as EIP-712 structured data for comprehensive threat analysis,
+ * including signature farming, phishing attempts, and malicious
+ * structured data patterns.
  */
-export const ThreatAnalysisRequestBodySchema = z.object({
-  /** Target address for the transaction */
-  to: AddressSchema,
-
+export const ThreatAnalysisRequestSchema = z.object({
   /**
-   * Amount of ETH (in wei) being sent with the transaction.
-   * Represented as a string to handle large numbers without precision loss.
-   * Example: "1000000000000000000" for 1 ETH
+   * EIP-712 typed data to analyze for security threats.
+   * Contains domain, primaryType, types, and message fields
+   * following the EIP-712 standard for structured data signing.
    */
-  value: NumericStringSchema,
-
-  /**
-   * Transaction data payload as a hex string.
-   * @see RecipientAnalysisRequestBodySchema.data
-   */
-  data: HexSchema,
-
-  /**
-   * Type of operation being performed.
-   * @see ContractAnalysisRequestBodySchema.operation
-   */
-  operation: z.number().int().min(0).max(1),
-
-  /** Gas limit for the Safe transaction execution */
-  safeTxGas: NumericStringSchema,
-
-  /** Base gas for the Safe transaction */
-  baseGas: NumericStringSchema,
-
-  /** Gas price for the transaction */
-  gasPrice: NumericStringSchema,
-
-  /** Token address for gas payment (address(0) for ETH) */
-  gasToken: AddressSchema,
-
-  /** Address to receive gas payment refund */
-  refundReceiver: AddressSchema,
-
-  /** Safe transaction nonce */
-  nonce: NumericStringSchema,
+  data: TypedDataSchema,
 
   /** Address of the transaction signer/wallet */
   walletAddress: AddressSchema,
@@ -105,6 +74,4 @@ export type RecipientAnalysisRequestBody = z.infer<
 export type ContractAnalysisRequestBody = z.infer<
   typeof ContractAnalysisRequestBodySchema
 >;
-export type ThreatAnalysisRequestBody = z.infer<
-  typeof ThreatAnalysisRequestBodySchema
->;
+export type ThreatAnalysisRequest = z.infer<typeof ThreatAnalysisRequestSchema>;

--- a/src/modules/safe-shield/safe-shield.service.spec.ts
+++ b/src/modules/safe-shield/safe-shield.service.spec.ts
@@ -33,6 +33,7 @@ import { Operation } from '@/domain/safe/entities/operation.entity';
 import * as utils from './utils/transaction-mapping.utils';
 import type { AnalysisResult } from '@/modules/safe-shield/entities/analysis-result.entity';
 import type { RecipientStatus } from '@/modules/safe-shield/entities/recipient-status.entity';
+import { threatAnalysisRequestBuilder } from '@/modules/safe-shield/entities/__tests__/builders/analysis-requests.builder';
 
 // Utility function for generating Wei values
 const generateRandomWeiAmount = (): bigint =>
@@ -573,19 +574,9 @@ describe('SafeShieldService', () => {
   });
 
   describe('analyzeThreats', () => {
-    const mockThreatRequest = {
-      to: mockRecipientAddress,
-      value: '0',
-      data: mockData,
-      operation: 0,
-      safeTxGas: '0',
-      baseGas: '0',
-      gasPrice: '0',
-      gasToken: getAddress(faker.finance.ethereumAddress()),
-      refundReceiver: getAddress(faker.finance.ethereumAddress()),
-      nonce: '0',
-      walletAddress: mockRecipientAddress,
-    };
+    const mockThreatRequest = threatAnalysisRequestBuilder()
+      .with('walletAddress', mockRecipientAddress)
+      .build();
 
     it('should analyze threats for a transaction', async () => {
       const mockThreatResponse = threatAnalysisResponseBuilder().build();
@@ -595,14 +586,14 @@ describe('SafeShieldService', () => {
       const result = await service.analyzeThreats({
         chainId: mockChainId,
         safeAddress: mockSafeAddress,
-        txRequest: mockThreatRequest,
+        request: mockThreatRequest,
       });
 
       expect(result).toEqual(mockThreatResponse);
       expect(mockThreatAnalysisService.analyze).toHaveBeenCalledWith({
         chainId: mockChainId,
         safeAddress: mockSafeAddress,
-        requestData: mockThreatRequest,
+        request: mockThreatRequest,
       });
     });
 
@@ -634,7 +625,7 @@ describe('SafeShieldService', () => {
       const result = await service.analyzeThreats({
         chainId: mockChainId,
         safeAddress: mockSafeAddress,
-        txRequest: mockThreatRequest,
+        request: mockThreatRequest,
       });
 
       expect(result).toEqual(mockMultipleThreatsResponse);

--- a/src/modules/safe-shield/safe-shield.service.ts
+++ b/src/modules/safe-shield/safe-shield.service.ts
@@ -15,7 +15,7 @@ import { TransactionsService } from '@/routes/transactions/transactions.service'
 import { Operation } from '@/domain/safe/entities/operation.entity';
 import type { TransactionInfo } from '@/routes/transactions/entities/transaction-info.entity';
 import { RecipientInteractionAnalysisDto } from './entities/dtos/recipient-analysis.dto';
-import { ThreatAnalysisRequestBody } from '@/modules/safe-shield/entities/analysis-requests.entity';
+import { ThreatAnalysisRequest } from '@/modules/safe-shield/entities/analysis-requests.entity';
 
 /**
  * Main orchestration service for Safe Shield transaction analysis.
@@ -160,22 +160,22 @@ export class SafeShieldService {
    * @param args - Analysis parameters
    * @param args.chainId - The chain ID
    * @param args.safeAddress - The Safe address
-   * @param args.txRequest - The transaction data
+   * @param args.request - The transaction data/ sign message as TypedData
    * @returns A threat analysis response
    */
   async analyzeThreats({
     chainId,
     safeAddress,
-    txRequest,
+    request,
   }: {
     chainId: string;
     safeAddress: Address;
-    txRequest: ThreatAnalysisRequestBody;
+    request: ThreatAnalysisRequest;
   }): Promise<ThreatAnalysisResponse> {
     return this.threatAnalysisService.analyze({
       chainId,
       safeAddress,
-      requestData: txRequest,
+      request,
     });
   }
 


### PR DESCRIPTION
###Summary
Refactors threat analysis to accept EIP-712 typed data for message signing analysis, replacing the previous transaction-based approach. This enables security analysis of arbitrary messages and structured data that users are asked to sign.

##Changes
✅ Created ThreatAnalysisRequestSchema accepting EIP-712 typed data with data, walletAddress, and optional origin fields
✅ Added comprehensive validation using existing TypedDataSchema from the messages domain
✅ Updated ThreatAnalysisService.analyze() to accept ThreatAnalysisRequest instead of transaction parameters
✅ Updated cache key generation to handle the new request format
✅ Extracted serializeMessage() helper method for JSON serialization
✅ Extracted getFailedAnalysisResponse() helper to eliminate duplication