### PR TITLE
fix: Caching relay count failing due to non-int ttlSeconds value

### DIFF
--- a/src/domain/relay/relayers/no-fee-campaign.relayer.ts
+++ b/src/domain/relay/relayers/no-fee-campaign.relayer.ts
@@ -169,9 +169,10 @@ export class NoFeeCampaignRelayer implements IRelayer {
       const currentCount = await this.getRelayCount(args);
       const incremented = currentCount + 1;
 
-      const ttlSeconds =
+      const ttlSeconds = Math.floor(
         this.relayConfiguration[parseInt(args.chainId)].endsAtTimeStamp -
-        new Date().getTime() / 1000;
+          new Date().getTime() / 1000,
+      );
 
       return this.relayApi.setRelayCount({
         chainId: args.chainId,


### PR DESCRIPTION
## Summary

The incremented value of relay count is not being stored in cache due to `ttlSeconds` being a non-integer value.
The PR fixes the issue by using `Math.floor` function so that `ttlSeconds` is an integer.
