### PR TITLE
fix(safe-shield): Disable NOT_VERIFIED_BY_SAFE check

### DIFF
--- a/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
+++ b/src/modules/safe-shield/contract-analysis/contract-analysis.service.spec.ts
@@ -796,7 +796,7 @@ describe('ContractAnalysisService', () => {
         expect(delegateCall).toBeUndefined();
       });
 
-      it('should return NOT_VERIFIED_BY_SAFE when no contracts found', async () => {
+      it('should return undefined when no contracts found', async () => {
         const mockContractPage = pageBuilder()
           .with('count', 0)
           .with('results', [])
@@ -817,12 +817,7 @@ describe('ContractAnalysisService', () => {
           chainId,
         });
 
-        expect(verification).toEqual({
-          severity: SEVERITY_MAPPING.NOT_VERIFIED_BY_SAFE,
-          type: 'NOT_VERIFIED_BY_SAFE',
-          title: TITLE_MAPPING.NOT_VERIFIED_BY_SAFE,
-          description: DESCRIPTION_MAPPING.NOT_VERIFIED_BY_SAFE(),
-        });
+        expect(verification).toBeUndefined();
         expect(delegateCall).toBeUndefined();
       });
 
@@ -980,12 +975,7 @@ describe('ContractAnalysisService', () => {
           isDelegateCall: true,
         });
 
-        expect(verification).toEqual({
-          severity: SEVERITY_MAPPING.NOT_VERIFIED_BY_SAFE,
-          type: 'NOT_VERIFIED_BY_SAFE',
-          title: TITLE_MAPPING.NOT_VERIFIED_BY_SAFE,
-          description: DESCRIPTION_MAPPING.NOT_VERIFIED_BY_SAFE(),
-        });
+        expect(verification).toBeUndefined();
 
         expect(delegateCall).toEqual({
           severity: SEVERITY_MAPPING.UNEXPECTED_DELEGATECALL,


### PR DESCRIPTION
## Summary [COR-787](https://linear.app/safe-global/issue/COR-787/safe-shield-5c-new-contract-message-is-misleading-for-the-multisend)

## Changes

- temp disable NOT_VERIFIED_BY_SAFE check in contract verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Returns undefined for contract verification when no contracts are found, adjusts analysis to omit missing verification results, and updates tests accordingly.
> 
> - **ContractAnalysisService**:
>   - `verifyContract`
>     - Returns `undefined` verification when `getContracts` returns no results; tuple type updated to allow `undefined`.
>     - Keeps delegatecall check; still returns `UNEXPECTED_DELEGATECALL` when untrusted/unknown and delegatecall is used.
>     - On fetch errors, returns `VERIFICATION_UNAVAILABLE`.
>   - `analyzeContract`
>     - Includes `CONTRACT_VERIFICATION` only when a verification result exists.
> - **Tests**:
>   - Update specs to expect `verification` as `undefined` when no contracts are found (including delegatecall path).
>   - Adjust expectations where verification results are conditionally present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13dd9461a2b58b6231a6125c06a788e45253fc34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->