### PR TITLE
Refactor/performanceImprovements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,15 @@ Before creating **EACH** commit, you MUST run the following commands in sequence
 
    If there are any remaining lint errors, fix them manually before proceeding.
 
-3. **Run tests:**
+3. **Validate environment configuration:**
+
+   ```bash
+   yarn env:validate
+   ```
+
+   **Stop immediately if this fails.** It means the configuration schema is broken and must be fixed before proceeding.
+
+4. **Run tests:**
 
    ```bash
    yarn test
@@ -59,12 +67,23 @@ The correct workflow for making commits is:
 # 2. Run quality checks
 yarn format
 yarn lint --fix
+yarn env:validate  # STOP if this fails
 yarn test
 
 # 3. Only after all checks pass, commit
 git add <files>
 git commit -m "Your commit message"
 ```
+
+### Batch Related Changes
+
+When committing multiple files, **group related changes into logical commits** rather than committing all files at once or one file at a time. Each commit should represent a single coherent change:
+
+- Files that fix the same issue or implement the same feature go together
+- A source file and its corresponding test file go in the same commit
+- Unrelated changes get separate commits even if made at the same time
+
+For example, if you fix a bug in `encryption.ts`, update its test, and also fix an unrelated issue in `redis.cache.service.ts`, make two commits — not one and not three.
 
 ## License Headers
 
@@ -81,7 +100,7 @@ For `.md` files the hook uses a multi-line HTML comment style (`<!--| | -->`), s
 
 This is enforced by a `pre-commit` hook (`insert-license` from `Lucas-C/pre-commit-hooks`) and a `license-headers` CI job. The canonical header text lives in `LICENSE_HEADER.txt`.
 
-Every file you create or modify in a PR **MUST** have the correct license header. Add it yourself — do not rely on the pre-commit hook to do it for you. If the pre-commit hook adds it automatically, include that change in your commit.
+Every file you create or modify in a PR **MUST** have the correct license header. **Always add the license header yourself to every modified file** — do not rely on the pre-commit hook to do it for you. If the pre-commit hook adds it automatically, include that change in your commit.
 
 ## Important Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 <!--
   SPDX-License-Identifier: FSL-1.1-MIT
  -->
+
 Follow all instructions in AGENTS.md strictly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+<!--
+  SPDX-License-Identifier: FSL-1.1-MIT
+ -->
+Follow all instructions in AGENTS.md strictly.

--- a/src/datasources/cache/constants.ts
+++ b/src/datasources/cache/constants.ts
@@ -18,11 +18,3 @@ export const CacheKeyPrefix = Symbol('CacheKeyPrefix');
  * Ref: https://github.com/redis/redis/blob/cc244370a2d622d5d2fec5573ae87de6c59ed3b9/src/expire.c#L573
  */
 export const MAX_TTL = Number.MAX_SAFE_INTEGER - 1;
-
-/**
- * Maximum number of entries in the in-memory derived-key cache used by the
- * encryption utilities. Oldest entries are evicted (FIFO) once this limit
- * is reached, bounding memory usage while avoiding repeated scrypt calls for
- * frequently used (key, salt) pairs.
- */
-export const MAX_DERIVED_KEY_CACHE_SIZE = 50;

--- a/src/datasources/cache/constants.ts
+++ b/src/datasources/cache/constants.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 /**
  * The {@link CacheKeyPrefix} is meant to be used whenever a prefix should be added to the keys
  * registered in the cache.
@@ -17,3 +18,11 @@ export const CacheKeyPrefix = Symbol('CacheKeyPrefix');
  * Ref: https://github.com/redis/redis/blob/cc244370a2d622d5d2fec5573ae87de6c59ed3b9/src/expire.c#L573
  */
 export const MAX_TTL = Number.MAX_SAFE_INTEGER - 1;
+
+/**
+ * Maximum number of entries in the in-memory derived-key cache used by the
+ * encryption utilities. Oldest entries are evicted (FIFO) once this limit
+ * is reached, bounding memory usage while avoiding repeated scrypt calls for
+ * frequently used (key, salt) pairs.
+ */
+export const MAX_DERIVED_KEY_CACHE_SIZE = 50;

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -108,7 +108,7 @@ describe('RedisCacheService with a Key Prefix', () => {
     jest.useFakeTimers();
     const now = jest.now();
     const key = faker.string.alphanumeric();
-    multiMock.exec.mockResolvedValueOnce([1, 1, true]);
+    multiMock.exec.mockResolvedValueOnce([1, 1, 1]);
 
     await redisCacheService.deleteByKey(key);
 
@@ -129,16 +129,21 @@ describe('RedisCacheService with a Key Prefix', () => {
   });
 
   it('deleteByKey should return 0 if the pipeline unlink result is not a number', async () => {
-    multiMock.exec.mockResolvedValueOnce([
-      new Error('Pipeline error'),
-      1,
-      true,
-    ]);
+    multiMock.exec.mockResolvedValueOnce([new Error('Pipeline error'), 1, 1]);
 
     const result = await redisCacheService.deleteByKey(
       faker.string.alphanumeric(),
     );
 
     expect(result).toBe(0);
+  });
+
+  it('deleteByKey should throw if invalidation marker pipeline replies are invalid', async () => {
+    const key = faker.string.alphanumeric();
+    multiMock.exec.mockResolvedValueOnce([1, new Error('Pipeline error'), 1]);
+
+    await expect(redisCacheService.deleteByKey(key)).rejects.toThrow(
+      `Invalidation marker failed for key "${key}"`,
+    );
   });
 });

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -141,7 +141,7 @@ describe('RedisCacheService with a Key Prefix', () => {
     expect(result).toBe(0);
   });
 
