### PR TITLE
feat: add service key as URL param to chains v2 endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -110,10 +110,6 @@
 # Default if none is set: https://safe-config.safe.global
 # SAFE_CONFIG_BASE_URI=https://safe-config.safe.global
 
-# The service key for Config Service v2 endpoints (used by v2 chains endpoints)
-# Default if none is set: frontend
-# SAFE_CONFIG_FRONTEND_KEY=frontend
-
 # The base url for the Safe Locking Service
 # Default if none is set: https://safe-locking.safe.global
 # LOCKING_PROVIDER_API_BASE_URI=https://safe-locking.safe.global

--- a/specs/001-service-aware-config/contracts/chains-v2.yaml
+++ b/specs/001-service-aware-config/contracts/chains-v2.yaml
@@ -44,12 +44,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Chain'
         '404':
-          description: Service not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        '404':
           description: Chain not found
           content:
             application/json:

--- a/specs/001-service-aware-config/contracts/chains-v2.yaml
+++ b/specs/001-service-aware-config/contracts/chains-v2.yaml
@@ -12,46 +12,23 @@ servers:
     description: CGW v2 API
 
 paths:
-  /chains:
-    get:
-      summary: Get supported chains (v2)
-      description: |
-        Retrieves a paginated list of all blockchain networks supported by the Safe infrastructure,
-        with features scoped to the configured service key (e.g., "frontend").
-      operationId: getChainsV2
-      tags:
-        - chains
-      parameters:
-        - name: cursor
-          in: query
-          required: false
-          description: Pagination cursor for retrieving the next set of results
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Paginated list of supported chains with service-scoped features
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChainPage'
-        '500':
-          description: Internal server error (Config Service unavailable)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  /chains/{chainId}:
+  /chains/{serviceKey}/{chainId}:
     get:
       summary: Get chain details (v2)
       description: |
         Retrieves detailed information about a specific blockchain network,
-        with features scoped to the configured service key.
+        with features scoped to the service key.
       operationId: getChainV2
       tags:
         - chains
       parameters:
+        - name: serviceKey
+          in: path
+          required: true
+          description: Service key for scoping chain features (e.g., WALLET_WEB, MOBILE)
+          schema:
+            type: string
+          example: 'WALLET_WEB'
         - name: chainId
           in: path
           required: true
@@ -67,6 +44,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Chain'
         '404':
+          description: Service not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
           description: Chain not found
           content:
             application/json:
@@ -74,6 +57,49 @@ paths:
                 $ref: '#/components/schemas/Error'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /chains/{serviceKey}:
+    get:
+      summary: Get supported chains (v2)
+      description: |
+        Retrieves a paginated list of all blockchain networks supported by the Safe infrastructure,
+        with features scoped to the service key.
+      operationId: getChainsV2
+      tags:
+        - chains
+      parameters:
+        - name: serviceKey
+          in: path
+          required: true
+          description: Service key for scoping chain features (e.g., WALLET_WEB, MOBILE)
+          schema:
+            type: string
+          example: 'WALLET_WEB'
+        - name: cursor
+          in: query
+          required: false
+          description: Pagination cursor for retrieving the next set of results
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Paginated list of supported chains with service-scoped features
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainPage'
+        '404':
+          description: Service not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error (Config Service unavailable)
           content:
             application/json:
               schema:

--- a/specs/001-service-aware-config/data-model.md
+++ b/specs/001-service-aware-config/data-model.md
@@ -95,8 +95,13 @@ interface IChainsRepository {
   clearChain(chainId: string): Promise<void>;
 
   // NEW: v2 methods
-  getChainV2(chainId: string): Promise<Chain>;
-  getChainsV2(limit?: number, offset?: number): Promise<Page<Chain>>;
+  getChainV2(serviceKey: string, chainId: string): Promise<Chain>;
+  getChainsV2(
+    serviceKey: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Chain>>;
+  clearChainV2(chainId: string, serviceKey: string): Promise<void>;
 }
 ```
 
@@ -117,28 +122,6 @@ chains_v2_{serviceKey}                    → List of chains for service
 ```
 
 **Rationale**: Separate namespace prevents cache pollution between v1/v2 and between different service keys.
-
-## Configuration Schema
-
-### New Configuration Property
-
-**Location**: `src/config/entities/configuration.ts`
-
-```typescript
-safeConfig: {
-  baseUri: string;
-  chains: {
-    maxSequentialPages: number;
-  }
-  safes: {
-    maxSequentialPages: number;
-  }
-  serviceKey: string; // NEW: Default "frontend"
-}
-```
-
-**Environment Variable**: `SAFE_CONFIG_FRONTEND_KEY`
-**Default Value**: `"frontend"`
 
 ## Validation Rules
 

--- a/specs/001-service-aware-config/quickstart.md
+++ b/specs/001-service-aware-config/quickstart.md
@@ -15,9 +15,6 @@
 Add the following to your `.env` file:
 
 ```bash
-# Optional: Override default service key (defaults to "frontend")
-SAFE_CONFIG_FRONTEND_KEY=frontend
-
 # Existing required variables
 SAFE_CONFIG_BASE_URI=https://safe-config.safe.global/
 ```
@@ -44,16 +41,16 @@ yarn start:dev
 
 ### 4. Test the New Endpoints
 
-**Get all chains (v2)**:
+**Get all chains (v2)** (service key in URL path):
 
 ```bash
-curl http://localhost:3000/v2/chains
+curl http://localhost:3000/v2/chains/WALLET_WEB
 ```
 
 **Get single chain (v2)**:
 
 ```bash
-curl http://localhost:3000/v2/chains/1
+curl http://localhost:3000/v2/chains/WALLET_WEB/1
 ```
 
 **Compare with v1** (should still work unchanged):
@@ -94,7 +91,7 @@ yarn test:integration --testPathPattern=chains.v2
 
 ## Key Implementation Notes
 
-1. **Service Key**: Configured via `SAFE_CONFIG_FRONTEND_KEY` env var, defaults to `"frontend"`
+1. **Service Key**: Passed as URL path parameter (e.g. `/v2/chains/WALLET_WEB` or `/v2/chains/WALLET_WEB/1`)
 
 2. **Cache Isolation**: v2 endpoints use separate cache keys (`chains_v2_{serviceKey}`) to prevent pollution
 
@@ -124,8 +121,9 @@ docker-compose exec redis redis-cli FLUSHALL
 
 Ensure the service key is registered in Config Service. Common values:
 
-- `frontend` (default)
-- `cgw`
+- `WALLET_WEB`
+- `MOBILE`
+- `CGW`
 
 ## API Documentation
 

--- a/specs/001-service-aware-config/research.md
+++ b/specs/001-service-aware-config/research.md
@@ -22,20 +22,20 @@
 
 ### 2. Service Key Configuration Pattern
 
-**Task**: Determine how to configure the service key in CGW.
+**Task**: Determine how to pass the service key to v2 endpoints.
 
-**Decision**: Add `safeConfig.serviceKey` configuration with environment variable `SAFE_CONFIG_FRONTEND_KEY`, defaulting to `"frontend"`.
+**Decision**: Accept `serviceKey` as a URL path parameter (e.g. `/v2/chains/WALLET_WEB`, `/v2/chains/WALLET_WEB/1`).
 
 **Rationale**:
 
-- Follows existing configuration patterns in `configuration.ts`
-- Environment variable allows runtime configuration without code changes
-- Default "frontend" per spec requirements (FR-005)
+- Allows different clients to request different service-scoped configs in the same CGW instance
+- No configuration needed - each request is self-describing
+- Aligns with Config Service v2 API structure
 
 **Alternatives considered**:
 
-- Feature flag approach - Rejected: Service key is a required parameter, not optional behavior
-- Per-request header - Rejected: Spec requires CGW-level configuration, not per-request
+- Environment variable `SAFE_CONFIG_FRONTEND_KEY` - Rejected: Single key per CGW instance, limits flexibility
+- Per-request header - Rejected: Path parameter is more explicit and RESTful
 
 ### 3. Cache Key Strategy for v2 Endpoints
 

--- a/specs/001-service-aware-config/spec.md
+++ b/specs/001-service-aware-config/spec.md
@@ -26,9 +26,9 @@ A new CGW v2 chains endpoint retrieves a list of all supported chains with confi
 
 **Acceptance Scenarios**:
 
-1. **Given** the CGW is configured with a service key (e.g., "frontend"), **When** a request is made to the new v2 chains endpoint, **Then** the CGW fetches chain data from the Config Service v2 endpoint using that service key and returns the scoped chain list.
+1. **Given** a request to `/v2/chains/{serviceKey}` (e.g. `WALLET_WEB`), **When** the request is processed, **Then** the CGW fetches chain data from the Config Service v2 endpoint using that service key and returns the scoped chain list.
 
-2. **Given** the CGW is configured with a service key, **When** the Config Service v2 endpoint is unavailable, **Then** the new v2 CGW endpoint handles the error gracefully and returns an appropriate error response.
+2. **Given** a request to the v2 chains endpoint, **When** the Config Service v2 endpoint is unavailable, **Then** the new v2 CGW endpoint handles the error gracefully and returns an appropriate error response.
 
 3. **Given** a request is made to the new v2 chains endpoint, **Then** the response structure is compatible with the existing v1 chains endpoint format (same Chain entity schema).
 
@@ -46,7 +46,7 @@ A new CGW v2 single-chain endpoint retrieves configuration for a specific chain 
 
 **Acceptance Scenarios**:
 
-1. **Given** the CGW is configured with a service key, **When** a request is made to the new v2 chain endpoint for a specific chain (e.g., chainId "1"), **Then** the CGW fetches that chain's data from Config Service `GET /api/v2/chains/{service_key}/{chain_id}/` and returns the scoped configuration.
+1. **Given** a request to `/v2/chains/{serviceKey}/1`, **When** the request is processed, **Then** the CGW fetches that chain's data from Config Service `GET /api/v2/chains/{service_key}/{chain_id}/` and returns the scoped configuration.
 
 2. **Given** a request is made to the new v2 chain endpoint for a non-existent chain, **Then** the CGW returns a 404 error.
 
@@ -56,21 +56,21 @@ A new CGW v2 single-chain endpoint retrieves configuration for a specific chain 
 
 ---
 
-### User Story 3 - Configurable Service Key (Priority: P2)
+### User Story 3 - Service Key via URL (Priority: P2)
 
-Operators can configure which service key the CGW uses when communicating with the Config Service. This allows flexibility in deployment scenarios where the CGW might serve different contexts.
+Clients pass the service key as a URL path parameter when requesting v2 chain data. This allows different clients to request different service-scoped configs from the same CGW instance without configuration.
 
-**Why this priority**: Important for operational flexibility but has a reasonable default ("frontend" per user requirements).
+**Why this priority**: Enables per-request service scoping without deployment-level configuration.
 
-**Independent Test**: Can be tested by deploying with different service key configurations and verifying the correct endpoints are called.
+**Independent Test**: Request `/v2/chains/WALLET_WEB` and verify Config Service is called with WALLET_WEB.
 
 **Acceptance Scenarios**:
 
-1. **Given** no service key is explicitly configured, **When** the CGW starts, **Then** it uses "frontend" as the default service key.
+1. **Given** a request to `/v2/chains/{serviceKey}`, **When** the request is processed, **Then** the CGW calls Config Service v2 with that service key.
 
-2. **Given** a custom service key is configured via environment variable, **When** the CGW starts, **Then** it uses the configured service key for all Config Service v2 calls.
+2. **Given** a request to `/v2/chains/{serviceKey}/{chainId}`, **When** the request is processed, **Then** the CGW calls Config Service v2 with that service key and chain ID.
 
-3. **Given** the service key configuration is changed, **When** the cache is invalidated, **Then** subsequent requests use the new service key.
+3. **Given** different service keys in the URL, **When** requests are made, **Then** each uses its own cache namespace (no cross-service pollution).
 
 ---
 
@@ -102,9 +102,9 @@ When chain configurations are updated in the Config Service, the CGW's cached da
 
 ### Functional Requirements
 
-- **FR-001**: System MUST expose `GET /v2/chains` endpoint that fetches data from Config Service v2 `GET /api/v2/chains/{service_key}/` using the configured service key.
+- **FR-001**: System MUST expose `GET /v2/chains/:service_key` endpoint that fetches data from Config Service v2 `GET /api/v2/chains/{service_key}/` using the configured service key.
 
-- **FR-002**: System MUST expose `GET /v2/chains/:chainId` endpoint that fetches data from Config Service v2 `GET /api/v2/chains/{service_key}/{chain_id}/` using the configured service key.
+- **FR-002**: System MUST expose `GET /v2/chains/:service_key/:chainId` endpoint that fetches data from Config Service v2 `GET /api/v2/chains/{service_key}/{chain_id}/` using the configured service key.
 
 - **FR-002a**: Other chain-related endpoints (`/about`, `/about/backbone`, `/about/master-copies`, `/about/indexing`) do NOT require v2 versions as they fetch data from Transaction Service, not Config Service.
 

--- a/specs/001-service-aware-config/tasks.md
+++ b/specs/001-service-aware-config/tasks.md
@@ -100,19 +100,20 @@
 
 ---
 
-## Phase 5: User Story 3 - Configurable Service Key (Priority: P2)
+## Phase 5: User Story 3 - Service Key via URL (Priority: P2)
 
-**Goal**: Operators can configure the service key via `SAFE_CONFIG_FRONTEND_KEY` environment variable
+**Goal**: Service key passed as URL path parameter (e.g. `/v2/chains/WALLET_WEB`, `/v2/chains/WALLET_WEB/1`)
 
-**Independent Test**: Set `SAFE_CONFIG_FRONTEND_KEY=custom` and verify v2 endpoints call Config Service with "custom" service key
+**Independent Test**: Request `/v2/chains/WALLET_WEB` and verify Config Service is called with WALLET_WEB
 
 ### Implementation for User Story 3
 
-- [x] T030 [US3] Add configuration validation test for `safeConfig.serviceKey` in `src/config/configuration.validator.spec.ts`
-- [ ] T031 [US3] Update `.env.sample` with `SAFE_CONFIG_FRONTEND_KEY` documentation
-- [x] T032 [US3] Add integration test verifying service key is used in Config Service v2 calls in `src/modules/chains/routes/v2/chains.v2.controller.integration.spec.ts`
+- [x] T030 [US3] Add configuration validation test for `safeConfig.serviceKey` in `src/config/configuration.validator.spec.ts` (obsolete: removed config, tests removed)
+- [x] T031 [US3] ~~Update `.env.sample` with `SAFE_CONFIG_FRONTEND_KEY`~~ Obsolete: service key now from URL, removed from .env
+- [x] T032 [US3] Add integration test verifying service key from URL is used in Config Service v2 calls in `src/modules/chains/routes/v2/chains.v2.controller.integration.spec.ts`
+- [x] T031b [US3] Migrate v2 chains endpoints to accept serviceKey as URL param; remove SAFE_CONFIG_FRONTEND_KEY
 
-**Checkpoint**: User Story 3 complete - service key is configurable and validated
+**Checkpoint**: User Story 3 complete - service key comes from URL
 
 ---
 

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -439,35 +439,4 @@ describe('Configuration validator', () => {
       });
     });
   });
