### PR TITLE
fix(Safe Shield): recipient extraction for native transfers

### DIFF
--- a/src/modules/safe-shield/entities/transaction-data.entity.ts
+++ b/src/modules/safe-shield/entities/transaction-data.entity.ts
@@ -2,7 +2,7 @@ import type { DataDecoded } from '@/routes/data-decode/entities/data-decoded.ent
 import type { Address, Hex } from 'viem';
 
 export type TransactionData = {
-  data: Hex;
+  data: Hex | null;
   operation: number;
   to: Address;
   value: bigint | string;

--- a/src/modules/safe-shield/utils/__tests__/recipient-extraction.utils.spec.ts
+++ b/src/modules/safe-shield/utils/__tests__/recipient-extraction.utils.spec.ts
@@ -322,6 +322,25 @@ describe('recipient-extraction.utils', () => {
         expect(result).toBe(expectedRecipient);
       });
 
+      it('should extract recipient from transaction.to for native transfer with null data', () => {
+        const expectedRecipient = getAddress(faker.finance.ethereumAddress());
+
+        const transaction: DecodedTransactionData = {
+          operation: 0,
+          to: expectedRecipient,
+          value: '1000000000000000000',
+          data: null,
+          dataDecoded: null,
+        };
+
+        mockErc20Decoder.helpers.isTransfer.mockReturnValue(false);
+        mockErc20Decoder.helpers.isTransferFrom.mockReturnValue(false);
+
+        const result = extractRecipient(transaction, mockErc20Decoder);
+
+        expect(result).toBe(expectedRecipient);
+      });
+
       it('should return undefined when dataDecoded is null and data is not empty', () => {
         const expectedRecipient = getAddress(faker.finance.ethereumAddress());
 

--- a/src/modules/safe-shield/utils/recipient-extraction.utils.ts
+++ b/src/modules/safe-shield/utils/recipient-extraction.utils.ts
@@ -49,7 +49,7 @@ export function extractRecipient(
   }
 
   // Native transfer
-  if (data === '0x') {
+  if (!data || data === '0x') {
     return getAddress(to);
   }
 }


### PR DESCRIPTION
Fixes the recipient address extraction for transactions with `data` being null/undefined.

## Summary
### Problem
Recipient address extraction failed for some native transfers because we only treated transactions as “native” when data === '0x'. In practice, the data field can be null, which our logic didn’t account for, causing those transfers to be misclassified and the recipient not to be extracted.


## Changes
Expand the native-transfer check to also handle data being null. Transactions with no calldata (i.e., data is '0x', null, or undefined) are now treated as native transfers, and the recipient address is extracted correctly.

- Modified `TransactionData` type to accept null for the data field.
- Updated recipient extraction logic to handle cases where data is null or '0x'.
- Added a test case to ensure recipient extraction works correctly with null data.
