### PR TITLE
fix: Reject tx relaying when gasLimit exceeds maxGasLimit

### DIFF
--- a/src/domain/relay/errors/exceeds-max-gas-limit.ts
+++ b/src/domain/relay/errors/exceeds-max-gas-limit.ts
@@ -1,0 +1,12 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+
+export class ExceedsMaxGasLimitError extends UnprocessableEntityException {
+  constructor(
+    readonly current: bigint,
+    readonly maxGasLimit: bigint,
+  ) {
+    super(
+      `Transaction exceeds maxGasLimit for transaction | current: ${current} | limit: ${maxGasLimit}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Check gasLimit before checking token balance, reject tx exceeding `maxGasLimit`

## Changes
- Add new error for exceeding `maxGasLimit`
- Reject tx exceeding `maxGasLimit`
- Update test case
