### PR TITLE
fix(safe-shield): disable NEW_CONTRACT check

### DIFF
--- a/src/modules/safe-shield/contract-analysis/contract-analysis.constants.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.constants.ts
@@ -41,7 +41,6 @@ export const TITLE_MAPPING: Record<ContractStatus | CommonStatus, string> = {
 
 type DescriptionArgs = {
   name?: string;
-  interactions?: number;
   error?: string;
 };
 
@@ -63,8 +62,7 @@ export const DESCRIPTION_MAPPING: Record<
     'Contract verification is currently unavailable.',
   NEW_CONTRACT: () =>
     'You are interacting with this contract for the first time.',
-  KNOWN_CONTRACT: ({ interactions = 0 } = {}) =>
-    `You have interacted with this contract ${interactions} time${interactions !== 1 ? 's' : ''}.`,
+  KNOWN_CONTRACT: () => 'You have already interacted with this contract.',
   UNEXPECTED_DELEGATECALL: () =>
     'This transaction calls a smart contract that will be able to modify your Safe account. Learn more',
 };


### PR DESCRIPTION
## Summary [COR-763](https://linear.app/safe-global/issue/COR-763/safe-shield-first-interaction-is-displayed-for-the-contract-i-have)

## Changes

- temporary disable NEW_CONTRACT check in contract analysis
- update message for `KNOWN_CONTRACT` to not show the count

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops emitting NEW_CONTRACT, makes interaction result optional (empty when none), and updates KNOWN_CONTRACT copy; refactors mappings and updates tests.
> 
> - **Contract Analysis Service**:
>   - `analyzeInteractions` now returns `undefined` when no interactions; only returns `KNOWN_CONTRACT` when count > 0.
>   - `analyzeContract` outputs empty `CONTRACT_INTERACTION` when no interaction result.
>   - Removed `interactions` handling from mapping logic.
> - **Constants**:
>   - `DESCRIPTION_MAPPING.KNOWN_CONTRACT` changed to a generic message without counts.
>   - Removed `interactions` from description args.
> - **Tests**:
>   - Updated specs to expect no `NEW_CONTRACT` and empty interaction arrays when applicable.
>   - Added test for both `delegateCallResult` and `interactionResult` being undefined (returns empty arrays).
>   - Adjusted expectations to new `KNOWN_CONTRACT` description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a44265b93b26752795d7cd4a704ddac762d00c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->