### PR TITLE
chore: reverse Blockaid mapping logic

### DIFF
--- a/src/modules/safe-shield/threat-analysis/blockaid/blockaid-api.constants.ts
+++ b/src/modules/safe-shield/threat-analysis/blockaid/blockaid-api.constants.ts
@@ -40,7 +40,7 @@ const CLASSIFICATION_MAPPING: Record<string, string> = {
 };
 
 /**
- * Prepares a description from reason and classification or falls back to scan description.
+ * Prepares a description from a scan description or falls back to reason and classification mapping.
  * @param {string} reason - A description about the reasons the transaction was flagged
  * @param {string} classification - A classification explaining the reason of threat analysis result
  * @param {string} description - A fallback description from Blockaid
@@ -51,11 +51,17 @@ export const prepareDescription = (
   classification?: string,
   description?: string,
 ): string | undefined => {
-  const reasonMsg = reason ? REASON_MAPPING[reason] : '';
-  const classificationMsg = classification
-    ? CLASSIFICATION_MAPPING[classification]
-    : '';
-  return reasonMsg && classificationMsg
-    ? `The transaction ${reasonMsg} ${classificationMsg}.`
-    : description;
+  if (description) {
+    return description;
+  }
+
+  const reasonMsg = reason && REASON_MAPPING[reason];
+  const classificationMsg =
+    classification && CLASSIFICATION_MAPPING[classification];
+
+  if (!reasonMsg || !classificationMsg) {
+    return undefined;
+  }
+
+  return `The transaction ${reasonMsg} ${classificationMsg}.`;
 };

--- a/src/modules/safe-shield/threat-analysis/threat-analysis.service.spec.ts
+++ b/src/modules/safe-shield/threat-analysis/threat-analysis.service.spec.ts
@@ -214,7 +214,6 @@ describe('ThreatAnalysisService', () => {
           status: 'Success',
           result_type: 'Warning',
           classification,
-          description: faker.lorem.sentence(),
           reason,
           features: [
             {
@@ -469,7 +468,6 @@ describe('ThreatAnalysisService', () => {
             result_type: 'Warning',
             classification,
             reason,
-            description: faker.lorem.sentence(),
             features: features,
           },
           simulation: {


### PR DESCRIPTION
## Summary
part of [COR-567](https://linear.app/safe-global/issue/COR-567/threat-analysis-service-blockaid-integration)

## Changes
- updated the Blockaid response mapping for validation to use Blockaid response's description as a main one and fallback to classification/reason mapping if not available.