-  it('deleteByKey should throw if invalidation marker pipeline replies are invalid', async () => {
+  it('deleteByKey should log if invalidation marker hSet reply is invalid', async () => {
     const key = faker.string.alphanumeric();
     multiMock.exec.mockResolvedValueOnce([
       1,
@@ -149,8 +149,41 @@ describe('RedisCacheService with a Key Prefix', () => {
       true,
     ]);
 
-    await expect(redisCacheService.deleteByKey(key)).rejects.toThrow(
-      `Invalidation marker failed for key "${key}"`,
+    const result = await redisCacheService.deleteByKey(key);
+
+    expect(result).toBe(1);
+    expect(mockLoggingService.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: `Invalidation marker failed for key "${key}"`,
+      }),
+    );
+  });
+
+  it('deleteByKey should log if expire returns an unexpected type', async () => {
+    const key = faker.string.alphanumeric();
+    multiMock.exec.mockResolvedValueOnce([1, 1, 'unexpected']);
+
+    const result = await redisCacheService.deleteByKey(key);
+
+    expect(result).toBe(1);
+    expect(mockLoggingService.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: `Invalidation marker failed for key "${key}"`,
+      }),
+    );
+  });
+
+  it('deleteByKey should log and return 0 if exec rejects', async () => {
+    const key = faker.string.alphanumeric();
+    multiMock.exec.mockRejectedValueOnce(new Error('Connection lost'));
+
+    const result = await redisCacheService.deleteByKey(key);
+
+    expect(result).toBe(0);
+    expect(mockLoggingService.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: `Invalidation pipeline failed for key "${key}"`,
+      }),
     );
   });
 });

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -108,7 +108,7 @@ describe('RedisCacheService with a Key Prefix', () => {
     jest.useFakeTimers();
     const now = jest.now();
     const key = faker.string.alphanumeric();
-    multiMock.exec.mockResolvedValueOnce([1, 1, 1]);
+    multiMock.exec.mockResolvedValueOnce([1, 1, true]);
 
     await redisCacheService.deleteByKey(key);
 
@@ -122,14 +122,13 @@ describe('RedisCacheService with a Key Prefix', () => {
     expect(multiMock.expire).toHaveBeenCalledWith(
       `${keyPrefix}-invalidationTimeMs:${key}`,
       defaultExpirationTimeInSeconds,
-      'NX',
     );
     expect(multiMock.exec).toHaveBeenCalled();
     jest.useRealTimers();
   });
 
   it('deleteByKey should return 0 if the pipeline unlink result is not a number', async () => {
-    multiMock.exec.mockResolvedValueOnce([new Error('Pipeline error'), 1, 1]);
+    multiMock.exec.mockResolvedValueOnce([new Error('Pipeline error'), 1, true]);
 
     const result = await redisCacheService.deleteByKey(
       faker.string.alphanumeric(),
@@ -140,7 +139,7 @@ describe('RedisCacheService with a Key Prefix', () => {
 
   it('deleteByKey should throw if invalidation marker pipeline replies are invalid', async () => {
     const key = faker.string.alphanumeric();
-    multiMock.exec.mockResolvedValueOnce([1, new Error('Pipeline error'), 1]);
+    multiMock.exec.mockResolvedValueOnce([1, new Error('Pipeline error'), true]);
 
     await expect(redisCacheService.deleteByKey(key)).rejects.toThrow(
       `Invalidation marker failed for key "${key}"`,

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -129,7 +129,11 @@ describe('RedisCacheService with a Key Prefix', () => {
   });
 
   it('deleteByKey should return 0 if the pipeline unlink result is not a number', async () => {
-    multiMock.exec.mockResolvedValueOnce([new Error('Pipeline error'), 1, true]);
+    multiMock.exec.mockResolvedValueOnce([
+      new Error('Pipeline error'),
+      1,
+      true,
+    ]);
 
     const result = await redisCacheService.deleteByKey(
       faker.string.alphanumeric(),

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -128,7 +128,11 @@ describe('RedisCacheService with a Key Prefix', () => {
   });
 
   it('deleteByKey should return 0 if the pipeline unlink result is not a number', async () => {
-    multiMock.exec.mockResolvedValueOnce([new Error('Pipeline error'), 1, true]);
+    multiMock.exec.mockResolvedValueOnce([
+      new Error('Pipeline error'),
+      1,
+      true,
+    ]);
 
     const result = await redisCacheService.deleteByKey(
       faker.string.alphanumeric(),
@@ -139,7 +143,11 @@ describe('RedisCacheService with a Key Prefix', () => {
 
   it('deleteByKey should throw if invalidation marker pipeline replies are invalid', async () => {
     const key = faker.string.alphanumeric();
-    multiMock.exec.mockResolvedValueOnce([1, new Error('Pipeline error'), true]);
+    multiMock.exec.mockResolvedValueOnce([
+      1,
+      new Error('Pipeline error'),
+      true,
+    ]);
 
     await expect(redisCacheService.deleteByKey(key)).rejects.toThrow(
       `Invalidation marker failed for key "${key}"`,

--- a/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
+++ b/src/datasources/cache/redis.cache.service.key-prefix.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { CacheDir } from '@/datasources/cache/entities/cache-dir.entity';
@@ -125,5 +126,15 @@ describe('RedisCacheService with a Key Prefix', () => {
     );
     expect(multiMock.exec).toHaveBeenCalled();
     jest.useRealTimers();
+  });
+
+  it('deleteByKey should return 0 if the pipeline unlink result is not a number', async () => {
+    multiMock.exec.mockResolvedValueOnce([new Error('Pipeline error'), 1, true]);
+
+    const result = await redisCacheService.deleteByKey(
+      faker.string.alphanumeric(),
+    );
+
+    expect(result).toBe(0);
   });
 });

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -98,6 +98,12 @@ export class RedisCacheService
     return await this.client.hGet(key, cacheDir.field);
   }
 
+  /**
+   * Deletes a cache key and writes an invalidation marker.
+   *
+   * @returns The number of keys removed, or 0 if the key did not exist
+   *   **or** the pipeline failed (failures are logged, not thrown).
+   */
   async deleteByKey(key: string): Promise<number> {
     const keyWithPrefix = this._prefixKey(key);
     const invalidationKey = this._prefixKey(`invalidationTimeMs:${key}`);

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -82,7 +82,13 @@ export class RedisCacheService
         source: 'RedisCacheService',
         event: `Error setting/expiring ${key}:${cacheDir.field}`,
       });
-      await this.client.unlink(key).catch(() => {});
+      await this.client.unlink(key).catch(() => {
+        this.loggingService.warn({
+          type: LogType.CacheError,
+          source: 'RedisCacheService',
+          event: `Cleanup unlink failed for ${key}`,
+        });
+      });
       throw error;
     }
   }
@@ -106,7 +112,14 @@ export class RedisCacheService
       .expire(invalidationKey, expirationTime, 'NX')
       .exec();
 
-    const unlinkResult = results[0];
+    const [unlinkResult, hSetResult, expireResult] = results;
+
+    // hSet returns the count of added fields (number), expire returns 0 or 1 (number).
+    // A non-number value (e.g. Error) indicates a pipeline command failure.
+    if (typeof hSetResult !== 'number' || typeof expireResult !== 'number') {
+      throw new Error(`Invalidation marker failed for key "${key}"`);
+    }
+
     return typeof unlinkResult === 'number' ? unlinkResult : 0;
   }
 

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { RedisClientType } from '@/datasources/cache/cache.module';
 import { ICacheService } from '@/datasources/cache/cache.service.interface';
@@ -105,7 +106,8 @@ export class RedisCacheService
       .expire(invalidationKey, expirationTime, 'NX')
       .exec();
 
-    return results[0] as unknown as number;
+    const unlinkResult = results[0];
+    return typeof unlinkResult === 'number' ? unlinkResult : 0;
   }
 
   async increment(

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -105,19 +105,33 @@ export class RedisCacheService
       this.defaultExpirationTimeInSeconds,
     );
 
-    const results = await this.client
-      .multi()
-      .unlink(keyWithPrefix)
-      .hSet(invalidationKey, '', Date.now().toString())
-      .expire(invalidationKey, expirationTime)
-      .exec();
+    let results: Array<unknown>;
+    try {
+      results = await this.client
+        .multi()
+        .unlink(keyWithPrefix)
+        .hSet(invalidationKey, '', Date.now().toString())
+        .expire(invalidationKey, expirationTime)
+        .exec();
+    } catch {
+      this.loggingService.error({
+        type: LogType.CacheError,
+        source: 'RedisCacheService',
+        event: `Invalidation pipeline failed for key "${key}"`,
+      });
+      return 0;
+    }
 
     const [unlinkResult, hSetResult, expireResult] = results;
 
     // hSet returns the count of added fields (number), expire returns boolean.
     // A mismatched type (e.g. Error) indicates a pipeline command failure.
     if (typeof hSetResult !== 'number' || typeof expireResult !== 'boolean') {
-      throw new Error(`Invalidation marker failed for key "${key}"`);
+      this.loggingService.error({
+        type: LogType.CacheError,
+        source: 'RedisCacheService',
+        event: `Invalidation marker failed for key "${key}"`,
+      });
     }
 
     return typeof unlinkResult === 'number' ? unlinkResult : 0;

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -109,14 +109,14 @@ export class RedisCacheService
       .multi()
       .unlink(keyWithPrefix)
       .hSet(invalidationKey, '', Date.now().toString())
-      .expire(invalidationKey, expirationTime, 'NX')
+      .expire(invalidationKey, expirationTime)
       .exec();
 
     const [unlinkResult, hSetResult, expireResult] = results;
 
-    // hSet returns the count of added fields (number), expire returns 0 or 1 (number).
-    // A non-number value (e.g. Error) indicates a pipeline command failure.
-    if (typeof hSetResult !== 'number' || typeof expireResult !== 'number') {
+    // hSet returns the count of added fields (number), expire returns boolean.
+    // A mismatched type (e.g. Error) indicates a pipeline command failure.
+    if (typeof hSetResult !== 'number' || typeof expireResult !== 'boolean') {
       throw new Error(`Invalidation marker failed for key "${key}"`);
     }
 

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -117,6 +117,8 @@ export class RedisCacheService
         .multi()
         .unlink(keyWithPrefix)
         .hSet(invalidationKey, '', Date.now().toString())
+        // No NX — refresh TTL on every invalidation so the marker persists
+        // for the full duration from the most recent delete, not the first.
         .expire(invalidationKey, expirationTime)
         .exec();
     } catch {

--- a/src/datasources/cache/redis.cache.service.ts
+++ b/src/datasources/cache/redis.cache.service.ts
@@ -82,7 +82,7 @@ export class RedisCacheService
         source: 'RedisCacheService',
         event: `Error setting/expiring ${key}:${cacheDir.field}`,
       });
-      await this.client.unlink(key);
+      await this.client.unlink(key).catch(() => {});
       throw error;
     }
   }

--- a/src/domain/common/utils/__tests__/encryption.spec.ts
+++ b/src/domain/common/utils/__tests__/encryption.spec.ts
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { encryptData, decryptData } from '@/domain/common/utils/encryption';
-import { MAX_DERIVED_KEY_CACHE_SIZE } from '@/datasources/cache/constants';
+import {
+  encryptData,
+  decryptData,
+  clearDerivedKeyCache,
+  MAX_DERIVED_KEY_CACHE_SIZE,
+} from '@/domain/common/utils/encryption';
 import { faker } from '@faker-js/faker/.';
 import { getAddress } from 'viem';
 
 describe('Encryption Utils', () => {
+  afterEach(() => {
+    clearDerivedKeyCache();
+  });
+
   const testKey = faker.string.alphanumeric();
   const testSalt = faker.string.alphanumeric();
   const testData = {

--- a/src/domain/common/utils/__tests__/encryption.spec.ts
+++ b/src/domain/common/utils/__tests__/encryption.spec.ts
@@ -4,6 +4,7 @@ import {
   decryptData,
   clearDerivedKeyCache,
   MAX_DERIVED_KEY_CACHE_SIZE,
+  DERIVED_KEY_MAX_AGE_MS,
 } from '@/domain/common/utils/encryption';
 import { faker } from '@faker-js/faker/.';
 import { getAddress } from 'viem';
@@ -196,6 +197,22 @@ describe('Encryption Utils', () => {
       expect(() => decryptData(encrypted2, 'a:b', 'c')).toThrow(
         'Failed to decrypt data',
       );
+    });
+
+    it('should re-derive key after TTL expiration', () => {
+      jest.useFakeTimers();
+      const data = { value: faker.string.alphanumeric() };
+      const key = faker.string.alphanumeric(16);
+      const salt = faker.string.alphanumeric(8);
+
+      const encrypted = encryptData(data, key, salt);
+
+      // Advance past the TTL so the cached entry expires
+      jest.advanceTimersByTime(DERIVED_KEY_MAX_AGE_MS + 1);
+
+      // Should still decrypt correctly by re-deriving the key
+      expect(decryptData(encrypted, key, salt)).toEqual(data);
+      jest.useRealTimers();
     });
 
     it('should still work correctly after cache eviction', () => {

--- a/src/domain/common/utils/__tests__/encryption.spec.ts
+++ b/src/domain/common/utils/__tests__/encryption.spec.ts
@@ -1,4 +1,6 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { encryptData, decryptData } from '@/domain/common/utils/encryption';
+import { MAX_DERIVED_KEY_CACHE_SIZE } from '@/datasources/cache/constants';
 import { faker } from '@faker-js/faker/.';
 import { getAddress } from 'viem';
 
@@ -166,6 +168,42 @@ describe('Encryption Utils', () => {
       expect(() => decryptData(encrypted, testKey, wrongSalt)).toThrow(
         'Failed to decrypt data',
       );
+    });
+  });
+
+  describe('cache behavior', () => {
+    it('should not collide cache keys for ambiguous (key, salt) pairs', () => {
+      const data = { value: faker.string.alphanumeric() };
+
+      // These two pairs produce the same naive "${key}:${salt}" cache key "a:b:c"
+      const encrypted1 = encryptData(data, 'a:b', 'c');
+      const encrypted2 = encryptData(data, 'a', 'b:c');
+
+      expect(decryptData(encrypted1, 'a:b', 'c')).toEqual(data);
+      expect(decryptData(encrypted2, 'a', 'b:c')).toEqual(data);
+
+      expect(() => decryptData(encrypted1, 'a', 'b:c')).toThrow(
+        'Failed to decrypt data',
+      );
+      expect(() => decryptData(encrypted2, 'a:b', 'c')).toThrow(
+        'Failed to decrypt data',
+      );
+    });
+
+    it('should still work correctly after cache eviction', () => {
+      const data = { value: faker.string.alphanumeric() };
+      const firstKey = faker.string.alphanumeric(16);
+      const firstSalt = faker.string.alphanumeric(8);
+
+      const encrypted = encryptData(data, firstKey, firstSalt);
+
+      // Overflow the cache with unique pairs to trigger eviction
+      for (let i = 0; i < MAX_DERIVED_KEY_CACHE_SIZE + 1; i++) {
+        encryptData(data, `eviction-key-${i}`, `eviction-salt-${i}`);
+      }
+
+      // firstKey/firstSalt entry was evicted; key must be re-derived on decrypt
+      expect(decryptData(encrypted, firstKey, firstSalt)).toEqual(data);
     });
   });
 

--- a/src/domain/common/utils/encryption.ts
+++ b/src/domain/common/utils/encryption.ts
@@ -6,24 +6,35 @@ import {
   scryptSync,
 } from 'crypto';
 export const MAX_DERIVED_KEY_CACHE_SIZE = 50;
-const derivedKeyCache = new Map<string, Buffer>();
+export const DERIVED_KEY_MAX_AGE_MS = 15 * 60 * 1000; // 15 minutes
+
+interface CachedKey {
+  key: Buffer;
+  createdAt: number;
+}
+
+const derivedKeyCache = new Map<string, CachedKey>();
 
 function getDerivedKey(encryptionKey: string, salt: string): Buffer {
   // Length-prefix the key to avoid collisions e.g. ("a:b","c") vs ("a","b:c")
   const cacheKey = `${encryptionKey.length}:${encryptionKey}:${salt}`;
   const cached = derivedKeyCache.get(cacheKey);
-  if (cached) {
+  if (cached && Date.now() - cached.createdAt < DERIVED_KEY_MAX_AGE_MS) {
     // Promote to end of Map for LRU eviction
     derivedKeyCache.delete(cacheKey);
     derivedKeyCache.set(cacheKey, cached);
-    return cached;
+    return cached.key;
+  }
+  // Remove stale entry if it expired
+  if (cached) {
+    derivedKeyCache.delete(cacheKey);
   }
   const derived = scryptSync(encryptionKey, Buffer.from(salt, 'utf8'), 32);
   if (derivedKeyCache.size >= MAX_DERIVED_KEY_CACHE_SIZE) {
     // Evict least recently used (first entry in insertion order)
     derivedKeyCache.delete(derivedKeyCache.keys().next().value!);
   }
-  derivedKeyCache.set(cacheKey, derived);
+  derivedKeyCache.set(cacheKey, { key: derived, createdAt: Date.now() });
   return derived;
 }
 

--- a/src/domain/common/utils/encryption.ts
+++ b/src/domain/common/utils/encryption.ts
@@ -1,21 +1,26 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import {
   createCipheriv,
   createDecipheriv,
   randomBytes,
   scryptSync,
 } from 'crypto';
+import { MAX_DERIVED_KEY_CACHE_SIZE } from '@/datasources/cache/constants';
 
 const derivedKeyCache = new Map<string, Buffer>();
 
 function getDerivedKey(encryptionKey: string, salt: string): Buffer {
-  const cacheKey = `${encryptionKey}:${salt}`;
+  // Length-prefix the key to avoid collisions e.g. ("a:b","c") vs ("a","b:c")
+  const cacheKey = `${encryptionKey.length}:${encryptionKey}:${salt}`;
   const cached = derivedKeyCache.get(cacheKey);
   if (cached) {
     return cached;
   }
   const derived = scryptSync(encryptionKey, Buffer.from(salt, 'utf8'), 32);
+  if (derivedKeyCache.size >= MAX_DERIVED_KEY_CACHE_SIZE) {
+    derivedKeyCache.delete(derivedKeyCache.keys().next().value!);
+  }
   derivedKeyCache.set(cacheKey, derived);
-
   return derived;
 }
 

--- a/src/domain/common/utils/encryption.ts
+++ b/src/domain/common/utils/encryption.ts
@@ -5,8 +5,7 @@ import {
   randomBytes,
   scryptSync,
 } from 'crypto';
-import { MAX_DERIVED_KEY_CACHE_SIZE } from '@/datasources/cache/constants';
-
+export const MAX_DERIVED_KEY_CACHE_SIZE = 50;
 const derivedKeyCache = new Map<string, Buffer>();
 
 function getDerivedKey(encryptionKey: string, salt: string): Buffer {
@@ -14,14 +13,25 @@ function getDerivedKey(encryptionKey: string, salt: string): Buffer {
   const cacheKey = `${encryptionKey.length}:${encryptionKey}:${salt}`;
   const cached = derivedKeyCache.get(cacheKey);
   if (cached) {
+    // Promote to end of Map for LRU eviction
+    derivedKeyCache.delete(cacheKey);
+    derivedKeyCache.set(cacheKey, cached);
     return cached;
   }
   const derived = scryptSync(encryptionKey, Buffer.from(salt, 'utf8'), 32);
   if (derivedKeyCache.size >= MAX_DERIVED_KEY_CACHE_SIZE) {
+    // Evict least recently used (first entry in insertion order)
     derivedKeyCache.delete(derivedKeyCache.keys().next().value!);
   }
   derivedKeyCache.set(cacheKey, derived);
   return derived;
+}
+
+/**
+ * Clears the derived key cache. Exported for testing and key rotation.
+ */
+export function clearDerivedKeyCache(): void {
+  derivedKeyCache.clear();
 }
 
 /**

--- a/src/modules/chains/domain/chains.repository.ts
+++ b/src/modules/chains/domain/chains.repository.ts
@@ -15,7 +15,6 @@ import {
 } from '@/modules/indexing/domain/entities/indexing-status.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 
-import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { LenientBasePageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import {
@@ -103,37 +102,24 @@ export class ChainsRepository implements IChainsRepository {
 
   async getAllChains(): Promise<Array<Chain>> {
     const firstPage = await this.getChains(ChainsRepository.MAX_LIMIT, 0);
-    const chains: Array<Chain> = [...firstPage.results];
 
     if (!firstPage.next) {
-      return chains;
+      return firstPage.results;
     }
 
     const totalCount = firstPage.count ?? firstPage.results.length;
     const totalPages = Math.ceil(totalCount / ChainsRepository.MAX_LIMIT);
-    const remainingPageCount = Math.min(
-      totalPages - 1,
-      this.maxSequentialPages - 1,
-    );
+    const pagesToFetch = Math.min(totalPages - 1, this.maxSequentialPages - 1);
 
-    const firstNextUrl = new URL(firstPage.next);
-    const firstNextOffset =
-      PaginationData.fromLimitAndOffset(firstNextUrl).offset;
-
-    const remainingOffsets: Array<number> = [];
-    for (let i = 0; i < remainingPageCount; i++) {
-      remainingOffsets.push(firstNextOffset + i * ChainsRepository.MAX_LIMIT);
-    }
-
+    // Offsets assume the config service returns fixed-size pages of MAX_LIMIT
     const remainingPages = await Promise.all(
-      remainingOffsets.map((offset) =>
-        this.getChains(ChainsRepository.MAX_LIMIT, offset),
+      Array.from({ length: pagesToFetch }, (_, i) =>
+        this.getChains(
+          ChainsRepository.MAX_LIMIT,
+          (i + 1) * ChainsRepository.MAX_LIMIT,
+        ),
       ),
     );
-
-    for (const page of remainingPages) {
-      chains.push(...page.results);
-    }
 
     if (totalPages > this.maxSequentialPages) {
       this.loggingService.error(
@@ -141,7 +127,7 @@ export class ChainsRepository implements IChainsRepository {
       );
     }
 
-    return chains;
+    return [firstPage, ...remainingPages].flatMap((p) => p.results);
   }
 
   async getSingletons(chainId: string): Promise<Array<Singleton>> {

--- a/src/modules/chains/domain/chains.repository.ts
+++ b/src/modules/chains/domain/chains.repository.ts
@@ -58,23 +58,7 @@ export class ChainsRepository implements IChainsRepository {
     const page = await this.configApi
       .getChains({ limit, offset })
       .then(LenientBasePageSchema.parse);
-    const valid: Array<Chain> = [];
-    const invalid: Array<unknown> = [];
-    for (const item of page.results) {
-      const result = ChainSchema.safeParse(item);
-      if (result.success) {
-        valid.push(result.data);
-      } else {
-        invalid.push(item);
-      }
-    }
-    if (invalid.length > 0) {
-      this.loggingService.error({
-        message: 'Some chains could not be parsed',
-        errors: invalid,
-      });
-    }
-    return { ...page, results: valid };
+    return this.parseChainPage(page);
   }
 
   async getChainsV2(
@@ -85,6 +69,21 @@ export class ChainsRepository implements IChainsRepository {
     const page = await this.configApi
       .getChainsV2(serviceKey, { limit, offset })
       .then(LenientBasePageSchema.parse);
+    return this.parseChainPage(page);
+  }
+
+  async getChainV2(serviceKey: string, chainId: string): Promise<Chain> {
+    const chain = await this.configApi.getChainV2(serviceKey, chainId);
+    return ChainSchema.parse(chain);
+  }
+
+  async clearChainV2(chainId: string, serviceKey: string): Promise<void> {
+    return this.configApi.clearChainV2(serviceKey, chainId);
+  }
+
+  private parseChainPage(
+    page: Page<unknown>,
+  ): Page<Chain> {
     const valid: Array<Chain> = [];
     const invalid: Array<unknown> = [];
     for (const item of page.results) {
@@ -102,15 +101,6 @@ export class ChainsRepository implements IChainsRepository {
       });
     }
     return { ...page, results: valid };
-  }
-
-  async getChainV2(serviceKey: string, chainId: string): Promise<Chain> {
-    const chain = await this.configApi.getChainV2(serviceKey, chainId);
-    return ChainSchema.parse(chain);
-  }
-
-  async clearChainV2(chainId: string, serviceKey: string): Promise<void> {
-    return this.configApi.clearChainV2(serviceKey, chainId);
   }
 
   async getAllChains(): Promise<Array<Chain>> {

--- a/src/modules/chains/domain/chains.repository.ts
+++ b/src/modules/chains/domain/chains.repository.ts
@@ -111,7 +111,8 @@ export class ChainsRepository implements IChainsRepository {
     const totalPages = Math.ceil(totalCount / ChainsRepository.MAX_LIMIT);
     const pagesToFetch = Math.min(totalPages - 1, this.maxSequentialPages - 1);
 
-    // Offsets assume the config service returns fixed-size pages of MAX_LIMIT
+    // Offsets assume the config service returns fixed-size pages of MAX_LIMIT.
+    // Chain configuration changes are infrequent, so parallel fetch is safe.
     const remainingPages = await Promise.all(
       Array.from({ length: pagesToFetch }, (_, i) =>
         this.getChains(

--- a/src/modules/chains/domain/chains.repository.ts
+++ b/src/modules/chains/domain/chains.repository.ts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
-import {
-  ChainLenientPageSchema,
-  ChainSchema,
-} from '@/modules/chains/domain/entities/schemas/chain.schema';
+import { ChainSchema } from '@/modules/chains/domain/entities/schemas/chain.schema';
 import { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import { Singleton } from '@/modules/chains/domain/entities/singleton.entity';
 import { SingletonsSchema } from '@/modules/chains/domain/entities/schemas/singleton.schema';
@@ -17,7 +14,7 @@ import {
   IndexingStatusSchema,
 } from '@/modules/indexing/domain/entities/indexing-status.entity';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
-import differenceBy from 'lodash/differenceBy';
+
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { LenientBasePageSchema } from '@/domain/entities/schemas/page.schema.factory';
@@ -61,14 +58,23 @@ export class ChainsRepository implements IChainsRepository {
     const page = await this.configApi
       .getChains({ limit, offset })
       .then(LenientBasePageSchema.parse);
-    const valid = ChainLenientPageSchema.parse(page);
-    if (valid.results.length < page.results.length) {
+    const valid: Array<Chain> = [];
+    const invalid: Array<unknown> = [];
+    for (const item of page.results) {
+      const result = ChainSchema.safeParse(item);
+      if (result.success) {
+        valid.push(result.data);
+      } else {
+        invalid.push(item);
+      }
+    }
+    if (invalid.length > 0) {
       this.loggingService.error({
         message: 'Some chains could not be parsed',
-        errors: differenceBy(page.results, valid.results, 'chainId'),
+        errors: invalid,
       });
     }
-    return valid;
+    return { ...page, results: valid };
   }
 
   async getChainsV2(
@@ -79,14 +85,23 @@ export class ChainsRepository implements IChainsRepository {
     const page = await this.configApi
       .getChainsV2(serviceKey, { limit, offset })
       .then(LenientBasePageSchema.parse);
-    const valid = ChainLenientPageSchema.parse(page);
-    if (valid.results.length < page.results.length) {
+    const valid: Array<Chain> = [];
+    const invalid: Array<unknown> = [];
+    for (const item of page.results) {
+      const result = ChainSchema.safeParse(item);
+      if (result.success) {
+        valid.push(result.data);
+      } else {
+        invalid.push(item);
+      }
+    }
+    if (invalid.length > 0) {
       this.loggingService.error({
         message: 'Some chains could not be parsed',
-        errors: differenceBy(page.results, valid.results, 'chainId'),
+        errors: invalid,
       });
     }
-    return valid;
+    return { ...page, results: valid };
   }
 
   async getChainV2(serviceKey: string, chainId: string): Promise<Chain> {
@@ -99,27 +114,40 @@ export class ChainsRepository implements IChainsRepository {
   }
 
   async getAllChains(): Promise<Array<Chain>> {
-    const chains: Array<Chain> = [];
+    const firstPage = await this.getChains(ChainsRepository.MAX_LIMIT, 0);
+    const chains: Array<Chain> = [...firstPage.results];
 
-    let offset = 0;
-    let next = null;
-
-    for (let i = 0; i < this.maxSequentialPages; i++) {
-      const result = await this.getChains(ChainsRepository.MAX_LIMIT, offset);
-
-      next = result.next;
-      chains.push(...result.results);
-
-      if (!next) {
-        break;
-      }
-
-      const url = new URL(next);
-      const paginationData = PaginationData.fromLimitAndOffset(url);
-      offset = paginationData.offset;
+    if (!firstPage.next) {
+      return chains;
     }
 
-    if (next) {
+    const totalCount = firstPage.count ?? firstPage.results.length;
+    const totalPages = Math.ceil(totalCount / ChainsRepository.MAX_LIMIT);
+    const remainingPageCount = Math.min(
+      totalPages - 1,
+      this.maxSequentialPages - 1,
+    );
+
+    const firstNextUrl = new URL(firstPage.next);
+    const firstNextOffset =
+      PaginationData.fromLimitAndOffset(firstNextUrl).offset;
+
+    const remainingOffsets: Array<number> = [];
+    for (let i = 0; i < remainingPageCount; i++) {
+      remainingOffsets.push(firstNextOffset + i * ChainsRepository.MAX_LIMIT);
+    }
+
+    const remainingPages = await Promise.all(
+      remainingOffsets.map((offset) =>
+        this.getChains(ChainsRepository.MAX_LIMIT, offset),
+      ),
+    );
+
+    for (const page of remainingPages) {
+      chains.push(...page.results);
+    }
+
+    if (totalPages > this.maxSequentialPages) {
       this.loggingService.error(
         'More chains available despite request limit reached',
       );

--- a/src/modules/chains/domain/chains.repository.ts
+++ b/src/modules/chains/domain/chains.repository.ts
@@ -81,9 +81,7 @@ export class ChainsRepository implements IChainsRepository {
     return this.configApi.clearChainV2(serviceKey, chainId);
   }
 
-  private parseChainPage(
-    page: Page<unknown>,
-  ): Page<Chain> {
+  private parseChainPage(page: Page<unknown>): Page<Chain> {
     const valid: Array<Chain> = [];
     const invalid: Array<unknown> = [];
     for (const item of page.results) {

--- a/src/modules/chains/domain/entities/schemas/__tests__/chain.schema.spec.ts
+++ b/src/modules/chains/domain/entities/schemas/__tests__/chain.schema.spec.ts
@@ -9,7 +9,6 @@ import { nativeCurrencyBuilder } from '@/modules/chains/domain/entities/__tests_
 import { pricesProviderBuilder } from '@/modules/chains/domain/entities/__tests__/prices-provider.builder';
 import { rpcUriBuilder } from '@/modules/chains/domain/entities/__tests__/rpc-uri.builder';
 import { themeBuilder } from '@/modules/chains/domain/entities/__tests__/theme.builder';
-import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import {
   ChainSchema,
   BalancesProviderSchema,
@@ -21,10 +20,8 @@ import {
   PricesProviderSchema,
   RpcUriSchema,
   ThemeSchema,
-  ChainLenientPageSchema,
   BeaconChainExplorerUriTemplateSchema,
 } from '@/modules/chains/domain/entities/schemas/chain.schema';
-import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
 import { faker } from '@faker-js/faker';
 
 describe('Chain schemas', () => {
@@ -557,38 +554,6 @@ describe('Chain schemas', () => {
           message: 'Invalid input: expected object, received undefined',
         },
       ]);
-    });
-  });
-
-  describe('ChainLenientPageSchema', () => {
-    it('should validate a valid Chain page', () => {
-      const chains = faker.helpers.multiple(() => chainBuilder().build(), {
-        count: { min: 1, max: 5 },
-      });
-      const chainPage = pageBuilder()
-        .with('results', chains)
-        .with('count', chains.length)
-        .build();
-
-      const result = ChainLenientPageSchema.safeParse(chainPage);
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should exclude invalid Chain items', () => {
-      const chains = faker.helpers.multiple(() => chainBuilder().build(), {
-        count: { min: 1, max: 5 },
-      });
-      const chainPage = pageBuilder<Chain>()
-        .with('results', chains)
-        .with('count', chains.length)
-        .build();
-      // @ts-expect-error - results are assumed optional
-      delete chainPage.results[0].chainId;
-
-      const result = ChainLenientPageSchema.safeParse(chainPage);
-
-      expect(result.success).toBe(true);
     });
   });
 });

--- a/src/modules/chains/domain/entities/schemas/chain.schema.ts
+++ b/src/modules/chains/domain/entities/schemas/chain.schema.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
 import { RpcUriAuthentication } from '@/modules/chains/domain/entities/rpc-uri-authentication.entity';
-import { buildLenientPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+
 import { TokenDetailsSchema } from '@/domain/common/schemas/token-metadata.schema';
 import {
   NullableAddressSchema,
@@ -107,5 +107,3 @@ export const ChainSchema = z.object({
 });
 
 // TODO: Merge schema definitions with ChainEntity.
-
-export const ChainLenientPageSchema = buildLenientPageSchema(ChainSchema);

--- a/src/modules/notifications/domain/v2/entities/upsert-subscriptions.dto.entity.ts
+++ b/src/modules/notifications/domain/v2/entities/upsert-subscriptions.dto.entity.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { DeviceType } from '@/modules/notifications/domain/v2/entities/device-type.entity';
 import { NotificationType } from '@/modules/notifications/domain/v2/entities/notification-type.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -12,7 +13,7 @@ const UpsertSubscriptionsDtoSafesSchema = z.object({
 
 export const UpsertSubscriptionsDtoSchema = z.object({
   cloudMessagingToken: z.string(),
-  safes: z.array(UpsertSubscriptionsDtoSafesSchema),
+  safes: z.array(UpsertSubscriptionsDtoSafesSchema).max(100),
   deviceType: z.enum(DeviceType),
   deviceUuid: UuidSchema.nullish().default(null),
 });

--- a/src/modules/notifications/domain/v2/notifications.repository.spec.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.spec.ts
@@ -130,29 +130,31 @@ describe('NotificationsRepositoryV2', () => {
       expect(
         mockEntityManager.createQueryBuilder().delete().from,
       ).toHaveBeenNthCalledWith(1, NotificationSubscription);
-      for (const [index, safe] of upsertSubscriptionsDto.safes.entries()) {
-        const nthTime = index + 1; // Index is zero based for that reason we need to add 1 to it
-        expect(
-          mockEntityManager
-            .createQueryBuilder()
-            .delete()
-            .from(NotificationSubscription).where,
-        ).toHaveBeenNthCalledWith(
-          nthTime,
-          `chain_id = :chainId
-          AND safe_address = :safeAddress
-          AND push_notification_device.id = :deviceId
-          AND (
-            signer_address = :signerAddress OR signer_address IS NULL
-          )`,
-          {
-            chainId: safe.chainId,
-            safeAddress: safe.address,
-            deviceId: deviceId,
-            signerAddress: authPayload.signer_address ?? null,
-          },
-        );
+
+      const conditions = upsertSubscriptionsDto.safes.map((_, i) => {
+        return `(chain_id = :chainId${i} AND safe_address = :safeAddress${i})`;
+      });
+      const parameters: Record<string, unknown> = {
+        deviceId: deviceId,
+        signerAddress: authPayload.signer_address ?? null,
+      };
+      for (let i = 0; i < upsertSubscriptionsDto.safes.length; i++) {
+        parameters[`chainId${i}`] = upsertSubscriptionsDto.safes[i].chainId;
+        parameters[`safeAddress${i}`] = upsertSubscriptionsDto.safes[i].address;
       }
+      expect(
+        mockEntityManager
+          .createQueryBuilder()
+          .delete()
+          .from(NotificationSubscription).where,
+      ).toHaveBeenCalledWith(
+        `(${conditions.join(' OR ')})
+        AND push_notification_device.id = :deviceId
+        AND (
+          signer_address = :signerAddress OR signer_address IS NULL
+        )`,
+        parameters,
+      );
     });
 
     it('Should insert the subscription object when upserting a new subscription', async () => {
@@ -593,7 +595,7 @@ describe('NotificationsRepositoryV2', () => {
       expect(notificationSubscriptionsRepository.remove).not.toHaveBeenCalled();
     });
 
-    it('Should clear cache for each subscription after deletion', async () => {
+    it('Should clear cache for all subscriptions in a single batched call after deletion', async () => {
       const mockSubscriptions = Array.from({ length: 2 }, () =>
         notificationSubscriptionBuilder().build(),
       );
@@ -626,7 +628,7 @@ describe('NotificationsRepositoryV2', () => {
       expect(
         notificationSubscriptionsRepository.manager.connection.queryResultCache
           ?.remove,
-      ).toHaveBeenCalledTimes(mockSubscriptions.length);
+      ).toHaveBeenCalledTimes(1);
     });
 
     it('Should handle empty subscriptions array', async () => {

--- a/src/modules/notifications/domain/v2/notifications.repository.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { UpsertSubscriptionsDto } from '@/modules/notifications/domain/v2/entities/upsert-subscriptions.dto.entity';
 import { FirebaseNotification } from '@/datasources/push-notifications-api/entities/firebase-notification.entity';
 import { IPushNotificationsApi } from '@/domain/interfaces/push-notifications-api.interface';

--- a/src/modules/notifications/domain/v2/notifications.repository.ts
+++ b/src/modules/notifications/domain/v2/notifications.repository.ts
@@ -176,7 +176,7 @@ export class NotificationsRepositoryV2 implements INotificationsRepositoryV2 {
   ): Promise<void> {
     const safes = args.upsertSubscriptionsDto.safes;
     if (safes.length === 0) {
-      return undefined;
+      return;
     }
 
     const conditions = safes.map((_, i) => {

--- a/src/modules/owners/routes/owners.controller.v2.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v2.integration.spec.ts
@@ -141,11 +141,17 @@ describe('Owners Controller (Unit)', () => {
       const chain2 = chainBuilder().with('chainId', chainId2).build();
 
       const chainsUrl = `${safeConfigUrl}/api/v1/chains`;
-      const offset = 1;
       const chainsPage1 = pageBuilder()
         .with('results', [chain1])
         .with('count', ChainsRepository.MAX_LIMIT + 1)
-        .with('next', limitAndOffsetUrlFactory(undefined, offset, chainsUrl))
+        .with(
+          'next',
+          limitAndOffsetUrlFactory(
+            undefined,
+            ChainsRepository.MAX_LIMIT,
+            chainsUrl,
+          ),
+        )
         .build();
       const chainsPage2 = pageBuilder()
         .with('results', [chain2])
@@ -170,7 +176,10 @@ describe('Owners Controller (Unit)', () => {
             status: 200,
           });
         }
-        if (url === chainsUrl && networkRequest!.params!.offset === offset) {
+        if (
+          url === chainsUrl &&
+          networkRequest!.params!.offset === ChainsRepository.MAX_LIMIT
+        ) {
           return Promise.resolve({
             data: rawify(chainsPage2),
             status: 200,

--- a/src/modules/owners/routes/owners.controller.v2.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v2.integration.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
@@ -143,6 +144,7 @@ describe('Owners Controller (Unit)', () => {
       const offset = 1;
       const chainsPage1 = pageBuilder()
         .with('results', [chain1])
+        .with('count', ChainsRepository.MAX_LIMIT + 1)
         .with('next', limitAndOffsetUrlFactory(undefined, offset, chainsUrl))
         .build();
       const chainsPage2 = pageBuilder()

--- a/src/modules/owners/routes/owners.controller.v3.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v3.integration.spec.ts
@@ -216,11 +216,17 @@ describe('Owners Controller V3 (Unit)', () => {
       const chain2 = chainBuilder().with('chainId', chainId2).build();
 
       const chainsUrl = `${safeConfigUrl}/api/v1/chains`;
-      const offset = 1;
       const chainsPage1 = pageBuilder()
         .with('results', [chain1])
         .with('count', ChainsRepository.MAX_LIMIT + 1)
-        .with('next', limitAndOffsetUrlFactory(undefined, offset, chainsUrl))
+        .with(
+          'next',
+          limitAndOffsetUrlFactory(
+            undefined,
+            ChainsRepository.MAX_LIMIT,
+            chainsUrl,
+          ),
+        )
         .build();
       const chainsPage2 = pageBuilder()
         .with('results', [chain2])
@@ -252,7 +258,10 @@ describe('Owners Controller V3 (Unit)', () => {
               status: 200,
             });
           }
-          if (url === chainsUrl && networkRequest!.params!.offset === offset) {
+          if (
+            url === chainsUrl &&
+            networkRequest!.params!.offset === ChainsRepository.MAX_LIMIT
+          ) {
             return Promise.resolve({
               data: rawify(chainsPage2),
               status: 200,

--- a/src/modules/owners/routes/owners.controller.v3.integration.spec.ts
+++ b/src/modules/owners/routes/owners.controller.v3.integration.spec.ts
@@ -219,6 +219,7 @@ describe('Owners Controller V3 (Unit)', () => {
       const offset = 1;
       const chainsPage1 = pageBuilder()
         .with('results', [chain1])
+        .with('count', ChainsRepository.MAX_LIMIT + 1)
         .with('next', limitAndOffsetUrlFactory(undefined, offset, chainsUrl))
         .build();
       const chainsPage2 = pageBuilder()

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -258,6 +258,8 @@ export class ZerionPortfolioApi implements IPortfolioApi {
       return {
         tokenInfo: {
           ...meta.tokenInfo,
+          // Use || (not ??) so empty-string symbol/name falls back to
+          // position.attributes.name instead of displaying blank.
           symbol: meta.tokenInfo.symbol || position.attributes.name,
           name: meta.tokenInfo.name || position.attributes.name,
         },

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -200,11 +200,14 @@ export class ZerionPortfolioApi implements IPortfolioApi {
   /**
    * Resolves a position's network, implementation, and token info.
    * Shared by _buildTokenBalances and _buildAppPositions.
+   *
+   * Uses || (not ??) for symbol/name so that empty strings fall back
+   * to position.attributes.name instead of displaying blank.
    */
   private _resolvePositionMeta(
     position: ZerionBalance,
     networkMap: Map<string, string>,
-  ): { tokenInfo: TokenBalance['tokenInfo'] } | null {
+  ): TokenBalance['tokenInfo'] | null {
     const networkName = position.relationships?.chain?.data?.id;
     if (!networkName) return null;
 
@@ -223,20 +226,19 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     const address = impl.address ? getAddress(impl.address) : null;
 
     return {
-      tokenInfo: {
-        address,
-        decimals: impl.decimals,
-        symbol: position.attributes.fungible_info.symbol ?? '',
-        name: position.attributes.fungible_info.name ?? '',
-        logoUri: position.attributes.fungible_info.icon?.url ?? '',
-        chainId,
-        trusted: !(position.attributes.flags.is_trash ?? false),
-        type:
-          address === null ||
-          address === '0x0000000000000000000000000000000000000000'
-            ? 'NATIVE_TOKEN'
-            : 'ERC20',
-      },
+      address,
+      decimals: impl.decimals,
+      symbol:
+        position.attributes.fungible_info.symbol || position.attributes.name,
+      name: position.attributes.fungible_info.name || position.attributes.name,
+      logoUri: position.attributes.fungible_info.icon?.url ?? '',
+      chainId,
+      trusted: !(position.attributes.flags.is_trash ?? false),
+      type:
+        address === null ||
+        address === '0x0000000000000000000000000000000000000000'
+          ? 'NATIVE_TOKEN'
+          : 'ERC20',
     };
   }
 
@@ -252,17 +254,11 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     networkMap: Map<string, string>,
   ): Array<TokenBalance> {
     const tokenBalances = positions.map((position): TokenBalance | null => {
-      const meta = this._resolvePositionMeta(position, networkMap);
-      if (!meta) return null;
+      const tokenInfo = this._resolvePositionMeta(position, networkMap);
+      if (!tokenInfo) return null;
 
       return {
-        tokenInfo: {
-          ...meta.tokenInfo,
-          // Use || (not ??) so empty-string symbol/name falls back to
-          // position.attributes.name instead of displaying blank.
-          symbol: meta.tokenInfo.symbol || position.attributes.name,
-          name: meta.tokenInfo.name || position.attributes.name,
-        },
+        tokenInfo,
         balance: position.attributes.quantity.int,
         balanceFiat:
           position.attributes.value !== null
@@ -367,8 +363,8 @@ export class ZerionPortfolioApi implements IPortfolioApi {
     networkMap: Map<string, string>,
   ): Array<AppPosition> {
     const appPositions = positions.map((position): AppPosition | null => {
-      const meta = this._resolvePositionMeta(position, networkMap);
-      if (!meta) return null;
+      const tokenInfo = this._resolvePositionMeta(position, networkMap);
+      if (!tokenInfo) return null;
 
       const poolAddress = position.attributes.pool_address;
       const receiptTokenAddress =
@@ -381,7 +377,7 @@ export class ZerionPortfolioApi implements IPortfolioApi {
         type: position.attributes.position_type,
         name: position.attributes.name,
         groupId: position.attributes.group_id ?? undefined,
-        tokenInfo: meta.tokenInfo,
+        tokenInfo,
         receiptTokenAddress,
         balance: position.attributes.quantity.int,
         balanceFiat:

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -198,51 +198,70 @@ export class ZerionPortfolioApi implements IPortfolioApi {
   }
 
   /**
+   * Resolves a position's network, implementation, and token info.
+   * Shared by _buildTokenBalances and _buildAppPositions.
+   */
+  private _resolvePositionMeta(
+    position: ZerionBalance,
+    networkMap: Map<string, string>,
+  ): { tokenInfo: TokenBalance['tokenInfo'] } | null {
+    const networkName = position.relationships?.chain?.data?.id;
+    if (!networkName) return null;
+
+    const chainId = networkMap.get(networkName);
+    if (!chainId) return null;
+
+    const impl = position.attributes.fungible_info.implementations.find(
+      (i) => i.chain_id === networkName,
+    );
+    if (!impl) return null;
+
+    if (impl.address !== null && !isAddress(impl.address)) {
+      return null;
+    }
+
+    const address = impl.address ? getAddress(impl.address) : null;
+
+    return {
+      tokenInfo: {
+        address,
+        decimals: impl.decimals,
+        symbol: position.attributes.fungible_info.symbol ?? '',
+        name: position.attributes.fungible_info.name ?? '',
+        logoUri: position.attributes.fungible_info.icon?.url ?? '',
+        chainId,
+        trusted: !(position.attributes.flags.is_trash ?? false),
+        type:
+          address === null ||
+          address === '0x0000000000000000000000000000000000000000'
+            ? 'NATIVE_TOKEN'
+            : 'ERC20',
+      },
+    };
+  }
+
+  /**
    * Maps Zerion wallet positions to domain TokenBalance entities.
    *
    * @param {Array<ZerionBalance>} positions - Zerion wallet positions
-   * @param {boolean} isTestnet - Whether this is a testnet request
-   * @returns {Promise<Array<TokenBalance>>} Promise that resolves to token balance entities
+   * @param {Map<string, string>} networkMap - Map of Zerion network IDs to chain IDs
+   * @returns {Array<TokenBalance>} Token balance entities
    */
   private _buildTokenBalances(
     positions: Array<ZerionBalance>,
     networkMap: Map<string, string>,
   ): Array<TokenBalance> {
     const tokenBalances = positions.map((position): TokenBalance | null => {
-      const networkName = position.relationships?.chain?.data?.id;
-      if (!networkName) return null;
-
-      const chainId = networkMap.get(networkName);
-      if (!chainId) return null;
-
-      const impl = position.attributes.fungible_info.implementations.find(
-        (i) => i.chain_id === networkName,
-      );
-      if (!impl) return null;
-
-      if (impl.address !== null && !isAddress(impl.address)) {
-        return null;
-      }
-
-      const address = impl.address ? getAddress(impl.address) : null;
+      const meta = this._resolvePositionMeta(position, networkMap);
+      if (!meta) return null;
 
       return {
         tokenInfo: {
-          address,
-          decimals: impl.decimals,
+          ...meta.tokenInfo,
           symbol:
-            position.attributes.fungible_info.symbol ??
-            position.attributes.name,
+            meta.tokenInfo.symbol || position.attributes.name,
           name:
-            position.attributes.fungible_info.name ?? position.attributes.name,
-          logoUri: position.attributes.fungible_info.icon?.url ?? '',
-          chainId,
-          trusted: !(position.attributes.flags.is_trash ?? false),
-          type:
-            address === null ||
-            address === '0x0000000000000000000000000000000000000000'
-              ? 'NATIVE_TOKEN'
-              : 'ERC20',
+            meta.tokenInfo.name || position.attributes.name,
         },
         balance: position.attributes.quantity.int,
         balanceFiat:
@@ -270,8 +289,8 @@ export class ZerionPortfolioApi implements IPortfolioApi {
    * Maps Zerion app positions to domain AppBalance entities, grouped by app and group_id.
    *
    * @param {Array<ZerionBalance>} positions - Zerion app positions
-   * @param {boolean} isTestnet - Whether this is a testnet request
-   * @returns {Promise<Array<AppBalance>>} Promise that resolves to app balance entities
+   * @param {Map<string, string>} networkMap - Map of Zerion network IDs to chain IDs
+   * @returns {Array<AppBalance>} App balance entities
    */
   private _buildAppBalances(
     positions: Array<ZerionBalance>,
@@ -340,30 +359,16 @@ export class ZerionPortfolioApi implements IPortfolioApi {
    * Maps Zerion positions to domain AppPosition entities.
    *
    * @param {Array<ZerionBalance>} positions - Zerion balance positions
-   * @param {boolean} isTestnet - Whether this is a testnet request
-   * @returns {Promise<Array<AppPosition>>} Promise that resolves to app position entities
+   * @param {Map<string, string>} networkMap - Map of Zerion network IDs to chain IDs
+   * @returns {Array<AppPosition>} App position entities
    */
   private _buildAppPositions(
     positions: Array<ZerionBalance>,
     networkMap: Map<string, string>,
   ): Array<AppPosition> {
     const appPositions = positions.map((position): AppPosition | null => {
-      const networkName = position.relationships?.chain?.data?.id;
-      if (!networkName) return null;
-
-      const chainId = networkMap.get(networkName);
-      if (!chainId) return null;
-
-      const impl = position.attributes.fungible_info.implementations.find(
-        (i) => i.chain_id === networkName,
-      );
-      if (!impl) return null;
-
-      if (impl.address !== null && !isAddress(impl.address)) {
-        return null;
-      }
-
-      const address = impl.address ? getAddress(impl.address) : null;
+      const meta = this._resolvePositionMeta(position, networkMap);
+      if (!meta) return null;
 
       const poolAddress = position.attributes.pool_address;
       const receiptTokenAddress =
@@ -376,20 +381,7 @@ export class ZerionPortfolioApi implements IPortfolioApi {
         type: position.attributes.position_type,
         name: position.attributes.name,
         groupId: position.attributes.group_id ?? undefined,
-        tokenInfo: {
-          address,
-          decimals: impl.decimals,
-          symbol: position.attributes.fungible_info.symbol ?? '',
-          name: position.attributes.fungible_info.name ?? '',
-          logoUri: position.attributes.fungible_info.icon?.url ?? '',
-          chainId,
-          trusted: !(position.attributes.flags.is_trash ?? false),
-          type:
-            address === null ||
-            address === '0x0000000000000000000000000000000000000000'
-              ? 'NATIVE_TOKEN'
-              : 'ERC20',
-        },
+        tokenInfo: meta.tokenInfo,
         receiptTokenAddress,
         balance: position.attributes.quantity.int,
         balanceFiat:

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -258,10 +258,8 @@ export class ZerionPortfolioApi implements IPortfolioApi {
       return {
         tokenInfo: {
           ...meta.tokenInfo,
-          symbol:
-            meta.tokenInfo.symbol || position.attributes.name,
-          name:
-            meta.tokenInfo.name || position.attributes.name,
+          symbol: meta.tokenInfo.symbol || position.attributes.name,
+          name: meta.tokenInfo.name || position.attributes.name,
         },
         balance: position.attributes.quantity.int,
         balanceFiat:

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import { groupBy } from 'lodash';
 import type { Address } from 'viem';

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -305,7 +305,7 @@ export class ZerionPortfolioApi implements IPortfolioApi {
             url: appMetadata?.url ?? undefined,
           },
           balanceFiat: getNumberString(
-            this._calculatePositionsBalance(appPositions),
+            this._calculateTotalBalance(appPositions),
           ),
           groups,
         };
@@ -414,18 +414,6 @@ export class ZerionPortfolioApi implements IPortfolioApi {
    * @returns {number} Total fiat value
    */
   private _calculateTotalBalance(positions: Array<ZerionBalance>): number {
-    return positions.reduce((sum, position) => {
-      return sum + (position.attributes.value ?? 0);
-    }, 0);
-  }
-
-  /**
-   * Calculates total fiat value of app positions.
-   *
-   * @param {Array<ZerionBalance>} positions - App positions to calculate balance for
-   * @returns {number} Total fiat value
-   */
-  private _calculatePositionsBalance(positions: Array<ZerionBalance>): number {
     return positions.reduce((sum, position) => {
       return sum + (position.attributes.value ?? 0);
     }, 0);

--- a/src/modules/safe/routes/safes.controller.overview.integration.spec.ts
+++ b/src/modules/safe/routes/safes.controller.overview.integration.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
@@ -198,15 +199,18 @@ describe('Safes Controller Overview', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -217,10 +221,10 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[6][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
@@ -228,9 +232,6 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
-        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
-      );
     });
 
     it('should not return awaiting confirmations if no more confirmations are required', async () => {
@@ -368,15 +369,18 @@ describe('Safes Controller Overview', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -387,10 +391,10 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[6][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
@@ -398,9 +402,6 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
-        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
-      );
     });
 
     it('overview of multiple Safes across different chains is correctly serialised', async () => {
@@ -965,15 +966,18 @@ describe('Safes Controller Overview', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         params: { trusted: false, exclude_spam: true },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -984,10 +988,10 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[6][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
@@ -995,9 +999,6 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
-        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
-      );
     });
 
     it('forwards trusted and exclude spam queries', async () => {
@@ -1117,16 +1118,19 @@ describe('Safes Controller Overview', () => {
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}`,
       );
       expect(networkService.get.mock.calls[3][0].url).toBe(
+        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
+      );
+      expect(networkService.get.mock.calls[4][0].url).toBe(
         `${chain.transactionService}/api/v1/safes/${safeInfo.address}/balances/`,
       );
-      expect(networkService.get.mock.calls[3][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
         // Forwarded params
         params: { trusted: true, exclude_spam: false },
       });
-      expect(networkService.get.mock.calls[4][0].url).toBe(
+      expect(networkService.get.mock.calls[5][0].url).toBe(
         `${pricesProviderUrl}/simple/token_price/${chain.pricesProvider.chainName}`,
       );
-      expect(networkService.get.mock.calls[4][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           vs_currencies: currency.toLowerCase(),
@@ -1137,10 +1141,10 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[5][0].url).toBe(
+      expect(networkService.get.mock.calls[6][0].url).toBe(
         `${pricesProviderUrl}/simple/price`,
       );
-      expect(networkService.get.mock.calls[5][0].networkRequest).toStrictEqual({
+      expect(networkService.get.mock.calls[6][0].networkRequest).toStrictEqual({
         headers: { 'x-cg-pro-api-key': pricesApiKey },
         params: {
           ids: chain.pricesProvider.nativeCoin,
@@ -1148,9 +1152,6 @@ describe('Safes Controller Overview', () => {
           include_24hr_change: true,
         },
       });
-      expect(networkService.get.mock.calls[6][0].url).toBe(
-        `${chain.transactionService}/api/v2/safes/${safeInfo.address}/multisig-transactions/`,
-      );
     });
   });
 

--- a/src/modules/safe/routes/safes.service.ts
+++ b/src/modules/safe/routes/safes.service.ts
@@ -141,11 +141,11 @@ export class SafesService {
     const settledOverviews = await Promise.allSettled(
       limitedSafes.map(async ({ chainId, address }) => {
         const chain = await this.chainsRepository.getChain(chainId);
-        const [safe, balances] = await Promise.all([
-          this.safeRepository.getSafe({
-            chainId,
-            address,
-          }),
+        const safe = await this.safeRepository.getSafe({
+          chainId,
+          address,
+        });
+        const [balances, queue] = await Promise.all([
           this.balancesRepository.getBalances({
             chain,
             safeAddress: address,
@@ -153,11 +153,11 @@ export class SafesService {
             fiatCode: args.currency,
             excludeSpam: args.excludeSpam,
           }),
+          this.safeRepository.getTransactionQueue({
+            chainId,
+            safe,
+          }),
         ]);
-        const queue = await this.safeRepository.getTransactionQueue({
-          chainId,
-          safe,
-        });
 
         const fiatBalance = balances
           .filter((b) => b.fiatBalance !== null)

--- a/src/modules/safe/routes/safes.service.ts
+++ b/src/modules/safe/routes/safes.service.ts
@@ -151,7 +151,9 @@ export class SafesService {
           fiatCode: args.currency,
           excludeSpam: args.excludeSpam,
         });
-        // Prevent unhandled rejection if safePromise rejects first
+        // Swallow rejection to prevent Node unhandled rejection warning
+        // if safePromise rejects before balancesPromise is awaited.
+        // The actual error still propagates via Promise.all below.
         balancesPromise.catch(() => {});
 
         const safe = await safePromise;

--- a/src/modules/safe/routes/safes.service.ts
+++ b/src/modules/safe/routes/safes.service.ts
@@ -151,6 +151,8 @@ export class SafesService {
           fiatCode: args.currency,
           excludeSpam: args.excludeSpam,
         });
+        // Prevent unhandled rejection if safePromise rejects first
+        balancesPromise.catch(() => {});
 
         const safe = await safePromise;
         const [balances, queue] = await Promise.all([

--- a/src/modules/safe/routes/safes.service.ts
+++ b/src/modules/safe/routes/safes.service.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import max from 'lodash/max';
 import semver from 'semver';
@@ -141,22 +142,20 @@ export class SafesService {
     const settledOverviews = await Promise.allSettled(
       limitedSafes.map(async ({ chainId, address }) => {
         const chain = await this.chainsRepository.getChain(chainId);
-        const safe = await this.safeRepository.getSafe({
-          chainId,
-          address,
+
+        const safePromise = this.safeRepository.getSafe({ chainId, address });
+        const balancesPromise = this.balancesRepository.getBalances({
+          chain,
+          safeAddress: address,
+          trusted: args.trusted,
+          fiatCode: args.currency,
+          excludeSpam: args.excludeSpam,
         });
+
+        const safe = await safePromise;
         const [balances, queue] = await Promise.all([
-          this.balancesRepository.getBalances({
-            chain,
-            safeAddress: address,
-            trusted: args.trusted,
-            fiatCode: args.currency,
-            excludeSpam: args.excludeSpam,
-          }),
-          this.safeRepository.getTransactionQueue({
-            chainId,
-            safe,
-          }),
+          balancesPromise,
+          this.safeRepository.getTransactionQueue({ chainId, safe }),
         ]);
 
         const fiatBalance = balances

--- a/src/modules/transactions/routes/transactions.service.ts
+++ b/src/modules/transactions/routes/transactions.service.ts
@@ -239,10 +239,12 @@ export class TransactionsService {
         chainId: args.chainId,
         address: args.safeAddress,
       }),
-      this.multisigTransactionMapper.prefetchAddressInfos({
-        chainId: args.chainId,
-        transactions: domainTransactions.results,
-      }),
+      this.multisigTransactionMapper
+        .prefetchAddressInfos({
+          chainId: args.chainId,
+          transactions: domainTransactions.results,
+        })
+        .catch(() => undefined),
     ]);
 
     const dataDecoded = await Promise.all(

--- a/src/modules/transactions/routes/transactions.service.ts
+++ b/src/modules/transactions/routes/transactions.service.ts
@@ -244,7 +244,13 @@ export class TransactionsService {
           chainId: args.chainId,
           transactions: domainTransactions.results,
         })
-        .catch(() => undefined),
+        .catch((error) => {
+          this.loggingService.debug({
+            type: LogType.ExternalRequest,
+            message: 'prefetchAddressInfos failed; falling back to on-demand',
+            error,
+          });
+        }),
     ]);
 
     const dataDecoded = await Promise.all(

--- a/src/modules/transactions/routes/transactions.service.ts
+++ b/src/modules/transactions/routes/transactions.service.ts
@@ -234,14 +234,16 @@ export class TransactionsService {
         offset: args.paginationData.offset,
       });
 
-    const safeInfo = await this.safeRepository.getSafe({
-      chainId: args.chainId,
-      address: args.safeAddress,
-    });
-    await this.multisigTransactionMapper.prefetchAddressInfos({
-      chainId: args.chainId,
-      transactions: domainTransactions.results,
-    });
+    const [safeInfo] = await Promise.all([
+      this.safeRepository.getSafe({
+        chainId: args.chainId,
+        address: args.safeAddress,
+      }),
+      this.multisigTransactionMapper.prefetchAddressInfos({
+        chainId: args.chainId,
+        transactions: domainTransactions.results,
+      }),
+    ]);
 
     const dataDecoded = await Promise.all(
       domainTransactions.results.map((domainTransaction) => {


### PR DESCRIPTION
## Summary

Performance improvements across several hot paths: Redis pipeline batching, parallelized async calls, in-memory key derivation cache, single-pass chain parsing, and batched SQL operations.

## Changes

### Redis pipelining (`redis.cache.service.ts`)
- Replaced sequential `hSet` + `expire` and `unlink` + `hSet` + `expire` calls with `multi().exec()` pipelines to reduce round-trips
- `deleteByKey` validates all three pipeline results (`unlink`, `hSet`, `expire`) and **logs errors** if the invalidation marker fails (does not throw — cache invalidation is best-effort)
- `deleteByKey` uses `.expire()` without `NX` so repeated invalidations refresh the TTL instead of being a no-op
- Cleanup `unlink` in `hSet` error path now logs a warning instead of silently swallowing errors

### Subscription batching (`notifications.repository.ts`)
- Consolidated `deletePreviousSubscriptions` into a single SQL `DELETE ... OR ...` instead of one query per safe
- Batched `removeGetSubscribersBySafeCache` and `deleteAllSubscriptions` cache invalidations into single calls
- Added `.max(100)` to `safes` array in `UpsertSubscriptionsDto` to prevent unbounded SQL query generation

### Parallelized hot endpoints
- **`getMultisigTransactions`** (`transactions.service.ts`): `getSafe()` and `prefetchAddressInfos()` now run concurrently via `Promise.all`. `prefetchAddressInfos` is wrapped in `.catch()` so cache-warming failure does not abort the request
- **`getSafeOverview`** (`safes.service.ts`): `getSafe()` and `getBalances()` start concurrently after chain resolves; `getTransactionQueue()` starts as soon as `getSafe()` resolves, overlapping with any remaining `getBalances()` time. Added `balancesPromise.catch(() => {})` to prevent unhandled rejection when `getSafe` rejects before `balancesPromise` is awaited

### Derived key cache (`encryption.ts`)
- Added a bounded in-memory LRU cache (max 50 entries) for `scryptSync` results to avoid repeated CPU-intensive derivation for the same `(key, salt)` pair
- True LRU eviction: entries are promoted on cache hit via delete-and-reinsert
- Cache key uses length-prefix to prevent collisions
- `MAX_DERIVED_KEY_CACHE_SIZE` is defined in `encryption.ts` (not in `datasources/`) to respect the domain→datasources layer boundary
- Exported `clearDerivedKeyCache()` for testing and key rotation

### Portfolio deduplication (`zerion-portfolio-api.service.ts`)
- Pre-computed a `Map<networkName, chainId>` to eliminate redundant cache/API lookups for duplicate networks when building token balances and app positions
- Extracted `_resolvePositionMeta` to deduplicate token resolution logic shared between `_buildTokenBalances` and `_buildAppPositions`
- Consolidated `_calculatePositionsBalance` and `_calculateTotalBalance` into a single method

### Chain data optimization (`chains.repository.ts`)
- **Single-pass chain parsing**: Replaced the two-pass flow (`LenientBasePageSchema.parse` then `ChainSchema.parse`) with a single pass using `ChainSchema.safeParse` per item via shared `parseChainPage` helper
- **Parallel chain fetching**: `getAllChains()` fetches the first page, uses its `count` to calculate remaining pages, then fetches them all in parallel via `Promise.all` with arithmetic offsets (multiples of `MAX_LIMIT`)

### Documentation (`AGENTS.md`, `CLAUDE.md`)
- Added `CLAUDE.md` referencing `AGENTS.md` for Claude Code auto-loading
- Added `yarn env:validate` to the pre-commit checklist (stop if it fails)
- Added batch commit guidelines for grouping related changes into logical commits
- Reinforced license header requirement on modified files

### Test updates
- Updated integration tests for `getSafeOverview` to match new parallelized network call order
- Set explicit `count` on `chainsPage1` in owners v2/v3 integration tests for `getAllChains` parallel fetch with offset-based pagination
- Updated `NotificationsRepositoryV2` tests to validate batched deletion logic
- Updated `RedisCacheService` tests to mock and validate `multi()` pipeline commands
- Added tests for derived key caching with `afterEach` cache cleanup
- Added SPDX license identifiers to modified source files

## Files changed (17)

| File | Changes |
|------|---------|
| `AGENTS.md` | Pre-commit checklist additions, batch commit guidelines |
| `CLAUDE.md` | New — references AGENTS.md |
| `src/datasources/cache/constants.ts` | SPDX license header |
| `src/datasources/cache/redis.cache.service.ts` | Pipeline batching, result validation, cleanup logging |
| `src/datasources/cache/redis.cache.service.key-prefix.spec.ts` | Updated tests for pipeline mocks |
| `src/domain/common/utils/encryption.ts` | LRU derived key cache, clearDerivedKeyCache export |
| `src/domain/common/utils/__tests__/encryption.spec.ts` | Cache tests with afterEach cleanup |
| `src/modules/chains/domain/chains.repository.ts` | Single-pass parsing + parallel fetch |
| `src/modules/notifications/domain/v2/entities/upsert-subscriptions.dto.entity.ts` | `.max(100)` on safes array |
| `src/modules/notifications/domain/v2/notifications.repository.ts` | Batched deletion |
| `src/modules/notifications/domain/v2/notifications.repository.spec.ts` | Updated tests |
| `src/modules/portfolio/datasources/zerion-portfolio-api.service.ts` | Network map dedup, _resolvePositionMeta extraction |
| `src/modules/safe/routes/safes.service.ts` | Parallel getSafeOverview |
| `src/modules/safe/routes/safes.controller.overview.integration.spec.ts` | Updated integration tests |
| `src/modules/transactions/routes/transactions.service.ts` | Parallel getSafe + prefetch with catch |
| `src/modules/owners/routes/owners.controller.v2.integration.spec.ts` | Offset-based pagination mocks |
| `src/modules/owners/routes/owners.controller.v3.integration.spec.ts` | Offset-based pagination mocks |

## Test plan

- [x] All existing tests pass with updated assertions
- [x] New tests added for derived key caching with cache cleanup
- [x] Integration tests updated for parallelized call ordering
- [x] Type check passes (0 new errors)
- [ ] Manual smoke test on staging for overview and transaction endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)