### PR TITLE
Remove RELAY_NO_FEE_CAMPAIGN_KEY

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -31,7 +31,6 @@ export class CacheRouter {
   private static readonly OWNERS_SAFE_KEY = 'owner_safes';
   private static readonly RATE_LIMIT_KEY = 'rate_limit';
   private static readonly RELAY_KEY = 'relay';
-  private static readonly RELAY_NO_FEE_CAMPAIGN_KEY = 'relay_no_fee_campaign';
   private static readonly RPC_REQUESTS_KEY = 'rpc_requests';
   private static readonly SAFE_APPS_KEY = 'safe_apps';
   private static readonly SAFE_BALANCES_KEY = 'safe_balances';
@@ -560,25 +559,11 @@ export class CacheRouter {
     return `${args.chainId}_${CacheRouter.RELAY_KEY}_${args.address}`;
   }
 
-  static getNoFeeCampaignRelayKey(args: {
-    chainId: string;
-    address: Address;
-  }): string {
-    return `${args.chainId}_${CacheRouter.RELAY_NO_FEE_CAMPAIGN_KEY}_${args.address}`;
-  }
-
   static getRelayCacheDir(args: {
     chainId: string;
     address: Address;
   }): CacheDir {
     return new CacheDir(CacheRouter.getRelayKey(args), '');
-  }
-
-  static getRelayNoFeeCampaignCacheDir(args: {
-    chainId: string;
-    address: Address;
-  }): CacheDir {
-    return new CacheDir(CacheRouter.getNoFeeCampaignRelayKey(args), '');
   }
 
   static getSafeAppsKey(chainId: string): string {

--- a/src/datasources/relay-api/gelato-api.service.spec.ts
+++ b/src/datasources/relay-api/gelato-api.service.spec.ts
@@ -211,6 +211,7 @@ describe('GelatoApi', () => {
         chainId,
         address,
         count,
+        ttlSeconds: faker.number.int(),
       });
 
       const result = await fakeCacheService.hGet(

--- a/src/datasources/relay-api/gelato-api.service.ts
+++ b/src/datasources/relay-api/gelato-api.service.ts
@@ -26,7 +26,6 @@ export class GelatoApi implements IRelayApi {
   private static GAS_LIMIT_BUFFER = BigInt(150_000);
 
   private readonly baseUri: string;
-  private readonly ttlSeconds: number;
 
   constructor(
     @Inject(NetworkService)
@@ -38,7 +37,6 @@ export class GelatoApi implements IRelayApi {
   ) {
     this.baseUri =
       this.configurationService.getOrThrow<string>('relay.baseUri');
-    this.ttlSeconds = configurationService.getOrThrow('relay.ttlSeconds');
   }
 
   async relay(args: {
@@ -85,35 +83,13 @@ export class GelatoApi implements IRelayApi {
     return count ? parseInt(count) : 0;
   }
 
-  async getRelayNoFeeCampaignCount(args: {
-    chainId: string;
-    address: Address;
-  }): Promise<number> {
-    const cacheDir = CacheRouter.getRelayNoFeeCampaignCacheDir(args);
-    const count = await this.cacheService.hGet(cacheDir);
-    return count ? parseInt(count) : 0;
-  }
-
   async setRelayCount(args: {
-    chainId: string;
-    address: Address;
-    count: number;
-  }): Promise<void> {
-    const cacheDir = CacheRouter.getRelayCacheDir(args);
-    await this.cacheService.hSet(
-      cacheDir,
-      args.count.toString(),
-      this.ttlSeconds,
-    );
-  }
-
-  async setRelayNoFeeCampaignCount(args: {
     chainId: string;
     address: Address;
     count: number;
     ttlSeconds: number;
   }): Promise<void> {
-    const cacheDir = CacheRouter.getRelayNoFeeCampaignCacheDir(args);
+    const cacheDir = CacheRouter.getRelayCacheDir(args);
     await this.cacheService.hSet(
       cacheDir,
       args.count.toString(),

--- a/src/domain/interfaces/relay-api.interface.ts
+++ b/src/domain/interfaces/relay-api.interface.ts
@@ -14,18 +14,7 @@ export interface IRelayApi {
 
   getRelayCount(args: { chainId: string; address: Address }): Promise<number>;
 
-  getRelayNoFeeCampaignCount(args: {
-    chainId: string;
-    address: Address;
-  }): Promise<number>;
-
   setRelayCount(args: {
-    chainId: string;
-    address: Address;
-    count: number;
-  }): Promise<void>;
-
-  setRelayNoFeeCampaignCount(args: {
     chainId: string;
     address: Address;
     count: number;

--- a/src/domain/relay/relayers/daily-limit.relayer.ts
+++ b/src/domain/relay/relayers/daily-limit.relayer.ts
@@ -11,6 +11,7 @@ import { RelayLimitReachedError } from '@/domain/relay/errors/relay-limit-reache
 @Injectable()
 export class DailyLimitRelayer implements IRelayer {
   private readonly limit: number;
+  private readonly ttlSeconds: number;
 
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
@@ -19,6 +20,7 @@ export class DailyLimitRelayer implements IRelayer {
     @Inject(IRelayApi) private readonly relayApi: IRelayApi,
   ) {
     this.limit = configurationService.getOrThrow('relay.limit');
+    this.ttlSeconds = configurationService.getOrThrow('relay.ttlSeconds');
   }
 
   async canRelay(args: {
@@ -105,6 +107,7 @@ export class DailyLimitRelayer implements IRelayer {
       chainId: args.chainId,
       address: args.address,
       count: incremented,
+      ttlSeconds: this.ttlSeconds,
     });
   }
 }

--- a/src/domain/relay/relayers/no-fee-campaign.relayer.ts
+++ b/src/domain/relay/relayers/no-fee-campaign.relayer.ts
@@ -160,7 +160,7 @@ export class NoFeeCampaignRelayer implements IRelayer {
     if (!this.isActive(args.chainId)) {
       return 0;
     }
-    return this.relayApi.getRelayNoFeeCampaignCount(args);
+    return this.relayApi.getRelayCount(args);
   }
 
   private async incrementRelayCount(args: {
@@ -175,7 +175,7 @@ export class NoFeeCampaignRelayer implements IRelayer {
         this.relayconfiguration[parseInt(args.chainId)].endsAtTimeStamp -
         new Date().getTime() / 1000;
 
-      return this.relayApi.setRelayNoFeeCampaignCount({
+      return this.relayApi.setRelayCount({
         chainId: args.chainId,
         address: args.address,
         count: incremented,


### PR DESCRIPTION
## Summary

Remove RELAY_NO_FEE_CAMPAIGN_KEY and use single key for cache storage related to relayer.

## Changes
- Let relayer decide value of `ttlSeconds` rather than gelato relay api setting the value. This is required because of 2 relayer paths: no-fee campaign relayer and daily limit logic. Each relaying method has its own `ttlSeconds` value.