### PR TITLE
fix(safe-shield): disable state override for Blockaid

### DIFF
--- a/src/modules/safe-shield/threat-analysis/blockaid/blockaid-api.service.spec.ts
+++ b/src/modules/safe-shield/threat-analysis/blockaid/blockaid-api.service.spec.ts
@@ -1,5 +1,5 @@
 import { BlockaidApi } from '@/modules/safe-shield/threat-analysis/blockaid/blockaid-api.service';
-import { GUARD_STORAGE_POSITION } from '@/modules/safe-shield/threat-analysis/blockaid/blockaid-api.constants';
+// import { GUARD_STORAGE_POSITION } from '@/modules/safe-shield/threat-analysis/blockaid/blockaid-api.constants';
 import type { TransactionScanResponse } from '@blockaid/client/resources/evm/evm';
 import type { Address } from 'viem';
 import { faker } from '@faker-js/faker';
@@ -59,14 +59,17 @@ describe('BlockaidApi', () => {
         ],
       },
     });
-    const stateOverride = {
-      [safeAddress]: {
-        stateDiff: {
-          [GUARD_STORAGE_POSITION]:
-            '0x0000000000000000000000000000000000000000000000000000000000000000',
-        },
-      },
-    };
+    // Temporary disable state override (to be reverted in
+    // https://linear.app/safe-global/issue/COR-802/put-back-blockaid-state-override)
+
+    // const stateOverride = {
+    //   [safeAddress]: {
+    //     stateDiff: {
+    //       [GUARD_STORAGE_POSITION]:
+    //         '0x0000000000000000000000000000000000000000000000000000000000000000',
+    //     },
+    //   },
+    // };
 
     it('should call blockaid client with correct parameters', async () => {
       const origin = faker.internet.url();
@@ -97,7 +100,7 @@ describe('BlockaidApi', () => {
         options: ['simulation', 'validation'],
         metadata: { domain: origin },
         account_address: walletAddress,
-        state_override: stateOverride,
+        //state_override: stateOverride,
       });
 
       expect(result).toEqual(mockScanResponse);
@@ -129,7 +132,7 @@ describe('BlockaidApi', () => {
         options: ['simulation', 'validation'],
         metadata: { non_dapp: true },
         account_address: walletAddress,
-        state_override: stateOverride,
+        //state_override: stateOverride,
       });
 
       expect(result).toEqual(mockScanResponse);

--- a/src/modules/safe-shield/threat-analysis/blockaid/blockaid-api.service.ts
+++ b/src/modules/safe-shield/threat-analysis/blockaid/blockaid-api.service.ts
@@ -1,5 +1,5 @@
 import { IBlockaidApi } from '@/modules/safe-shield/threat-analysis/blockaid/blockaid-api.interface';
-import { GUARD_STORAGE_POSITION } from '@/modules/safe-shield/threat-analysis/blockaid/blockaid-api.constants';
+// import { GUARD_STORAGE_POSITION } from '@/modules/safe-shield/threat-analysis/blockaid/blockaid-api.constants';
 import Blockaid from '@blockaid/client';
 import { TransactionScanResponse } from '@blockaid/client/resources/evm/evm';
 import { JsonRpcScanParams } from '@blockaid/client/resources/evm/json-rpc';
@@ -31,15 +31,18 @@ export class BlockaidApi implements IBlockaidApi {
       options: ['simulation', 'validation'],
       metadata: origin ? { domain: origin } : { non_dapp: true as const },
       account_address: walletAddress,
-      state_override: {
-        [safeAddress]: {
-          stateDiff: {
-            // Set the Guard storage slot to zero address to disable guard
-            [GUARD_STORAGE_POSITION]:
-              '0x0000000000000000000000000000000000000000000000000000000000000000',
-          },
-        },
-      },
+
+      // Temporary disable state override (to be reverted in
+      // https://linear.app/safe-global/issue/COR-802/put-back-blockaid-state-override)
+      // state_override: {
+      //   [safeAddress]: {
+      //     stateDiff: {
+      //       // Set the Guard storage slot to zero address to disable guard
+      //       [GUARD_STORAGE_POSITION]:
+      //         '0x0000000000000000000000000000000000000000000000000000000000000000',
+      //     },
+      //   },
+      // },
     };
 
     return await this.blockaidClient.evm.jsonRpc.scan(params);


### PR DESCRIPTION
## Summary [COR-803](https://linear.app/safe-global/issue/COR-803/exclude-blockaid-state-override-in-transaction-assistance-engine)

## Changes
- Temporarily remove the Blockaid-related state override 
