### PR TITLE
feat(safe-shield): include targetChainId to Bridge analysis

### DIFF
--- a/src/modules/safe-shield/entities/__tests__/analysis-result.entity.spec.ts
+++ b/src/modules/safe-shield/entities/__tests__/analysis-result.entity.spec.ts
@@ -204,10 +204,34 @@ describe('AnalysisResult', () => {
       ).not.toThrow();
     });
 
+    it('should validate bridge status with targetChainId', () => {
+      const bridgeResult = {
+        ...recipientAnalysisResultBuilder()
+          .with('type', 'INCOMPATIBLE_SAFE')
+          .build(),
+        targetChainId: '137',
+      };
+
+      expect(() =>
+        RecipientAnalysisResultSchema.parse(bridgeResult),
+      ).not.toThrow();
+    });
+
     it('should validate common status FAILED', () => {
       const failedResult = recipientAnalysisResultBuilder()
         .with('type', 'FAILED')
         .build();
+
+      expect(() =>
+        RecipientAnalysisResultSchema.parse(failedResult),
+      ).not.toThrow();
+    });
+
+    it('should validate common status FAILED with targetChainId', () => {
+      const failedResult = {
+        ...recipientAnalysisResultBuilder().with('type', 'FAILED').build(),
+        targetChainId: '137',
+      };
 
       expect(() =>
         RecipientAnalysisResultSchema.parse(failedResult),

--- a/src/modules/safe-shield/entities/analysis-requests.entity.ts
+++ b/src/modules/safe-shield/entities/analysis-requests.entity.ts
@@ -37,10 +37,6 @@ export const CounterpartyAnalysisRequestSchema = z.object({
   operation: z.nativeEnum(Operation),
 });
 
-export type CounterpartyAnalysisRequest = z.infer<
-  typeof CounterpartyAnalysisRequestSchema
->;
-
 /**
  * Request schema for threat analysis endpoint.
  *

--- a/src/modules/safe-shield/entities/analysis-result.entity.ts
+++ b/src/modules/safe-shield/entities/analysis-result.entity.ts
@@ -10,6 +10,7 @@ import {
   type ContractStatus,
 } from './contract-status.entity';
 import { ThreatStatusSchema, type ThreatStatus } from './threat-status.entity';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 
 /**
  * Common status code available for all analysis types.
@@ -88,14 +89,20 @@ export const AnalysisResultBaseSchema = z.object({
 
 /**
  * Zod schema for recipient analysis results.
+ *
+ * Combines recipient interaction and bridge analysis results using a union.
+ * - BridgeStatus and CommonStatus results include optional targetChainId field
+ * - RecipientStatus results do not include targetChainId field
  */
-export const RecipientAnalysisResultSchema = AnalysisResultBaseSchema.extend({
-  type: z.union([
-    RecipientStatusSchema,
-    BridgeStatusSchema,
-    CommonStatusSchema,
-  ]),
-});
+export const RecipientAnalysisResultSchema = z.union([
+  AnalysisResultBaseSchema.extend({
+    type: z.union([BridgeStatusSchema, CommonStatusSchema]),
+    targetChainId: NumericStringSchema.optional(),
+  }),
+  AnalysisResultBaseSchema.extend({
+    type: RecipientStatusSchema,
+  }),
+]);
 
 /**
  * Zod schema for contract analysis results.

--- a/src/modules/safe-shield/entities/dtos/counterparty-analysis-request.dto.ts
+++ b/src/modules/safe-shield/entities/dtos/counterparty-analysis-request.dto.ts
@@ -1,10 +1,11 @@
 import { Operation } from '@/domain/safe/entities/operation.entity';
-import { CounterpartyAnalysisRequest } from '@/modules/safe-shield/entities/analysis-requests.entity';
+import { CounterpartyAnalysisRequestSchema } from '@/modules/safe-shield/entities/analysis-requests.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { Address, Hex } from 'viem';
+import { z } from 'zod';
 
 export class CounterpartyAnalysisRequestDto
-  implements CounterpartyAnalysisRequest
+  implements z.infer<typeof CounterpartyAnalysisRequestSchema>
 {
   @ApiProperty({
     type: String,

--- a/src/modules/safe-shield/entities/dtos/counterparty-analysis.dto.ts
+++ b/src/modules/safe-shield/entities/dtos/counterparty-analysis.dto.ts
@@ -4,9 +4,11 @@ import {
   RecipientAnalysisResult,
   type ContractAnalysisResult,
 } from '../analysis-result.entity';
-import type { GroupedAnalysisResults } from '../analysis-responses.entity';
+import type {
+  CounterpartyAnalysisResponse,
+  GroupedAnalysisResults,
+} from '@/modules/safe-shield/entities/analysis-responses.entity';
 import { ContractStatus } from '@/modules/safe-shield/entities/contract-status.entity';
-import type { CounterpartyAnalysisResponse } from '@/modules/safe-shield/entities/analysis-responses.entity';
 import { AnalysisResultDto } from './analysis-result.dto';
 import { BridgeStatus } from '@/modules/safe-shield/entities/bridge-status.entity';
 import { RecipientStatus } from '@/modules/safe-shield/entities/recipient-status.entity';
@@ -103,12 +105,20 @@ export class RecipientResultDto extends AnalysisResultDto<
     example: 'MISSING_OWNERSHIP',
   })
   type!: RecipientStatus | BridgeStatus | CommonStatus;
+
+  @ApiProperty({
+    description:
+      'Target chain ID for bridge operations. Only present for BridgeStatus.',
+    example: '137',
+    required: false,
+  })
+  targetChainId?: string;
 }
 
 /**
  * DTO for full recipient analysis response.
  *
- * This DTO mirrors GroupedAnalysisResults<RecipientAnalysisResult> for Swagger documentation.
+ * This DTO represents the structure for Swagger documentation.
  * Results are grouped by status group and sorted by severity (CRITICAL first).
  * Used by endpoints that return both recipient interaction and bridge analysis.
  */
@@ -145,6 +155,7 @@ export class RecipientAnalysisDto
         type: 'MISSING_OWNERSHIP',
         title: 'No ownership on target chain',
         description: 'You do not have ownership of a Safe on the target chain',
+        targetChainId: '137',
       },
     ],
   })


### PR DESCRIPTION
## Summary [COR-739](https://linear.app/safe-global/issue/COR-739/provide-targetchainid-as-part-of-response-for-bridge-analysis)

Add a new field `targetChainId` for `BRIDGE` analysis

## Changes
- For the simplicity the Swagger definition for both `RECIPIENT_INTERACTION` and `BRIDGE` analysis groups include optional `targetChainId` field. In reality it wont be present for `RECIPIENT_INTERACTION`