-
-  describe('SAFE_CONFIG_FRONTEND_KEY', () => {
-    it('should accept valid service key', () => {
-      const config = {
-        ...validConfiguration,
-        SAFE_CONFIG_FRONTEND_KEY: 'frontend',
-      };
-      expect(() =>
-        configurationValidator(config, RootConfigurationSchema),
-      ).not.toThrow();
-    });
-
-    it('should accept custom service key', () => {
-      const config = {
-        ...validConfiguration,
-        SAFE_CONFIG_FRONTEND_KEY: 'cgw',
-      };
-      expect(() =>
-        configurationValidator(config, RootConfigurationSchema),
-      ).not.toThrow();
-    });
-
-    it('should be optional (defaults to "frontend")', () => {
-      const configWithoutKey = omit(validConfiguration, [
-        'SAFE_CONFIG_FRONTEND_KEY',
-      ]);
-      expect(() =>
-        configurationValidator(configWithoutKey, RootConfigurationSchema),
-      ).not.toThrow();
-    });
-  });
 });

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -338,7 +338,6 @@ export default (): ReturnType<typeof configuration> => ({
     safes: {
       maxSequentialPages: faker.number.int(),
     },
-    serviceKey: 'frontend',
   },
   safeDataDecoder: {
     baseUri: faker.internet.url({ appendSlash: false }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -484,7 +484,6 @@ export default () => ({
         process.env.SAFE_CONFIG_SAFES_MAX_SEQUENTIAL_PAGES ?? `${10}`,
       ),
     },
-    serviceKey: process.env.SAFE_CONFIG_FRONTEND_KEY || 'frontend',
   },
   safeDataDecoder: {
     baseUri:

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -55,7 +55,6 @@ export const RootConfigurationSchema = z
       .int()
       .min(1)
       .optional(),
-    SAFE_CONFIG_FRONTEND_KEY: z.string().optional(),
     LOG_LEVEL: z
       .enum(['error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly'])
       .optional(),

--- a/src/modules/chains/domain/chains.repository.interface.ts
+++ b/src/modules/chains/domain/chains.repository.interface.ts
@@ -35,26 +35,33 @@ export interface IChainsRepository {
    * Gets a collection of {@link Chain} in a paginated format using Config Service v2
    * with service-scoped feature configuration
    *
+   * @param serviceKey - the service key for scoping chain features
    * @param limit - the amount of chains to retrieve per {@link Page}
    * @param offset - the starting point for the pagination
    */
-  getChainsV2(limit?: number, offset?: number): Promise<Page<Chain>>;
+  getChainsV2(
+    serviceKey: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Chain>>;
 
   /**
    * Gets the {@link Chain} associated with {@link chainId} using Config Service v2
    * with service-scoped feature configuration
    *
+   * @param serviceKey - the service key for scoping chain features
    * @param chainId
    */
-  getChainV2(chainId: string): Promise<Chain>;
+  getChainV2(serviceKey: string, chainId: string): Promise<Chain>;
 
   /**
    * Triggers the removal of the v2 chain data stored in the DataSource (e.g. cache)
    * for a specific service key
    *
    * @param chainId
+   * @param serviceKey
    */
-  clearChainV2(chainId: string, serviceKey?: string): Promise<void>;
+  clearChainV2(chainId: string, serviceKey: string): Promise<void>;
 
   /**
    * Gets the supported {@link Singleton} associated with {@link chainId}

--- a/src/modules/chains/domain/chains.repository.spec.ts
+++ b/src/modules/chains/domain/chains.repository.spec.ts
@@ -50,7 +50,6 @@ describe('ChainsRepository', () => {
     mockConfigurationService.getOrThrow.mockImplementation((key) => {
       if (key === 'safeConfig.chains.maxSequentialPages')
         return maxSequentialPages;
-      if (key === 'safeConfig.serviceKey') return 'frontend';
     });
 
     target = new ChainsRepository(
@@ -313,6 +312,8 @@ describe('ChainsRepository', () => {
   });
 
   describe('V2 API methods', () => {
+    const serviceKey = 'WALLET_WEB';
+
     it('should return chains from v2 endpoint', async () => {
       const limit = faker.number.int({ max: 10 });
       const offset = faker.number.int({ max: 10 });
@@ -327,7 +328,7 @@ describe('ChainsRepository', () => {
       );
       mockConfigApi.getChainsV2.mockResolvedValueOnce(page);
 
-      const result = await target.getChainsV2(limit, offset);
+      const result = await target.getChainsV2(serviceKey, limit, offset);
 
       expect(result.count).toBe(chains.length);
       expect(result.results).toHaveLength(chains.length);
@@ -346,7 +347,7 @@ describe('ChainsRepository', () => {
       expect(result.next).toBeNull();
       expect(result.previous).toBeNull();
       expect(mockConfigApi.getChainsV2).toHaveBeenCalledTimes(1);
-      expect(mockConfigApi.getChainsV2).toHaveBeenCalledWith('frontend', {
+      expect(mockConfigApi.getChainsV2).toHaveBeenCalledWith(serviceKey, {
         limit,
         offset,
       });
@@ -358,7 +359,7 @@ describe('ChainsRepository', () => {
       const rawChain = rawify(chain);
       mockConfigApi.getChainV2.mockResolvedValueOnce(rawChain);
 
-      const result = await target.getChainV2(chainId);
+      const result = await target.getChainV2(serviceKey, chainId);
 
       expect(result).toStrictEqual({
         ...chain,
@@ -368,7 +369,7 @@ describe('ChainsRepository', () => {
       });
       expect(mockConfigApi.getChainV2).toHaveBeenCalledTimes(1);
       expect(mockConfigApi.getChainV2).toHaveBeenCalledWith(
-        'frontend',
+        serviceKey,
         chainId,
       );
     });
@@ -377,11 +378,11 @@ describe('ChainsRepository', () => {
       const chainId = faker.string.numeric();
       mockConfigApi.clearChainV2.mockResolvedValueOnce(undefined);
 
-      await target.clearChainV2(chainId);
+      await target.clearChainV2(chainId, serviceKey);
 
       expect(mockConfigApi.clearChainV2).toHaveBeenCalledTimes(1);
       expect(mockConfigApi.clearChainV2).toHaveBeenCalledWith(
-        'frontend',
+        serviceKey,
         chainId,
       );
     });

--- a/src/modules/chains/domain/chains.repository.ts
+++ b/src/modules/chains/domain/chains.repository.ts
@@ -27,7 +27,6 @@ export class ChainsRepository implements IChainsRepository {
   static readonly MAX_LIMIT = 40;
 
   private readonly maxSequentialPages: number;
-  private readonly serviceKey: string;
 
   constructor(
     @Inject(LoggingService) private readonly loggingService: ILoggingService,
@@ -39,9 +38,6 @@ export class ChainsRepository implements IChainsRepository {
   ) {
     this.maxSequentialPages = this.configurationService.getOrThrow<number>(
       'safeConfig.chains.maxSequentialPages',
-    );
-    this.serviceKey = this.configurationService.getOrThrow<string>(
-      'safeConfig.serviceKey',
     );
   }
 
@@ -68,9 +64,13 @@ export class ChainsRepository implements IChainsRepository {
     return valid;
   }
 
-  async getChainsV2(limit?: number, offset?: number): Promise<Page<Chain>> {
+  async getChainsV2(
+    serviceKey: string,
+    limit?: number,
+    offset?: number,
+  ): Promise<Page<Chain>> {
     const page = await this.configApi
-      .getChainsV2(this.serviceKey, { limit, offset })
+      .getChainsV2(serviceKey, { limit, offset })
       .then(LenientBasePageSchema.parse);
     const valid = ChainLenientPageSchema.parse(page);
     if (valid.results.length < page.results.length) {
@@ -82,13 +82,13 @@ export class ChainsRepository implements IChainsRepository {
     return valid;
   }
 
-  async getChainV2(chainId: string): Promise<Chain> {
-    const chain = await this.configApi.getChainV2(this.serviceKey, chainId);
+  async getChainV2(serviceKey: string, chainId: string): Promise<Chain> {
+    const chain = await this.configApi.getChainV2(serviceKey, chainId);
     return ChainSchema.parse(chain);
   }
 
-  async clearChainV2(chainId: string, serviceKey?: string): Promise<void> {
-    return this.configApi.clearChainV2(serviceKey ?? this.serviceKey, chainId);
+  async clearChainV2(chainId: string, serviceKey: string): Promise<void> {
+    return this.configApi.clearChainV2(serviceKey, chainId);
   }
 
   async getAllChains(): Promise<Array<Chain>> {

--- a/src/modules/chains/routes/v2/chains.v2.controller.ts
+++ b/src/modules/chains/routes/v2/chains.v2.controller.ts
@@ -20,12 +20,49 @@ import { PaginationData } from '@/routes/common/pagination/pagination.data';
   version: '2',
 })
 export class ChainsV2Controller {
-  constructor(private readonly chainsV2Service: ChainsV2Service) {}
+  constructor(private readonly chainsV2Service: ChainsV2Service) { }
+
+  @ApiOperation({
+    summary: 'Get chain details (v2)',
+    description:
+      'Retrieves detailed information about a specific blockchain network, with features scoped to the service key.',
+  })
+  @ApiParam({
+    name: 'serviceKey',
+    type: 'string',
+    description:
+      'Service key for scoping chain features (e.g., WALLET_WEB, MOBILE)',
+    example: 'WALLET_WEB',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID of the blockchain network',
+    example: '1',
+  })
+  @ApiOkResponse({
+    type: Chain,
+    description: 'Chain details with service-scoped features',
+  })
+  @Get(':serviceKey/:chainId')
+  async getChain(
+    @Param('serviceKey') serviceKey: string,
+    @Param('chainId') chainId: string,
+  ): Promise<Chain> {
+    return this.chainsV2Service.getChain(serviceKey, chainId);
+  }
 
   @ApiOperation({
     summary: 'Get supported chains (v2)',
     description:
-      'Retrieves a paginated list of all blockchain networks supported by the Safe infrastructure, with features scoped to the configured service key (e.g., "frontend").',
+      'Retrieves a paginated list of all blockchain networks supported by the Safe infrastructure, with features scoped to the service key.',
+  })
+  @ApiParam({
+    name: 'serviceKey',
+    type: 'string',
+    description:
+      'Service key for scoping chain features (e.g., WALLET_WEB, MOBILE)',
+    example: 'WALLET_WEB',
   })
   @ApiQuery({
     name: 'cursor',
@@ -38,31 +75,12 @@ export class ChainsV2Controller {
     description:
       'Paginated list of supported chains with service-scoped features',
   })
-  @Get()
+  @Get(':serviceKey')
   async getChains(
+    @Param('serviceKey') serviceKey: string,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
   ): Promise<Page<Chain>> {
-    return this.chainsV2Service.getChains(routeUrl, paginationData);
-  }
-
-  @ApiOperation({
-    summary: 'Get chain details (v2)',
-    description:
-      'Retrieves detailed information about a specific blockchain network, with features scoped to the configured service key.',
-  })
-  @ApiParam({
-    name: 'chainId',
-    type: 'string',
-    description: 'Chain ID of the blockchain network',
-    example: '1',
-  })
-  @ApiOkResponse({
-    type: Chain,
-    description: 'Chain details with service-scoped features',
-  })
-  @Get('/:chainId')
-  async getChain(@Param('chainId') chainId: string): Promise<Chain> {
-    return this.chainsV2Service.getChain(chainId);
+    return this.chainsV2Service.getChains(serviceKey, routeUrl, paginationData);
   }
 }

--- a/src/modules/chains/routes/v2/chains.v2.controller.ts
+++ b/src/modules/chains/routes/v2/chains.v2.controller.ts
@@ -20,7 +20,7 @@ import { PaginationData } from '@/routes/common/pagination/pagination.data';
   version: '2',
 })
 export class ChainsV2Controller {
-  constructor(private readonly chainsV2Service: ChainsV2Service) { }
+  constructor(private readonly chainsV2Service: ChainsV2Service) {}
 
   @ApiOperation({
     summary: 'Get chain details (v2)',

--- a/src/modules/chains/routes/v2/chains.v2.service.spec.ts
+++ b/src/modules/chains/routes/v2/chains.v2.service.spec.ts
@@ -24,7 +24,8 @@ describe('ChainsV2Service', () => {
 
   describe('getChains', () => {
     it('should return paginated chains with cursor URLs', async () => {
-      const routeUrl = new URL('https://example.com/v2/chains');
+      const serviceKey = 'WALLET_WEB';
+      const routeUrl = new URL(`https://example.com/v2/chains/${serviceKey}`);
       const limit = 10;
       const offset = 0;
       const chains = [
@@ -36,14 +37,17 @@ describe('ChainsV2Service', () => {
         .with('count', chains.length)
         .with(
           'next',
-          `https://config.example.com/api/v2/chains/frontend?limit=${limit}&offset=${limit}`,
+          `https://config.example.com/api/v2/chains/${serviceKey}?limit=${limit}&offset=${limit}`,
         )
         .with('previous', null)
         .build();
 
       mockChainsRepository.getChainsV2.mockResolvedValue(domainPage);
 
-      const result = await service.getChains(routeUrl, { limit, offset });
+      const result = await service.getChains(serviceKey, routeUrl, {
+        limit,
+        offset,
+      });
 
       expect(result.count).toBe(chains.length);
       expect(result.results).toHaveLength(2);
@@ -53,13 +57,15 @@ describe('ChainsV2Service', () => {
       expect(result.next).toContain('cursor=');
       expect(result.previous).toBeNull();
       expect(mockChainsRepository.getChainsV2).toHaveBeenCalledWith(
+        serviceKey,
         limit,
         offset,
       );
     });
 
     it('should handle chains with ENS registry addresses', async () => {
-      const routeUrl = new URL('https://example.com/v2/chains');
+      const serviceKey = 'WALLET_WEB';
+      const routeUrl = new URL(`https://example.com/v2/chains/${serviceKey}`);
       const chain = chainBuilder()
         .with('chainId', '1')
         .with('ensRegistryAddress', faker.finance.ethereumAddress() as Address)
@@ -73,7 +79,7 @@ describe('ChainsV2Service', () => {
 
       mockChainsRepository.getChainsV2.mockResolvedValue(domainPage);
 
-      const result = await service.getChains(routeUrl, {
+      const result = await service.getChains(serviceKey, routeUrl, {
         limit: 10,
         offset: 0,
       });
@@ -88,18 +94,23 @@ describe('ChainsV2Service', () => {
 
   describe('getChain', () => {
     it('should return single chain', async () => {
+      const serviceKey = 'WALLET_WEB';
       const chainId = '1';
       const chain = chainBuilder().with('chainId', chainId).build();
 
       mockChainsRepository.getChainV2.mockResolvedValue(chain);
 
-      const result = await service.getChain(chainId);
+      const result = await service.getChain(serviceKey, chainId);
 
       expect(result.chainId).toBe(chainId);
-      expect(mockChainsRepository.getChainV2).toHaveBeenCalledWith(chainId);
+      expect(mockChainsRepository.getChainV2).toHaveBeenCalledWith(
+        serviceKey,
+        chainId,
+      );
     });
 
     it('should handle chain with ENS registry address', async () => {
+      const serviceKey = 'WALLET_WEB';
       const chainId = '1';
       const ensAddress = faker.finance.ethereumAddress() as Address;
       const chain = chainBuilder()
@@ -109,7 +120,7 @@ describe('ChainsV2Service', () => {
 
       mockChainsRepository.getChainV2.mockResolvedValue(chain);
 
-      const result = await service.getChain(chainId);
+      const result = await service.getChain(serviceKey, chainId);
 
       if (chain.ensRegistryAddress) {
         expect(result.ensRegistryAddress?.toLowerCase()).toBe(

--- a/src/modules/chains/routes/v2/chains.v2.service.ts
+++ b/src/modules/chains/routes/v2/chains.v2.service.ts
@@ -12,7 +12,7 @@ export class ChainsV2Service {
   constructor(
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
-  ) { }
+  ) {}
 
   async getChains(
     serviceKey: string,

--- a/src/modules/chains/routes/v2/chains.v2.service.ts
+++ b/src/modules/chains/routes/v2/chains.v2.service.ts
@@ -12,13 +12,15 @@ export class ChainsV2Service {
   constructor(
     @Inject(IChainsRepository)
     private readonly chainsRepository: IChainsRepository,
-  ) {}
+  ) { }
 
   async getChains(
+    serviceKey: string,
     routeUrl: Readonly<URL>,
     paginationData: PaginationData,
   ): Promise<Page<Chain>> {
     const result = await this.chainsRepository.getChainsV2(
+      serviceKey,
       paginationData.limit,
       paginationData.offset,
     );
@@ -38,8 +40,8 @@ export class ChainsV2Service {
     };
   }
 
-  async getChain(chainId: string): Promise<Chain> {
-    const result = await this.chainsRepository.getChainV2(chainId);
+  async getChain(serviceKey: string, chainId: string): Promise<Chain> {
+    const result = await this.chainsRepository.getChainV2(serviceKey, chainId);
     return new Chain(result);
   }
 }

--- a/src/modules/hooks/domain/helpers/event-cache.helper.ts
+++ b/src/modules/hooks/domain/helpers/event-cache.helper.ts
@@ -519,7 +519,10 @@ export class EventCacheHelper {
     return [
       Promise.all([
         this.chainsRepository.clearChain(event.chainId),
-        this.chainsRepository.clearChainV2(event.chainId, event.service),
+        this.chainsRepository.clearChainV2(
+          event.chainId,
+          event.service ?? 'WALLET_WEB',
+        ),
       ]).then(() => {
         // RPC may have changed
         this.blockchainRepository.clearApi(event.chainId);
@@ -550,9 +553,9 @@ export class EventCacheHelper {
       Event,
       {
         type:
-          | TransactionEventType.NEW_DELEGATE
-          | TransactionEventType.UPDATED_DELEGATE
-          | TransactionEventType.DELETED_DELEGATE;
+        | TransactionEventType.NEW_DELEGATE
+        | TransactionEventType.UPDATED_DELEGATE
+        | TransactionEventType.DELETED_DELEGATE;
       }
     >,
   ): Array<Promise<void>> {
@@ -571,10 +574,10 @@ export class EventCacheHelper {
       Event,
       {
         type:
-          | TransactionEventType.PENDING_MULTISIG_TRANSACTION
-          | TransactionEventType.DELETED_MULTISIG_TRANSACTION
-          | TransactionEventType.EXECUTED_MULTISIG_TRANSACTION
-          | TransactionEventType.NEW_CONFIRMATION;
+        | TransactionEventType.PENDING_MULTISIG_TRANSACTION
+        | TransactionEventType.DELETED_MULTISIG_TRANSACTION
+        | TransactionEventType.EXECUTED_MULTISIG_TRANSACTION
+        | TransactionEventType.NEW_CONFIRMATION;
       }
     >,
   ): void {
@@ -592,11 +595,11 @@ export class EventCacheHelper {
       Event,
       {
         type:
-          | TransactionEventType.MODULE_TRANSACTION
-          | TransactionEventType.INCOMING_ETHER
-          | TransactionEventType.OUTGOING_ETHER
-          | TransactionEventType.INCOMING_TOKEN
-          | TransactionEventType.OUTGOING_TOKEN;
+        | TransactionEventType.MODULE_TRANSACTION
+        | TransactionEventType.INCOMING_ETHER
+        | TransactionEventType.OUTGOING_ETHER
+        | TransactionEventType.INCOMING_TOKEN
+        | TransactionEventType.OUTGOING_TOKEN;
       }
     >,
   ): void {
@@ -614,8 +617,8 @@ export class EventCacheHelper {
       Event,
       {
         type:
-          | TransactionEventType.MESSAGE_CREATED
-          | TransactionEventType.MESSAGE_CONFIRMATION;
+        | TransactionEventType.MESSAGE_CREATED
+        | TransactionEventType.MESSAGE_CONFIRMATION;
       }
     >,
   ): void {

--- a/src/modules/hooks/domain/helpers/event-cache.helper.ts
+++ b/src/modules/hooks/domain/helpers/event-cache.helper.ts
@@ -553,9 +553,9 @@ export class EventCacheHelper {
       Event,
       {
         type:
-        | TransactionEventType.NEW_DELEGATE
-        | TransactionEventType.UPDATED_DELEGATE
-        | TransactionEventType.DELETED_DELEGATE;
+          | TransactionEventType.NEW_DELEGATE
+          | TransactionEventType.UPDATED_DELEGATE
+          | TransactionEventType.DELETED_DELEGATE;
       }
     >,
   ): Array<Promise<void>> {
@@ -574,10 +574,10 @@ export class EventCacheHelper {
       Event,
       {
         type:
-        | TransactionEventType.PENDING_MULTISIG_TRANSACTION
-        | TransactionEventType.DELETED_MULTISIG_TRANSACTION
-        | TransactionEventType.EXECUTED_MULTISIG_TRANSACTION
-        | TransactionEventType.NEW_CONFIRMATION;
+          | TransactionEventType.PENDING_MULTISIG_TRANSACTION
+          | TransactionEventType.DELETED_MULTISIG_TRANSACTION
+          | TransactionEventType.EXECUTED_MULTISIG_TRANSACTION
+          | TransactionEventType.NEW_CONFIRMATION;
       }
     >,
   ): void {
@@ -595,11 +595,11 @@ export class EventCacheHelper {
       Event,
       {
         type:
-        | TransactionEventType.MODULE_TRANSACTION
-        | TransactionEventType.INCOMING_ETHER
-        | TransactionEventType.OUTGOING_ETHER
-        | TransactionEventType.INCOMING_TOKEN
-        | TransactionEventType.OUTGOING_TOKEN;
+          | TransactionEventType.MODULE_TRANSACTION
+          | TransactionEventType.INCOMING_ETHER
+          | TransactionEventType.OUTGOING_ETHER
+          | TransactionEventType.INCOMING_TOKEN
+          | TransactionEventType.OUTGOING_TOKEN;
       }
     >,
   ): void {
@@ -617,8 +617,8 @@ export class EventCacheHelper {
       Event,
       {
         type:
-        | TransactionEventType.MESSAGE_CREATED
-        | TransactionEventType.MESSAGE_CONFIRMATION;
+          | TransactionEventType.MESSAGE_CREATED
+          | TransactionEventType.MESSAGE_CONFIRMATION;
       }
     >,
   ): void {

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -743,9 +743,7 @@ describe('Hook Events for Cache', () => {
     },
   ])('$type clears v2 chain cache', async (payload) => {
     const chain = chainBuilder().build();
-    const serviceKey = configurationService.getOrThrow<string>(
-      'safeConfig.serviceKey',
-    );
+    const serviceKey = 'WALLET_WEB';
     const cacheDir = new CacheDir(
       `${chain.chainId}_chain_v2_${serviceKey}`,
       '',
@@ -782,9 +780,7 @@ describe('Hook Events for Cache', () => {
     },
   ])('$type clears v2 chains list cache', async (payload) => {
     const chain = chainBuilder().build();
-    const serviceKey = configurationService.getOrThrow<string>(
-      'safeConfig.serviceKey',
-    );
+    const serviceKey = 'WALLET_WEB';
     const cacheDir = new CacheDir(`chains_v2_${serviceKey}`, '');
     await fakeCacheService.hSet(
       cacheDir,


### PR DESCRIPTION
## Summary

Chains v2 endpoints now accept `serviceKey` as a URL path parameter instead of reading it from configuration (`SAFE_CONFIG_FRONTEND_KEY`).

## Motivation

Using the same endpoint for web and mobile, with each client passing its own service key, allows service-aware feature flags to be evaluated per client. Web can use e.g. `WALLET_WEB`, mobile another key, without separate CGW deployments.

## Updates for new v2 endpoints (still WIP)

> Note: This change is only applied to the new endpoints, that are still under development in #2905. It's not a breaking change as no production code is affected.

| Before                      | After                              |
|-----------------------------|------------------------------------|
| `GET /v2/chains`            | `GET /v2/chains/{serviceKey}`      |
| `GET /v2/chains/{chainId}`  | `GET /v2/chains/{serviceKey}/{chainId}` |

`SAFE_CONFIG_FRONTEND_KEY` has been removed.