### PR TITLE
fix(safe-shield): analyze interactions with only executed txs

### DIFF
--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
@@ -421,6 +421,7 @@ describe('ContractAnalysisService', () => {
       expect(mockTransactionApi.getMultisigTransactions).toHaveBeenCalledWith({
         safeAddress,
         to: contractAddress,
+        executed: true,
         limit: 1,
       });
 
@@ -492,6 +493,7 @@ describe('ContractAnalysisService', () => {
       expect(mockTransactionApi.getMultisigTransactions).toHaveBeenCalledWith({
         safeAddress,
         to: contractAddress,
+        executed: true,
         limit: 1,
       });
 
@@ -1002,6 +1004,7 @@ describe('ContractAnalysisService', () => {
       expect(mockTransactionApi.getMultisigTransactions).toHaveBeenCalledWith({
         safeAddress,
         to: contractAddress,
+        executed: true,
         limit: 1,
       });
 
@@ -1130,6 +1133,7 @@ describe('ContractAnalysisService', () => {
       expect(mockTransactionApi.getMultisigTransactions).toHaveBeenCalledWith({
         safeAddress,
         to: contractAddress,
+        executed: true,
         limit: 1,
       });
     });

--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.ts
@@ -204,6 +204,7 @@ export class ContractAnalysisService {
       const page = await transactionApi.getMultisigTransactions({
         safeAddress,
         to: contract,
+        executed: true,
         limit: 1,
       });
 


### PR DESCRIPTION
## Summary (part of [COR-620](https://linear.app/safe-global/issue/COR-620/live-counterparty-analysis-endpoint))

## Changes
- Check contract interactions in counterparty analysis only with executed transactions, otherwise the current transaction counts as well.
