### PR TITLE
fix: swagger type wrong for chainName and data

### DIFF
--- a/src/routes/chains/entities/balances-provider.entity.ts
+++ b/src/routes/chains/entities/balances-provider.entity.ts
@@ -1,8 +1,8 @@
 import { BalancesProvider as DomainBalancesProvider } from '@/domain/chains/entities/balances-provider.entity';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class BalancesProvider implements DomainBalancesProvider {
-  @ApiPropertyOptional({ type: Number, nullable: true })
+  @ApiProperty({ type: String, nullable: true })
   chainName!: string | null;
   @ApiProperty()
   enabled!: boolean;

--- a/src/routes/data-decode/entities/data-decoded.entity.ts
+++ b/src/routes/data-decode/entities/data-decoded.entity.ts
@@ -39,7 +39,7 @@ class MultiSend implements DomainMultiSend {
   @ApiProperty()
   to!: Address;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     type: String,
     nullable: true,
     description: 'Hexadecimal encoded data',


### PR DESCRIPTION
## Summary
- fix the type for the data prop on the data-decoded object. Swagger was returning this as object, but the more appropriate type here is string, as we are dealing with hex strings
- chainName was typed as Number in swagger, but was actually String in the code