### PR TITLE
fix(safe-shield): propagate error message from Blockaid if scan failed

### DIFF
--- a/src/modules/safe-shield/threat-analysis/threat-analysis.constants.ts
+++ b/src/modules/safe-shield/threat-analysis/threat-analysis.constants.ts
@@ -60,5 +60,5 @@ export const DESCRIPTION_MAPPING: Record<
   MODULE_CHANGE: () =>
     'Verify this change before proceeding as it will change Safe modules.',
   FAILED: ({ error } = {}) =>
-    `Threat analysis failed.${error ? ` (${error}).` : ''} Review before processing.`,
+    `Threat analysis failed.${error ? ` (${error})` : ''} Review before processing.`,
 };

--- a/src/modules/safe-shield/threat-analysis/threat-analysis.service.spec.ts
+++ b/src/modules/safe-shield/threat-analysis/threat-analysis.service.spec.ts
@@ -387,7 +387,9 @@ describe('ThreatAnalysisService', () => {
               severity: SEVERITY_MAPPING.FAILED,
               type: 'FAILED',
               title: TITLE_MAPPING.FAILED,
-              description: DESCRIPTION_MAPPING.FAILED(),
+              description: DESCRIPTION_MAPPING.FAILED({
+                error: 'Validation failed',
+              }),
             },
           ],
           BALANCE_CHANGE: [],


### PR DESCRIPTION
## Summary

 If Blockaid response for simulation/validation contains error, propagate the message to the response. Read both `description` and `error` fields

## Changes
