### PR TITLE
fix(safe-shield): Fix token_id schema in threat-analysis

### DIFF
--- a/src/modules/safe-shield/entities/__tests__/threat-analysis.types.spec.ts
+++ b/src/modules/safe-shield/entities/__tests__/threat-analysis.types.spec.ts
@@ -46,13 +46,17 @@ describe('ThreatAnalysis Types', () => {
           address: getAddress(faker.finance.ethereumAddress()),
           symbol: 'NFT',
         },
-        in: [{ token_id: faker.number.int() }],
-        out: [{ token_id: faker.number.int() }],
+        in: [{ token_id: '0x1a0' }],
+        out: [{ token_id: '0xff' }],
       };
 
       const result = BalanceChangeSchema.parse(nftBalanceChange);
 
-      expect(result).toEqual(nftBalanceChange);
+      expect(result).toEqual({
+        asset: nftBalanceChange.asset,
+        in: [{ token_id: 416 }],
+        out: [{ token_id: 255 }],
+      });
     });
 
     it('should parse Blockaid response and strip extra fields', () => {

--- a/src/modules/safe-shield/entities/threat-analysis.types.ts
+++ b/src/modules/safe-shield/entities/threat-analysis.types.ts
@@ -2,6 +2,7 @@
 
 import { z } from 'zod';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
 
 export const AssetTypeSchema = z.enum(['NATIVE', 'ERC20', 'ERC721', 'ERC1155']);
 export type AssetType = z.infer<typeof AssetTypeSchema>;
@@ -27,7 +28,7 @@ export const FungibleDiffSchema = z.object({
 });
 
 export const NFTDiffSchema = z.object({
-  token_id: z.number(),
+  token_id: HexSchema.transform(Number),
 });
 
 export const AssetDiffSchema = z.union([NFTDiffSchema, FungibleDiffSchema]);

--- a/src/modules/safe-shield/threat-analysis/threat-analysis.service.ts
+++ b/src/modules/safe-shield/threat-analysis/threat-analysis.service.ts
@@ -272,7 +272,7 @@ export class ThreatAnalysisService {
       .filter((f) => f.type === 'Malicious' || f.type === 'Warning')
       .reduce(
         (acc, { type, description }) => {
-          const sev = BLOCKAID_SEVERITY_MAP[type as 'Malicious' | 'Warning'];
+          const sev = BLOCKAID_SEVERITY_MAP[type];
           (acc[sev] ??= []).push(description);
           return acc;
         },


### PR DESCRIPTION
## Summary (part of [COR-620](https://linear.app/safe-global/issue/COR-620/live-counterparty-analysis-endpoint))

## Changes
- Fix the token_id schema that expects a hex representation of a number
