### PR TITLE
fix(safe-shield): Fix contract extraction for counterparty analysis

### DIFF
--- a/src/modules/safe-shield/utils/extraction.utils.spec.ts
+++ b/src/modules/safe-shield/utils/extraction.utils.spec.ts
@@ -96,10 +96,15 @@ describe('extraction.utils', () => {
       expect(mockErc20Decoder.helpers.isTransferFrom).not.toHaveBeenCalled();
     });
 
-    it('ignores transactions without decoded data', () => {
+    it('extracts contracts from transactions without decoded data but with valid data', () => {
+      mockErc20Decoder.helpers.isTransfer.mockReturnValue(false);
+      mockErc20Decoder.helpers.isTransferFrom.mockReturnValue(false);
+
+      const contract = getAddress(faker.finance.ethereumAddress());
       const result = extractContracts(
         [
           createTransaction({
+            to: contract,
             dataDecoded: null,
             operation: 1,
           }),
@@ -107,7 +112,7 @@ describe('extraction.utils', () => {
         mockErc20Decoder,
       );
 
-      expect(result).toEqual([]);
+      expect(result).toEqual([[contract, true]]);
     });
 
     it('ignores ERC20 transfer transactions', () => {

--- a/src/modules/safe-shield/utils/extraction.utils.ts
+++ b/src/modules/safe-shield/utils/extraction.utils.ts
@@ -25,7 +25,6 @@ export function extractContracts(
     if (
       data === '0x' ||
       !data ||
-      !dataDecoded ||
       erc20Decoder.helpers.isTransfer(data) ||
       erc20Decoder.helpers.isTransferFrom(data) ||
       (isExecTransaction(tx) && dataDecoded?.parameters?.[2].value === '0x')


### PR DESCRIPTION
## Summary (part of [COR-620](https://linear.app/safe-global/issue/COR-620/live-counterparty-analysis-endpoint))

## Changes
- relax the extraction of contracts logic to allow dataDecoded = null
