### PR TITLE
feat: add counterfactual-safes CGW module for backend persistence

### DIFF
--- a/migrations/1775500000000-create-counterfactual-safes.ts
+++ b/migrations/1775500000000-create-counterfactual-safes.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCounterfactualSafes1775500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE counterfactual_safes (
+        id SERIAL NOT NULL,
+        creator_id INTEGER,
+        chain_id VARCHAR(78) NOT NULL,
+        address VARCHAR(42) NOT NULL,
+        factory_address VARCHAR(42) NOT NULL,
+        master_copy VARCHAR(42) NOT NULL,
+        salt_nonce VARCHAR(78) NOT NULL,
+        safe_version VARCHAR(20) NOT NULL,
+        threshold INTEGER NOT NULL,
+        owners JSONB NOT NULL,
+        fallback_handler VARCHAR(42),
+        setup_to VARCHAR(42),
+        setup_data TEXT NOT NULL,
+        payment_token VARCHAR(42),
+        payment NUMERIC,
+        payment_receiver VARCHAR(42),
+        created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT PK_CFS_id PRIMARY KEY (id),
+        CONSTRAINT UQ_CFS_chainId_address UNIQUE (chain_id, address),
+        CONSTRAINT FK_CFS_creator_id FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE SET NULL
+      );
+      CREATE INDEX IDX_CFS_creator_id ON counterfactual_safes(creator_id);`,
+    );
+    await queryRunner.query(
+      `CREATE TRIGGER update_counterfactual_safes_updated_at
+        BEFORE UPDATE ON counterfactual_safes
+        FOR EACH ROW EXECUTE PROCEDURE update_updated_at();`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS counterfactual_safes CASCADE;`,
+    );
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -61,6 +61,7 @@ import {
 } from '@/logging/logging.interface';
 import { UsersModule } from '@/modules/users/users.module';
 import { SpacesModule } from '@/modules/spaces/spaces.module';
+import { CounterfactualSafesModule } from '@/modules/counterfactual-safes/counterfactual-safes.module';
 import { BullModule } from '@nestjs/bullmq';
 import { CsvExportModule } from '@/modules/csv-export/csv-export.module';
 import { SafeShieldModule } from '@/modules/safe-shield/safe-shield.module';
@@ -104,7 +105,9 @@ export class AppModule implements NestModule {
         HooksModule,
         NotificationsModule,
         MessagesModule,
-        ...(isUsersFeatureEnabled ? [UsersModule, SpacesModule] : []),
+        ...(isUsersFeatureEnabled
+          ? [UsersModule, SpacesModule, CounterfactualSafesModule]
+          : []),
         OwnersModule,
         RelayModule,
         RootModule,

--- a/src/domain/common/transformers/databaseAddress.transformer.spec.ts
+++ b/src/domain/common/transformers/databaseAddress.transformer.spec.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker/.';
+import {
+  databaseAddressTransformer,
+  databaseNullableAddressTransformer,
+} from './databaseAddress.transformer';
+import { getAddress } from 'viem';
+
+describe('databaseAddressTransformer', () => {
+  describe('to', () => {
+    it('should checksum a valid address', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase();
+      const checksummedAddress = getAddress(nonChecksummedAddress);
+      expect(databaseAddressTransformer.to(nonChecksummedAddress)).toBe(
+        checksummedAddress,
+      );
+    });
+  });
+  describe('from', () => {
+    it('should checksum a valid address', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase();
+      const checksummedAddress = getAddress(nonChecksummedAddress);
+      expect(databaseAddressTransformer.from(nonChecksummedAddress)).toBe(
+        checksummedAddress,
+      );
+    });
+  });
+});
+
+describe('databaseNullableAddressTransformer', () => {
+  describe('to', () => {
+    it('should return null if value is null', () => {
+      expect(databaseNullableAddressTransformer.to(null)).toBeNull();
+    });
+    it('should return null if value is undefined', () => {
+      expect(databaseNullableAddressTransformer.to(undefined)).toBeNull();
+    });
+    it('should checksum a valid address', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase();
+      const checksummedAddress = getAddress(nonChecksummedAddress);
+      expect(databaseNullableAddressTransformer.to(nonChecksummedAddress)).toBe(
+        checksummedAddress,
+      );
+    });
+  });
+  describe('from', () => {
+    it('should return null if value is null', () => {
+      expect(databaseNullableAddressTransformer.from(null)).toBeNull();
+    });
+    it('should return null if value is undefined', () => {
+      expect(databaseNullableAddressTransformer.from(undefined)).toBeNull();
+    });
+    it('should checksum a valid address', () => {
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase();
+      const checksummedAddress = getAddress(nonChecksummedAddress);
+      expect(
+        databaseNullableAddressTransformer.from(nonChecksummedAddress),
+      ).toBe(checksummedAddress);
+    });
+  });
+});

--- a/src/domain/common/transformers/databaseAddress.transformer.ts
+++ b/src/domain/common/transformers/databaseAddress.transformer.ts
@@ -1,13 +1,24 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { ValueTransformer } from 'typeorm';
 import type { Address } from 'viem';
 import { getAddress } from 'viem';
 
-// TODO: add tests
 export const databaseAddressTransformer: ValueTransformer = {
   to(value: string): Address {
     return getAddress(value);
   },
   from(value: string): Address {
+    return getAddress(value);
+  },
+};
+
+export const databaseNullableAddressTransformer: ValueTransformer = {
+  to(value: string | null): Address | null {
+    if (value === null || value === undefined) return null;
+    return getAddress(value);
+  },
+  from(value: string | null): Address | null {
+    if (value === null || value === undefined) return null;
     return getAddress(value);
   },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { AppModule } from '@/app.module';
 import { DefaultAppProvider } from '@/app.provider';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -14,7 +15,7 @@ async function bootstrap(): Promise<void> {
     configurationService.getOrThrow('application.allowCors') &&
     configurationService.getOrThrow('application.isDevelopment')
   ) {
-    app.enableCors();
+    app.enableCors({ origin: true, credentials: true });
   }
 
   await app.listen(applicationPort);

--- a/src/modules/counterfactual-safes/counterfactual-safes.module.ts
+++ b/src/modules/counterfactual-safes/counterfactual-safes.module.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { AuthModule } from '@/modules/auth/auth.module';
+import { UsersModule } from '@/modules/users/users.module';
+import { SpacesModule } from '@/modules/spaces/spaces.module';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { CounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository';
+import { ICounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface';
+import { CounterfactualSafesController } from '@/modules/counterfactual-safes/routes/counterfactual-safes.controller';
+import { CounterfactualSafesService } from '@/modules/counterfactual-safes/routes/counterfactual-safes.service';
+import { SpaceCounterfactualSafesController } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.controller';
+import { SpaceCounterfactualSafesService } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.service';
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [
+    PostgresDatabaseModuleV2,
+    TypeOrmModule.forFeature([CounterfactualSafe]),
+    forwardRef(() => AuthModule),
+    forwardRef(() => UsersModule),
+    forwardRef(() => SpacesModule),
+  ],
+  controllers: [
+    CounterfactualSafesController,
+    SpaceCounterfactualSafesController,
+  ],
+  providers: [
+    CounterfactualSafesService,
+    SpaceCounterfactualSafesService,
+    {
+      provide: ICounterfactualSafesRepository,
+      useClass: CounterfactualSafesRepository,
+    },
+  ],
+  exports: [ICounterfactualSafesRepository],
+})
+export class CounterfactualSafesModule {}

--- a/src/modules/counterfactual-safes/datasources/entities/__tests__/counterfactual-safe.entity.db.builder.ts
+++ b/src/modules/counterfactual-safes/datasources/entities/__tests__/counterfactual-safe.entity.db.builder.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+import type { Hex } from 'viem';
+
+export function counterfactualSafeBuilder(): IBuilder<CounterfactualSafe> {
+  return new Builder<CounterfactualSafe>()
+    .with('id', faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }))
+    .with('chainId', faker.string.numeric({ length: { min: 1, max: 6 } }))
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('factoryAddress', getAddress(faker.finance.ethereumAddress()))
+    .with('masterCopy', getAddress(faker.finance.ethereumAddress()))
+    .with('saltNonce', faker.string.numeric({ length: 13 }))
+    .with('safeVersion', '1.4.1')
+    .with('threshold', 1)
+    .with('owners', [getAddress(faker.finance.ethereumAddress())])
+    .with('fallbackHandler', getAddress(faker.finance.ethereumAddress()))
+    .with('setupTo', getAddress(faker.finance.ethereumAddress()))
+    .with(
+      'setupData',
+      ('0x' + faker.string.hexadecimal({ length: 64 }).slice(2)) as Hex,
+    )
+    .with('paymentToken', null)
+    .with('payment', null)
+    .with('paymentReceiver', getAddress(faker.finance.ethereumAddress()))
+    .with('createdAt', new Date())
+    .with('updatedAt', new Date());
+}

--- a/src/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db.ts
+++ b/src/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import {
+  databaseAddressTransformer,
+  databaseNullableAddressTransformer,
+} from '@/domain/common/transformers/databaseAddress.transformer';
+import { CounterfactualSafe as DomainCounterfactualSafe } from '@/modules/counterfactual-safes/domain/entities/counterfactual-safe.entity';
+import { CHAIN_ID_MAXLENGTH } from '@/routes/common/constants';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  JoinColumn,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import type { Address, Hex } from 'viem';
+
+@Entity('counterfactual_safes')
+@Unique('UQ_CFS_chainId_address', ['chainId', 'address'])
+export class CounterfactualSafe implements DomainCounterfactualSafe {
+  @PrimaryGeneratedColumn({
+    primaryKeyConstraintName: 'PK_CFS_id',
+  })
+  public readonly id!: number;
+
+  @Column({
+    name: 'chain_id',
+    type: 'varchar',
+    length: CHAIN_ID_MAXLENGTH,
+  })
+  public readonly chainId!: string;
+
+  @Column({
+    type: 'varchar',
+    length: 42,
+    transformer: databaseAddressTransformer,
+  })
+  public readonly address!: Address;
+
+  @Column({
+    name: 'factory_address',
+    type: 'varchar',
+    length: 42,
+    transformer: databaseAddressTransformer,
+  })
+  public readonly factoryAddress!: Address;
+
+  @Column({
+    name: 'master_copy',
+    type: 'varchar',
+    length: 42,
+    transformer: databaseAddressTransformer,
+  })
+  public readonly masterCopy!: Address;
+
+  @Column({
+    name: 'salt_nonce',
+    type: 'varchar',
+    length: 78,
+  })
+  public readonly saltNonce!: string;
+
+  @Column({
+    name: 'safe_version',
+    type: 'varchar',
+    length: 20,
+  })
+  public readonly safeVersion!: string;
+
+  @Column({
+    type: 'integer',
+  })
+  public readonly threshold!: number;
+
+  @Column({
+    type: 'jsonb',
+  })
+  public readonly owners!: Array<Address>;
+
+  @Column({
+    name: 'fallback_handler',
+    type: 'varchar',
+    length: 42,
+    nullable: true,
+    transformer: databaseNullableAddressTransformer,
+  })
+  public readonly fallbackHandler!: Address | null;
+
+  @Column({
+    name: 'setup_to',
+    type: 'varchar',
+    length: 42,
+    nullable: true,
+    transformer: databaseNullableAddressTransformer,
+  })
+  public readonly setupTo!: Address | null;
+
+  @Column({
+    name: 'setup_data',
+    type: 'text',
+  })
+  public readonly setupData!: Hex;
+
+  @Column({
+    name: 'payment_token',
+    type: 'varchar',
+    length: 42,
+    nullable: true,
+    transformer: databaseNullableAddressTransformer,
+  })
+  public readonly paymentToken!: Address | null;
+
+  @Column({
+    type: 'numeric',
+    nullable: true,
+  })
+  public readonly payment!: string | null;
+
+  @Column({
+    name: 'payment_receiver',
+    type: 'varchar',
+    length: 42,
+    nullable: true,
+    transformer: databaseNullableAddressTransformer,
+  })
+  public readonly paymentReceiver!: Address | null;
+
+  @Column({
+    name: 'created_at',
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+    update: false,
+  })
+  public readonly createdAt!: Date;
+
+  @Column({
+    name: 'updated_at',
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+    update: false,
+  })
+  public readonly updatedAt!: Date;
+
+  @ManyToOne(() => User, (user: User) => user.id, {
+    onDelete: 'SET NULL',
+    nullable: true,
+  })
+  @JoinColumn({
+    name: 'creator_id',
+    foreignKeyConstraintName: 'FK_CFS_creator_id',
+  })
+  public readonly creator?: User | null;
+}

--- a/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.integration.spec.ts
+++ b/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.integration.spec.ts
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { DataSource } from 'typeorm';
+import { getAddress, type Address } from 'viem';
+import configuration from '@/config/entities/__tests__/configuration';
+import { postgresConfig } from '@/config/entities/postgres.config';
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import { Member } from '@/modules/users/datasources/entities/member.entity.db';
+import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { CounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository';
+import { counterfactualSafeBuilder } from '@/modules/counterfactual-safes/datasources/entities/__tests__/counterfactual-safe.entity.db.builder';
+import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import type { ConfigService } from '@nestjs/config';
+import type { ILoggingService } from '@/logging/logging.interface';
+
+const mockLoggingService = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+function buildCounterfactualSafePayload(): Pick<
+  CounterfactualSafe,
+  | 'chainId'
+  | 'address'
+  | 'factoryAddress'
+  | 'masterCopy'
+  | 'saltNonce'
+  | 'safeVersion'
+  | 'threshold'
+  | 'owners'
+  | 'fallbackHandler'
+  | 'setupTo'
+  | 'setupData'
+  | 'paymentToken'
+  | 'payment'
+  | 'paymentReceiver'
+> {
+  const cfSafe = counterfactualSafeBuilder().build();
+  return {
+    chainId: cfSafe.chainId,
+    address: cfSafe.address,
+    factoryAddress: cfSafe.factoryAddress,
+    masterCopy: cfSafe.masterCopy,
+    saltNonce: cfSafe.saltNonce,
+    safeVersion: cfSafe.safeVersion,
+    threshold: cfSafe.threshold,
+    owners: cfSafe.owners,
+    fallbackHandler: cfSafe.fallbackHandler,
+    setupTo: cfSafe.setupTo,
+    setupData: cfSafe.setupData,
+    paymentToken: cfSafe.paymentToken,
+    payment: cfSafe.payment,
+    paymentReceiver: cfSafe.paymentReceiver,
+  };
+}
+
+describe('CounterfactualSafesRepository', () => {
+  let postgresDatabaseService: PostgresDatabaseService;
+  let counterfactualSafesRepo: CounterfactualSafesRepository;
+  let dbUserRepo: Repository<User>;
+  let dbWalletRepo: Repository<Wallet>;
+  let dbCounterfactualSafeRepo: Repository<CounterfactualSafe>;
+
+  const testDatabaseName = faker.string.alpha({
+    length: 10,
+    casing: 'lower',
+  });
+  const testConfiguration = configuration();
+
+  const dataSource = new DataSource({
+    ...postgresConfig({
+      ...testConfiguration.db.connection.postgres,
+      type: 'postgres',
+      database: testDatabaseName,
+    }),
+    migrationsTableName: testConfiguration.db.orm.migrationsTableName,
+    entities: [CounterfactualSafe, Member, Space, SpaceSafe, User, Wallet],
+  });
+
+  beforeAll(async () => {
+    // Create database
+    const testDataSource = new DataSource({
+      ...postgresConfig({
+        ...testConfiguration.db.connection.postgres,
+        type: 'postgres',
+        database: 'postgres',
+      }),
+    });
+    const testPostgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      testDataSource,
+    );
+    await testPostgresDatabaseService.initializeDatabaseConnection();
+    await testPostgresDatabaseService
+      .getDataSource()
+      .query(`CREATE DATABASE ${testDatabaseName}`);
+    await testPostgresDatabaseService.destroyDatabaseConnection();
+
+    // Create database connection
+    postgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      dataSource,
+    );
+    await postgresDatabaseService.initializeDatabaseConnection();
+
+    // Migrate database
+    const mockConfigService = {
+      getOrThrow: jest.fn().mockImplementation((key: string) => {
+        if (key === 'db.migrator.numberOfRetries') {
+          return testConfiguration.db.migrator.numberOfRetries;
+        }
+        if (key === 'db.migrator.retryAfterMs') {
+          return testConfiguration.db.migrator.retryAfterMs;
+        }
+      }),
+    } as jest.MockedObjectDeep<ConfigService>;
+    const migrator = new DatabaseMigrator(
+      mockLoggingService,
+      postgresDatabaseService,
+      mockConfigService,
+    );
+    await migrator.migrate();
+
+    counterfactualSafesRepo = new CounterfactualSafesRepository(
+      postgresDatabaseService,
+    );
+
+    dbUserRepo = dataSource.getRepository(User);
+    dbWalletRepo = dataSource.getRepository(Wallet);
+    dbCounterfactualSafeRepo = dataSource.getRepository(CounterfactualSafe);
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+
+    // Delete in dependency order
+    await dbCounterfactualSafeRepo
+      .createQueryBuilder()
+      .delete()
+      .where('1=1')
+      .execute();
+    await dbWalletRepo.createQueryBuilder().delete().where('1=1').execute();
+    await dbUserRepo.createQueryBuilder().delete().where('1=1').execute();
+  });
+
+  afterAll(async () => {
+    await postgresDatabaseService.getDataSource().dropDatabase();
+    await postgresDatabaseService.destroyDatabaseConnection();
+  });
+
+  describe('createdAt/updatedAt', () => {
+    it('should set createdAt and updatedAt when creating a CounterfactualSafe', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+      const before = new Date().getTime();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      const after = new Date().getTime();
+
+      const saved = await dbCounterfactualSafeRepo.findOneOrFail({
+        where: { chainId: payload.chainId, address: payload.address },
+      });
+
+      expect(saved.createdAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(saved.createdAt.getTime()).toBeLessThanOrEqual(after);
+      expect(saved.updatedAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(saved.updatedAt.getTime()).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a single CounterfactualSafe', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      const saved = await dbCounterfactualSafeRepo.findOneOrFail({
+        where: { chainId: payload.chainId, address: payload.address },
+        relations: { creator: true },
+      });
+
+      expect(saved).toMatchObject({
+        id: expect.any(Number),
+        chainId: payload.chainId,
+        address: payload.address,
+        factoryAddress: payload.factoryAddress,
+        masterCopy: payload.masterCopy,
+        saltNonce: payload.saltNonce,
+        safeVersion: payload.safeVersion,
+        threshold: payload.threshold,
+        owners: payload.owners,
+        fallbackHandler: payload.fallbackHandler,
+        setupTo: payload.setupTo,
+        setupData: payload.setupData,
+        paymentToken: payload.paymentToken,
+        payment: payload.payment,
+        paymentReceiver: payload.paymentReceiver,
+        creator: expect.objectContaining({ id: userId }),
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+    });
+
+    it('should create multiple CounterfactualSafes', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload1 = buildCounterfactualSafePayload();
+      const payload2 = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload1, payload2],
+      });
+
+      const all = await dbCounterfactualSafeRepo.find();
+      expect(all).toHaveLength(2);
+    });
+
+    it('should create with null creatorId', async () => {
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: null,
+        payload: [payload],
+      });
+
+      const saved = await dbCounterfactualSafeRepo.findOneOrFail({
+        where: { chainId: payload.chainId, address: payload.address },
+      });
+
+      expect(saved.chainId).toBe(payload.chainId);
+      expect(saved.address).toBe(payload.address);
+    });
+
+    it('should create with nullable address fields set to null', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = {
+        ...buildCounterfactualSafePayload(),
+        fallbackHandler: null,
+        setupTo: null,
+        paymentToken: null,
+        payment: null,
+        paymentReceiver: null,
+      };
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      const saved = await dbCounterfactualSafeRepo.findOneOrFail({
+        where: { chainId: payload.chainId, address: payload.address },
+      });
+
+      expect(saved.fallbackHandler).toBeNull();
+      expect(saved.setupTo).toBeNull();
+      expect(saved.paymentToken).toBeNull();
+      expect(saved.payment).toBeNull();
+      expect(saved.paymentReceiver).toBeNull();
+    });
+
+    it('should throw UniqueConstraintError on duplicate chainId + address', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      await expect(
+        counterfactualSafesRepo.create({
+          creatorId: userId,
+          payload: [payload],
+        }),
+      ).rejects.toThrow(UniqueConstraintError);
+    });
+  });
+
+  describe('findByCreatorId', () => {
+    it('should return counterfactual safes for a creator', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      const found = await counterfactualSafesRepo.findByCreatorId({
+        creatorId: userId,
+      });
+
+      expect(found).toHaveLength(1);
+      expect(found[0]).toMatchObject({
+        chainId: payload.chainId,
+        address: payload.address,
+      });
+    });
+
+    it('should return empty array for a creator with no safes', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+
+      const found = await counterfactualSafesRepo.findByCreatorId({
+        creatorId: userId,
+      });
+
+      expect(found).toEqual([]);
+    });
+
+    it('should not return safes created by another user', async () => {
+      const user1 = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId1 = user1.identifiers[0].id as User['id'];
+      const user2 = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId2 = user2.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId1,
+        payload: [payload],
+      });
+
+      const found = await counterfactualSafesRepo.findByCreatorId({
+        creatorId: userId2,
+      });
+
+      expect(found).toEqual([]);
+    });
+  });
+
+  describe('findOrFail', () => {
+    it('should return counterfactual safes matching the query', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      const found = await counterfactualSafesRepo.findOrFail({
+        where: { creator: { id: userId } },
+      });
+
+      expect(found).toHaveLength(1);
+      expect(found[0]).toMatchObject({
+        chainId: payload.chainId,
+        address: payload.address,
+      });
+    });
+
+    it('should throw NotFoundException if none found', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+
+      await expect(
+        counterfactualSafesRepo.findOrFail({
+          where: { creator: { id: userId } },
+        }),
+      ).rejects.toThrow(
+        new NotFoundException('Counterfactual Safe not found.'),
+      );
+    });
+  });
+
+  describe('find', () => {
+    it('should return counterfactual safes matching the query', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload1 = buildCounterfactualSafePayload();
+      const payload2 = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload1, payload2],
+      });
+
+      const found = await counterfactualSafesRepo.find({
+        where: { creator: { id: userId } },
+      });
+
+      expect(found).toHaveLength(2);
+    });
+
+    it('should return empty array if none found', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+
+      const found = await counterfactualSafesRepo.find({
+        where: { creator: { id: userId } },
+      });
+
+      expect(found).toEqual([]);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a counterfactual safe scoped by creator', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      await counterfactualSafesRepo.delete({
+        creatorId: userId,
+        payload: [{ chainId: payload.chainId, address: payload.address }],
+      });
+
+      const remaining = await dbCounterfactualSafeRepo.find();
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('should delete multiple counterfactual safes', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload1 = buildCounterfactualSafePayload();
+      const payload2 = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload1, payload2],
+      });
+
+      await counterfactualSafesRepo.delete({
+        creatorId: userId,
+        payload: [
+          { chainId: payload1.chainId, address: payload1.address },
+          { chainId: payload2.chainId, address: payload2.address },
+        ],
+      });
+
+      const remaining = await dbCounterfactualSafeRepo.find();
+      expect(remaining).toHaveLength(0);
+    });
+
+    it('should throw NotFoundException if counterfactual safe does not exist', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+
+      await expect(
+        counterfactualSafesRepo.delete({
+          creatorId: userId,
+          payload: [
+            {
+              chainId: faker.string.numeric(),
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        }),
+      ).rejects.toThrow(
+        new NotFoundException('Counterfactual Safe not found.'),
+      );
+    });
+
+    it("should not allow deleting another user's counterfactual safe", async () => {
+      const user1 = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId1 = user1.identifiers[0].id as User['id'];
+      const user2 = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId2 = user2.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId1,
+        payload: [payload],
+      });
+
+      // user2 tries to delete user1's safe — should not find it
+      await expect(
+        counterfactualSafesRepo.delete({
+          creatorId: userId2,
+          payload: [{ chainId: payload.chainId, address: payload.address }],
+        }),
+      ).rejects.toThrow(
+        new NotFoundException('Counterfactual Safe not found.'),
+      );
+
+      // The safe should still exist
+      const remaining = await dbCounterfactualSafeRepo.find();
+      expect(remaining).toHaveLength(1);
+    });
+
+    it('should throw BadRequestException if found count does not match payload count', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const payload = buildCounterfactualSafePayload();
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      await expect(
+        counterfactualSafesRepo.delete({
+          creatorId: userId,
+          payload: [
+            { chainId: payload.chainId, address: payload.address },
+            {
+              chainId: faker.string.numeric(),
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('address checksumming', () => {
+    it('should store non-checksummed addresses as checksummed', async () => {
+      const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const userId = user.identifiers[0].id as User['id'];
+      const nonChecksummedAddress = faker.finance
+        .ethereumAddress()
+        .toLowerCase() as Address;
+      const checksummedAddress = getAddress(nonChecksummedAddress);
+      const payload = {
+        ...buildCounterfactualSafePayload(),
+        address: nonChecksummedAddress,
+      };
+
+      await counterfactualSafesRepo.create({
+        creatorId: userId,
+        payload: [payload],
+      });
+
+      const saved = await dbCounterfactualSafeRepo.findOneOrFail({
+        where: { chainId: payload.chainId },
+      });
+
+      expect(saved.address).toEqual(checksummedAddress);
+    });
+  });
+});

--- a/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface.ts
+++ b/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import type { User } from '@/modules/users/datasources/entities/users.entity.db';
+import type { CounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository';
+import type {
+  FindOptionsRelations,
+  FindOptionsSelect,
+  FindOptionsWhere,
+} from 'typeorm';
+
+export const ICounterfactualSafesRepository = Symbol(
+  'ICounterfactualSafesRepository',
+);
+
+export interface ICounterfactualSafesRepository {
+  create(args: {
+    creatorId: User['id'] | null;
+    payload: Array<
+      Pick<
+        CounterfactualSafe,
+        | 'chainId'
+        | 'address'
+        | 'factoryAddress'
+        | 'masterCopy'
+        | 'saltNonce'
+        | 'safeVersion'
+        | 'threshold'
+        | 'owners'
+        | 'fallbackHandler'
+        | 'setupTo'
+        | 'setupData'
+        | 'paymentToken'
+        | 'payment'
+        | 'paymentReceiver'
+      >
+    >;
+  }): Promise<void>;
+
+  findByCreatorId(args: {
+    creatorId: User['id'];
+  }): Promise<Array<CounterfactualSafe>>;
+
+  findOrFail(
+    args: Parameters<CounterfactualSafesRepository['find']>[0],
+  ): Promise<Array<CounterfactualSafe>>;
+
+  find(args: {
+    where:
+      | Array<FindOptionsWhere<CounterfactualSafe>>
+      | FindOptionsWhere<CounterfactualSafe>;
+    select?: FindOptionsSelect<CounterfactualSafe>;
+    relations?: FindOptionsRelations<CounterfactualSafe>;
+  }): Promise<Array<CounterfactualSafe>>;
+
+  delete(args: {
+    creatorId: User['id'];
+    payload: Array<{
+      chainId: CounterfactualSafe['chainId'];
+      address: CounterfactualSafe['address'];
+    }>;
+  }): Promise<void>;
+}

--- a/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.ts
+++ b/src/modules/counterfactual-safes/domain/counterfactual-safes.repository.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
+import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
+import { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import type { ICounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface';
+import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
+import {
+  FindOptionsRelations,
+  FindOptionsSelect,
+  FindOptionsWhere,
+} from 'typeorm';
+import { getAddress } from 'viem';
+
+export class CounterfactualSafesRepository implements ICounterfactualSafesRepository {
+  public constructor(
+    @Inject(PostgresDatabaseService)
+    private readonly postgresDatabaseService: PostgresDatabaseService,
+  ) {}
+
+  public async create(
+    args: Parameters<ICounterfactualSafesRepository['create']>[0],
+  ): Promise<void> {
+    const repository =
+      await this.postgresDatabaseService.getRepository(CounterfactualSafe);
+
+    const itemsToInsert = args.payload.map((item) => ({
+      creator: args.creatorId ? { id: args.creatorId } : null,
+      chainId: item.chainId,
+      address: item.address,
+      factoryAddress: item.factoryAddress,
+      masterCopy: item.masterCopy,
+      saltNonce: item.saltNonce,
+      safeVersion: item.safeVersion,
+      threshold: item.threshold,
+      owners: item.owners.map((owner) => getAddress(owner)),
+      fallbackHandler: item.fallbackHandler,
+      setupTo: item.setupTo,
+      setupData: item.setupData,
+      paymentToken: item.paymentToken,
+      payment: item.payment,
+      paymentReceiver: item.paymentReceiver,
+    }));
+
+    try {
+      await repository.insert(itemsToInsert);
+    } catch (err) {
+      if (isUniqueConstraintError(err)) {
+        throw new UniqueConstraintError(
+          'A counterfactual Safe with the same chainId and address already exists.',
+        );
+      }
+      throw err;
+    }
+  }
+
+  public async findByCreatorId(args: {
+    creatorId: User['id'];
+  }): Promise<Array<CounterfactualSafe>> {
+    const repository =
+      await this.postgresDatabaseService.getRepository(CounterfactualSafe);
+
+    return await repository.find({
+      where: { creator: { id: args.creatorId } },
+    });
+  }
+
+  public async findOrFail(
+    args: Parameters<CounterfactualSafesRepository['find']>[0],
+  ): Promise<Array<CounterfactualSafe>> {
+    const results = await this.find(args);
+
+    if (results.length === 0) {
+      throw new NotFoundException('Counterfactual Safe not found.');
+    }
+
+    return results;
+  }
+
+  public async find(args: {
+    where:
+      | Array<FindOptionsWhere<CounterfactualSafe>>
+      | FindOptionsWhere<CounterfactualSafe>;
+    select?: FindOptionsSelect<CounterfactualSafe>;
+    relations?: FindOptionsRelations<CounterfactualSafe>;
+  }): Promise<Array<CounterfactualSafe>> {
+    const repository =
+      await this.postgresDatabaseService.getRepository(CounterfactualSafe);
+
+    return await repository.find(args);
+  }
+
+  public async delete(args: {
+    creatorId: User['id'];
+    payload: Array<{
+      chainId: CounterfactualSafe['chainId'];
+      address: CounterfactualSafe['address'];
+    }>;
+  }): Promise<void> {
+    const repository =
+      await this.postgresDatabaseService.getRepository(CounterfactualSafe);
+
+    const whereClause: Array<FindOptionsWhere<CounterfactualSafe>> =
+      args.payload.map((item) => ({
+        creator: { id: args.creatorId },
+        chainId: item.chainId,
+        address: item.address,
+      }));
+
+    const counterfactualSafes = await this.findOrFail({
+      where: whereClause,
+    });
+
+    if (counterfactualSafes.length !== args.payload.length) {
+      throw new BadRequestException(
+        `Expected ${args.payload.length} counterfactual Safe(s) to delete, but found ${counterfactualSafes.length}.`,
+      );
+    }
+
+    await repository.remove(counterfactualSafes);
+  }
+}

--- a/src/modules/counterfactual-safes/domain/entities/counterfactual-safe.entity.ts
+++ b/src/modules/counterfactual-safes/domain/entities/counterfactual-safe.entity.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
+import type { CounterfactualSafe as DbCounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { UserSchema } from '@/modules/users/domain/entities/user.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import type { Address } from 'viem';
+
+export type CounterfactualSafe = z.infer<typeof CounterfactualSafeSchema>;
+
+export const CounterfactualSafeSchema: z.ZodType<
+  z.infer<typeof RowSchema> & {
+    chainId: DbCounterfactualSafe['chainId'];
+    address: DbCounterfactualSafe['address'];
+    factoryAddress: DbCounterfactualSafe['factoryAddress'];
+    masterCopy: DbCounterfactualSafe['masterCopy'];
+    saltNonce: DbCounterfactualSafe['saltNonce'];
+    safeVersion: DbCounterfactualSafe['safeVersion'];
+    threshold: DbCounterfactualSafe['threshold'];
+    owners: DbCounterfactualSafe['owners'];
+    fallbackHandler: DbCounterfactualSafe['fallbackHandler'];
+    setupTo: DbCounterfactualSafe['setupTo'];
+    setupData: DbCounterfactualSafe['setupData'];
+    paymentToken: DbCounterfactualSafe['paymentToken'];
+    payment: DbCounterfactualSafe['payment'];
+    paymentReceiver: DbCounterfactualSafe['paymentReceiver'];
+    creator?: DbCounterfactualSafe['creator'];
+  }
+> = RowSchema.extend({
+  chainId: NumericStringSchema,
+  address: AddressSchema as z.ZodType<Address>,
+  factoryAddress: AddressSchema as z.ZodType<Address>,
+  masterCopy: AddressSchema as z.ZodType<Address>,
+  saltNonce: z.string(),
+  safeVersion: z.string(),
+  threshold: z.number().int().positive(),
+  owners: z.array(AddressSchema as z.ZodType<Address>).nonempty(),
+  fallbackHandler: (AddressSchema as z.ZodType<Address>).nullable(),
+  setupTo: (AddressSchema as z.ZodType<Address>).nullable(),
+  setupData: HexSchema,
+  paymentToken: (AddressSchema as z.ZodType<Address>).nullable(),
+  payment: z.string().nullable(),
+  paymentReceiver: (AddressSchema as z.ZodType<Address>).nullable(),
+  creator: z
+    .lazy(() => UserSchema)
+    .nullable()
+    .optional(),
+});

--- a/src/modules/counterfactual-safes/routes/__tests__/counterfactual-safes.controller.e2e-spec.ts
+++ b/src/modules/counterfactual-safes/routes/__tests__/counterfactual-safes.controller.e2e-spec.ts
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { type Server } from 'http';
+import request from 'supertest';
+import type { INestApplication } from '@nestjs/common';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import configuration from '@/config/entities/__tests__/configuration';
+import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { NotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/notifications.repository.module';
+import { TestNotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/test.notification.repository.module';
+import { CounterfactualSafesController } from '@/modules/counterfactual-safes/routes/counterfactual-safes.controller';
+import { checkGuardIsApplied } from '@/__tests__/util/check-guard';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { counterfactualSafeBuilder } from '@/modules/counterfactual-safes/datasources/entities/__tests__/counterfactual-safe.entity.db.builder';
+import { createTestModule } from '@/__tests__/testing-module';
+
+function buildCounterfactualSafe(chainId?: string): Record<string, unknown> {
+  const cfSafe = counterfactualSafeBuilder()
+    .with('chainId', chainId ?? chainBuilder().build().chainId)
+    .build();
+  return {
+    chainId: cfSafe.chainId,
+    address: cfSafe.address,
+    factoryAddress: cfSafe.factoryAddress,
+    masterCopy: cfSafe.masterCopy,
+    saltNonce: cfSafe.saltNonce,
+    safeVersion: cfSafe.safeVersion,
+    threshold: cfSafe.threshold,
+    owners: cfSafe.owners,
+    fallbackHandler: cfSafe.fallbackHandler,
+    to: cfSafe.setupTo,
+    data: cfSafe.setupData,
+    paymentToken: cfSafe.paymentToken,
+    payment: cfSafe.payment,
+    paymentReceiver: cfSafe.paymentReceiver,
+  };
+}
+
+describe('CounterfactualSafesController', () => {
+  let app: INestApplication<Server>;
+  let jwtService: IJwtService;
+
+  beforeAll(async () => {
+    jest.resetAllMocks();
+
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        auth: true,
+        users: true,
+      },
+    });
+
+    const moduleFixture = await createTestModule({
+      config: testConfiguration,
+      overridePostgresV2: false,
+      modules: [
+        {
+          originalModule: NotificationsRepositoryV2Module,
+          testModule: TestNotificationsRepositoryV2Module,
+        },
+      ],
+    });
+
+    jwtService = moduleFixture.get<IJwtService>(IJwtService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should require authentication for every endpoint', () => {
+    const endpoints = Object.values(
+      CounterfactualSafesController.prototype,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    ) as Array<Function>;
+
+    endpoints.forEach((fn) => checkGuardIsApplied(AuthGuard, fn));
+  });
+
+  describe('POST /v1/users/counterfactual-safes', () => {
+    it('Should create a counterfactual safe', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+    });
+
+    it('Should create multiple counterfactual safes', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe1 = buildCounterfactualSafe();
+      const cfSafe2 = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe1, cfSafe2] })
+        .expect(201);
+    });
+
+    it('Should fail on duplicate chainId + address', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(409);
+    });
+
+    it('Should return 422 for invalid data (non-hex data field)', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe = { ...buildCounterfactualSafe(), data: 'not-hex' };
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(422);
+    });
+
+    it('Should return 422 for invalid saltNonce', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe = {
+        ...buildCounterfactualSafe(),
+        saltNonce: 'not-numeric',
+      };
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(422);
+    });
+
+    it('Should return 422 for empty safes array', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [] })
+        .expect(422);
+    });
+
+    it('Should return 403 if not authenticated', async () => {
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .send({ safes: [cfSafe] })
+        .expect(403);
+    });
+  });
+
+  describe('GET /v1/users/counterfactual-safes', () => {
+    it('Should return counterfactual safes grouped by chainId', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      const getResponse = await request(app.getHttpServer())
+        .get('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200);
+
+      expect(getResponse.body.safes).toBeDefined();
+      expect(getResponse.body.safes[cfSafe.chainId]).toBeDefined();
+      expect(getResponse.body.safes[cfSafe.chainId]).toHaveLength(1);
+      expect(getResponse.body.safes[cfSafe.chainId][0]).toMatchObject({
+        address: cfSafe.address,
+        factoryAddress: cfSafe.factoryAddress,
+        masterCopy: cfSafe.masterCopy,
+        saltNonce: cfSafe.saltNonce,
+        safeVersion: cfSafe.safeVersion,
+        threshold: cfSafe.threshold,
+        owners: cfSafe.owners,
+        fallbackHandler: cfSafe.fallbackHandler,
+        to: cfSafe.to,
+        data: cfSafe.data,
+        paymentReceiver: cfSafe.paymentReceiver,
+      });
+    });
+
+    it('Should return empty safes for a user with none', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      const getResponse = await request(app.getHttpServer())
+        .get('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200);
+
+      expect(getResponse.body.safes).toEqual({});
+    });
+
+    it('Should not return safes created by another user', async () => {
+      const authPayloadDto1 = siweAuthPayloadDtoBuilder().build();
+      const accessToken1 = jwtService.sign(authPayloadDto1);
+      const authPayloadDto2 = siweAuthPayloadDtoBuilder().build();
+      const accessToken2 = jwtService.sign(authPayloadDto2);
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken1}`]);
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken2}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken1}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      const getResponse = await request(app.getHttpServer())
+        .get('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken2}`])
+        .expect(200);
+
+      expect(getResponse.body.safes).toEqual({});
+    });
+
+    it('Should return 403 if not authenticated', async () => {
+      await request(app.getHttpServer())
+        .get('/v1/users/counterfactual-safes')
+        .expect(403);
+    });
+  });
+
+  describe('DELETE /v1/users/counterfactual-safes', () => {
+    it('Should delete a counterfactual safe', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .delete('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          safes: [{ chainId: cfSafe.chainId, address: cfSafe.address }],
+        })
+        .expect(204);
+
+      const getResponse = await request(app.getHttpServer())
+        .get('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200);
+
+      expect(getResponse.body.safes).toEqual({});
+    });
+
+    it('Should return 404 when deleting non-existent safe', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const chain = chainBuilder().build();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      await request(app.getHttpServer())
+        .delete('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          safes: [
+            {
+              chainId: chain.chainId,
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
+        .expect(404);
+    });
+
+    it("Should not allow deleting another user's safe", async () => {
+      const authPayloadDto1 = siweAuthPayloadDtoBuilder().build();
+      const accessToken1 = jwtService.sign(authPayloadDto1);
+      const authPayloadDto2 = siweAuthPayloadDtoBuilder().build();
+      const accessToken2 = jwtService.sign(authPayloadDto2);
+      const cfSafe = buildCounterfactualSafe();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken1}`]);
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken2}`]);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken1}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .delete('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken2}`])
+        .send({
+          safes: [{ chainId: cfSafe.chainId, address: cfSafe.address }],
+        })
+        .expect(404);
+    });
+
+    it('Should return 403 if not authenticated', async () => {
+      await request(app.getHttpServer())
+        .delete('/v1/users/counterfactual-safes')
+        .send({
+          safes: [
+            {
+              chainId: '1',
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        })
+        .expect(403);
+    });
+  });
+});

--- a/src/modules/counterfactual-safes/routes/__tests__/space-counterfactual-safes.controller.e2e-spec.ts
+++ b/src/modules/counterfactual-safes/routes/__tests__/space-counterfactual-safes.controller.e2e-spec.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { type Server } from 'http';
+import request from 'supertest';
+import type { INestApplication } from '@nestjs/common';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import configuration from '@/config/entities/__tests__/configuration';
+import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { NotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/notifications.repository.module';
+import { TestNotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/test.notification.repository.module';
+import { SpaceCounterfactualSafesController } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.controller';
+import { checkGuardIsApplied } from '@/__tests__/util/check-guard';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { faker } from '@faker-js/faker/.';
+import { getAddress } from 'viem';
+import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { counterfactualSafeBuilder } from '@/modules/counterfactual-safes/datasources/entities/__tests__/counterfactual-safe.entity.db.builder';
+import { nameBuilder } from '@/domain/common/entities/name.builder';
+import { createTestModule } from '@/__tests__/testing-module';
+import { SpacesCreationRateLimitGuard } from '@/modules/spaces/routes/guards/spaces-creation-rate-limit.guard';
+
+function buildCounterfactualSafe(chainId?: string): Record<string, unknown> {
+  const cfSafe = counterfactualSafeBuilder()
+    .with('chainId', chainId ?? chainBuilder().build().chainId)
+    .build();
+  return {
+    chainId: cfSafe.chainId,
+    address: cfSafe.address,
+    factoryAddress: cfSafe.factoryAddress,
+    masterCopy: cfSafe.masterCopy,
+    saltNonce: cfSafe.saltNonce,
+    safeVersion: cfSafe.safeVersion,
+    threshold: cfSafe.threshold,
+    owners: cfSafe.owners,
+    fallbackHandler: cfSafe.fallbackHandler,
+    to: cfSafe.setupTo,
+    data: cfSafe.setupData,
+    paymentToken: cfSafe.paymentToken,
+    payment: cfSafe.payment,
+    paymentReceiver: cfSafe.paymentReceiver,
+  };
+}
+
+describe('SpaceCounterfactualSafesController', () => {
+  let app: INestApplication<Server>;
+  let jwtService: IJwtService;
+
+  beforeAll(async () => {
+    jest.resetAllMocks();
+
+    const defaultConfiguration = configuration();
+    const testConfiguration = (): typeof defaultConfiguration => ({
+      ...defaultConfiguration,
+      features: {
+        ...defaultConfiguration.features,
+        auth: true,
+        users: true,
+      },
+    });
+
+    const moduleFixture = await createTestModule({
+      config: testConfiguration,
+      overridePostgresV2: false,
+      guards: [
+        {
+          originalGuard: SpacesCreationRateLimitGuard,
+          testGuard: {
+            canActivate: (): true => true,
+          },
+        },
+      ],
+      modules: [
+        {
+          originalModule: NotificationsRepositoryV2Module,
+          testModule: TestNotificationsRepositoryV2Module,
+        },
+      ],
+    });
+
+    jwtService = moduleFixture.get<IJwtService>(IJwtService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should require authentication for every endpoint', () => {
+    const endpoints = Object.values(
+      SpaceCounterfactualSafesController.prototype,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    ) as Array<Function>;
+
+    endpoints.forEach((fn) => checkGuardIsApplied(AuthGuard, fn));
+  });
+
+  describe('GET /v1/spaces/:spaceId/counterfactual-safes', () => {
+    it('Should return counterfactual safes for a space', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const chain = chainBuilder().build();
+      const cfSafe = buildCounterfactualSafe(chain.chainId);
+
+      // Create user + space
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      const spaceRes = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: nameBuilder() });
+      const spaceId = spaceRes.body.id as number;
+
+      // Create counterfactual safe
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      // Add the safe to the space
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/safes`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          safes: [
+            {
+              chainId: cfSafe.chainId,
+              address: cfSafe.address,
+            },
+          ],
+        })
+        .expect(201);
+
+      // Get space counterfactual safes
+      const getResponse = await request(app.getHttpServer())
+        .get(`/v1/spaces/${spaceId}/counterfactual-safes`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200);
+
+      expect(getResponse.body.safes).toBeDefined();
+      expect(getResponse.body.safes[chain.chainId]).toHaveLength(1);
+      expect(getResponse.body.safes[chain.chainId][0]).toMatchObject({
+        address: cfSafe.address,
+      });
+    });
+
+    it('Should return empty safes for a space with no counterfactual safes', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      const spaceRes = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: nameBuilder() });
+      const spaceId = spaceRes.body.id as number;
+
+      const getResponse = await request(app.getHttpServer())
+        .get(`/v1/spaces/${spaceId}/counterfactual-safes`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200);
+
+      expect(getResponse.body.safes).toEqual({});
+    });
+
+    it('Should return 403 for a non-member', async () => {
+      const authPayloadDto1 = siweAuthPayloadDtoBuilder().build();
+      const accessToken1 = jwtService.sign(authPayloadDto1);
+      const authPayloadDto2 = siweAuthPayloadDtoBuilder().build();
+      const accessToken2 = jwtService.sign(authPayloadDto2);
+
+      // User 1 creates a space
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken1}`]);
+
+      const spaceRes = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${accessToken1}`])
+        .send({ name: nameBuilder() });
+      const spaceId = spaceRes.body.id as number;
+
+      // User 2 tries to access
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken2}`]);
+
+      await request(app.getHttpServer())
+        .get(`/v1/spaces/${spaceId}/counterfactual-safes`)
+        .set('Cookie', [`access_token=${accessToken2}`])
+        .expect(403);
+    });
+
+    it('Should return 403 if not authenticated', async () => {
+      await request(app.getHttpServer())
+        .get(`/v1/spaces/1/counterfactual-safes`)
+        .expect(403);
+    });
+
+    it('Should only return safes that are both in the space and counterfactual', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const chain = chainBuilder().build();
+      const cfSafe = buildCounterfactualSafe(chain.chainId);
+      const deployedAddress = getAddress(faker.finance.ethereumAddress());
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`]);
+
+      const spaceRes = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: nameBuilder() });
+      const spaceId = spaceRes.body.id as number;
+
+      // Create counterfactual safe
+      await request(app.getHttpServer())
+        .post('/v1/users/counterfactual-safes')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ safes: [cfSafe] })
+        .expect(201);
+
+      // Add both the counterfactual safe AND a deployed safe to the space
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/safes`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          safes: [
+            { chainId: cfSafe.chainId, address: cfSafe.address },
+            { chainId: chain.chainId, address: deployedAddress },
+          ],
+        })
+        .expect(201);
+
+      const getResponse = await request(app.getHttpServer())
+        .get(`/v1/spaces/${spaceId}/counterfactual-safes`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200);
+
+      // Only the counterfactual safe should be returned (the deployed one
+      // has no entry in counterfactual_safes table)
+      const allSafes = Object.values(
+        getResponse.body.safes as Record<string, Array<unknown>>,
+      ).flat();
+      expect(allSafes).toHaveLength(1);
+      expect(allSafes[0]).toMatchObject({
+        address: cfSafe.address,
+      });
+    });
+  });
+});

--- a/src/modules/counterfactual-safes/routes/counterfactual-safes.controller.ts
+++ b/src/modules/counterfactual-safes/routes/counterfactual-safes.controller.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import { CounterfactualSafesService } from '@/modules/counterfactual-safes/routes/counterfactual-safes.service';
+import { CounterfactualSafesSchema } from '@/modules/counterfactual-safes/routes/entities/counterfactual-safe.dto.entity';
+import { CreateCounterfactualSafesDto } from '@/modules/counterfactual-safes/routes/entities/create-counterfactual-safe.dto.entity';
+import {
+  DeleteCounterfactualSafesDto,
+  DeleteCounterfactualSafesSchema,
+} from '@/modules/counterfactual-safes/routes/entities/delete-counterfactual-safe.dto.entity';
+import { GetCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Inject,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+
+@ApiTags('counterfactual-safes')
+@Controller({
+  path: 'users/counterfactual-safes',
+  version: '1',
+})
+@UseGuards(AuthGuard)
+export class CounterfactualSafesController {
+  public constructor(
+    @Inject(CounterfactualSafesService)
+    private readonly counterfactualSafesService: CounterfactualSafesService,
+  ) {}
+
+  @ApiOperation({
+    summary: 'Save counterfactual Safe creation parameters',
+    description:
+      'Stores the CREATE2 deployment parameters for one or more counterfactual (undeployed) Safes. These parameters are needed to deploy the Safe later.',
+  })
+  @ApiBody({
+    type: CreateCounterfactualSafesDto,
+    description: 'Counterfactual Safe creation parameters',
+  })
+  @ApiCreatedResponse({
+    description: 'Counterfactual Safes saved successfully',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required',
+  })
+  @Post()
+  public async create(
+    @Body(new ValidationPipe(CounterfactualSafesSchema))
+    body: CreateCounterfactualSafesDto,
+    @Auth() authPayload: AuthPayload,
+  ): Promise<void> {
+    return await this.counterfactualSafesService.create({
+      authPayload,
+      payload: body.safes,
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Get counterfactual Safes',
+    description:
+      'Retrieves all counterfactual (undeployed) Safes for the authenticated user, grouped by chain ID.',
+  })
+  @ApiOkResponse({
+    description: 'Counterfactual Safes retrieved successfully',
+    type: GetCounterfactualSafesResponse,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required',
+  })
+  @Get()
+  public async get(
+    @Auth() authPayload: AuthPayload,
+  ): Promise<GetCounterfactualSafesResponse> {
+    return await this.counterfactualSafesService.get(authPayload);
+  }
+
+  @ApiOperation({
+    summary: 'Delete counterfactual Safes',
+    description:
+      'Removes counterfactual Safe records for the authenticated user, typically after successful deployment.',
+  })
+  @ApiNoContentResponse({
+    description: 'Counterfactual Safes deleted successfully',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required',
+  })
+  @ApiNotFoundResponse({
+    description: 'Counterfactual Safe not found',
+  })
+  @Delete()
+  @HttpCode(204)
+  public async delete(
+    @Body(new ValidationPipe(DeleteCounterfactualSafesSchema))
+    body: DeleteCounterfactualSafesDto,
+    @Auth() authPayload: AuthPayload,
+  ): Promise<void> {
+    return await this.counterfactualSafesService.delete({
+      authPayload,
+      payload: body.safes,
+    });
+  }
+}

--- a/src/modules/counterfactual-safes/routes/counterfactual-safes.service.ts
+++ b/src/modules/counterfactual-safes/routes/counterfactual-safes.service.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import { ICounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface';
+import { CreateCounterfactualSafeDto } from '@/modules/counterfactual-safes/routes/entities/create-counterfactual-safe.dto.entity';
+import { DeleteCounterfactualSafeDto } from '@/modules/counterfactual-safes/routes/entities/delete-counterfactual-safe.dto.entity';
+import { GetCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
+import { transformCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/counterfactual-safes.utils';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CounterfactualSafesService {
+  public constructor(
+    @Inject(ICounterfactualSafesRepository)
+    private readonly counterfactualSafesRepository: ICounterfactualSafesRepository,
+  ) {}
+
+  public async create(args: {
+    authPayload: AuthPayload;
+    payload: Array<CreateCounterfactualSafeDto>;
+  }): Promise<void> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+
+    return await this.counterfactualSafesRepository.create({
+      creatorId: userId,
+      payload: args.payload.map((item) => ({
+        chainId: item.chainId,
+        address: item.address,
+        factoryAddress: item.factoryAddress,
+        masterCopy: item.masterCopy,
+        saltNonce: item.saltNonce,
+        safeVersion: item.safeVersion,
+        threshold: item.threshold,
+        owners: item.owners,
+        fallbackHandler: item.fallbackHandler ?? null,
+        setupTo: item.to ?? null,
+        setupData: item.data,
+        paymentToken: item.paymentToken ?? null,
+        payment: item.payment ?? null,
+        paymentReceiver: item.paymentReceiver ?? null,
+      })),
+    });
+  }
+
+  public async get(
+    authPayload: AuthPayload,
+  ): Promise<GetCounterfactualSafesResponse> {
+    const userId = getAuthenticatedUserIdOrFail(authPayload);
+
+    const counterfactualSafes =
+      await this.counterfactualSafesRepository.findByCreatorId({
+        creatorId: userId,
+      });
+
+    return {
+      safes: transformCounterfactualSafesResponse(counterfactualSafes),
+    };
+  }
+
+  public async delete(args: {
+    authPayload: AuthPayload;
+    payload: Array<DeleteCounterfactualSafeDto>;
+  }): Promise<void> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+
+    await this.counterfactualSafesRepository.delete({
+      creatorId: userId,
+      payload: args.payload,
+    });
+  }
+}

--- a/src/modules/counterfactual-safes/routes/counterfactual-safes.utils.ts
+++ b/src/modules/counterfactual-safes/routes/counterfactual-safes.utils.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import type {
+  GetCounterfactualSafeItem,
+  GetCounterfactualSafesResponse,
+} from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
+import { groupBy, mapValues } from 'lodash';
+
+export function transformCounterfactualSafesResponse(
+  counterfactualSafes: Array<CounterfactualSafe>,
+): GetCounterfactualSafesResponse['safes'] {
+  const grouped = groupBy(counterfactualSafes, 'chainId');
+
+  return mapValues(grouped, (items) =>
+    items.map(
+      (item): GetCounterfactualSafeItem => ({
+        address: item.address,
+        factoryAddress: item.factoryAddress,
+        masterCopy: item.masterCopy,
+        saltNonce: item.saltNonce,
+        safeVersion: item.safeVersion,
+        threshold: item.threshold,
+        owners: item.owners,
+        fallbackHandler: item.fallbackHandler,
+        to: item.setupTo,
+        data: item.setupData,
+        paymentToken: item.paymentToken,
+        payment: item.payment,
+        paymentReceiver: item.paymentReceiver,
+      }),
+    ),
+  );
+}

--- a/src/modules/counterfactual-safes/routes/entities/counterfactual-safe.dto.entity.ts
+++ b/src/modules/counterfactual-safes/routes/entities/counterfactual-safe.dto.entity.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+import { SemverSchema } from '@/validation/entities/schemas/semver.schema';
+import z from 'zod';
+
+export const CounterfactualSafeSchema = z.object({
+  chainId: ChainIdSchema,
+  address: AddressSchema,
+  factoryAddress: AddressSchema,
+  masterCopy: AddressSchema,
+  saltNonce: NumericStringSchema.pipe(z.string().max(78)),
+  safeVersion: SemverSchema,
+  threshold: z.number().int().positive(),
+  owners: z.array(AddressSchema).nonempty(),
+  fallbackHandler: AddressSchema.nullish(),
+  to: AddressSchema.nullish(),
+  data: HexSchema,
+  paymentToken: AddressSchema.nullish(),
+  payment: NumericStringSchema.nullish(),
+  paymentReceiver: AddressSchema.nullish(),
+});
+
+export const CounterfactualSafesSchema = z.object({
+  safes: z.array(CounterfactualSafeSchema).nonempty().max(100),
+});
+
+export class CounterfactualSafeDto implements z.infer<
+  typeof CounterfactualSafeSchema
+> {
+  @ApiProperty({ type: String })
+  public readonly chainId!: CounterfactualSafe['chainId'];
+
+  @ApiProperty({ type: String })
+  public readonly address!: CounterfactualSafe['address'];
+
+  @ApiProperty({ type: String })
+  public readonly factoryAddress!: CounterfactualSafe['factoryAddress'];
+
+  @ApiProperty({ type: String })
+  public readonly masterCopy!: CounterfactualSafe['masterCopy'];
+
+  @ApiProperty({ type: String })
+  public readonly saltNonce!: CounterfactualSafe['saltNonce'];
+
+  @ApiProperty({ type: String })
+  public readonly safeVersion!: CounterfactualSafe['safeVersion'];
+
+  @ApiProperty({ type: Number })
+  public readonly threshold!: CounterfactualSafe['threshold'];
+
+  @ApiProperty({ type: [String] })
+  public readonly owners!: CounterfactualSafe['owners'];
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  public readonly fallbackHandler?: CounterfactualSafe['fallbackHandler'];
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  public readonly to?: CounterfactualSafe['setupTo'];
+
+  @ApiProperty({ type: String })
+  public readonly data!: CounterfactualSafe['setupData'];
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  public readonly paymentToken?: CounterfactualSafe['paymentToken'];
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  public readonly payment?: CounterfactualSafe['payment'];
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  public readonly paymentReceiver?: CounterfactualSafe['paymentReceiver'];
+}
+
+export class CounterfactualSafesDto implements z.infer<
+  typeof CounterfactualSafesSchema
+> {
+  @ApiProperty({ type: CounterfactualSafeDto, isArray: true })
+  public readonly safes!: [
+    CounterfactualSafeDto,
+    ...Array<CounterfactualSafeDto>,
+  ];
+}

--- a/src/modules/counterfactual-safes/routes/entities/create-counterfactual-safe.dto.entity.ts
+++ b/src/modules/counterfactual-safes/routes/entities/create-counterfactual-safe.dto.entity.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import {
+  CounterfactualSafeDto,
+  CounterfactualSafesDto,
+} from '@/modules/counterfactual-safes/routes/entities/counterfactual-safe.dto.entity';
+
+export class CreateCounterfactualSafeDto extends CounterfactualSafeDto {}
+export class CreateCounterfactualSafesDto extends CounterfactualSafesDto {}

--- a/src/modules/counterfactual-safes/routes/entities/delete-counterfactual-safe.dto.entity.ts
+++ b/src/modules/counterfactual-safes/routes/entities/delete-counterfactual-safe.dto.entity.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty } from '@nestjs/swagger';
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import z from 'zod';
+
+const DeleteCounterfactualSafeSchema = z.object({
+  chainId: ChainIdSchema,
+  address: AddressSchema,
+});
+
+export const DeleteCounterfactualSafesSchema = z.object({
+  safes: z.array(DeleteCounterfactualSafeSchema).nonempty().max(100),
+});
+
+export class DeleteCounterfactualSafeDto implements z.infer<
+  typeof DeleteCounterfactualSafeSchema
+> {
+  @ApiProperty({ type: String })
+  public readonly chainId!: CounterfactualSafe['chainId'];
+
+  @ApiProperty({ type: String })
+  public readonly address!: CounterfactualSafe['address'];
+}
+
+export class DeleteCounterfactualSafesDto implements z.infer<
+  typeof DeleteCounterfactualSafesSchema
+> {
+  @ApiProperty({ type: DeleteCounterfactualSafeDto, isArray: true })
+  public readonly safes!: [
+    DeleteCounterfactualSafeDto,
+    ...Array<DeleteCounterfactualSafeDto>,
+  ];
+}

--- a/src/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity.ts
+++ b/src/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { CounterfactualSafe } from '@/modules/counterfactual-safes/datasources/entities/counterfactual-safe.entity.db';
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
+import type { Address, Hex } from 'viem';
+
+export class GetCounterfactualSafeItem {
+  @ApiProperty({ type: String })
+  public readonly address!: Address;
+
+  @ApiProperty({ type: String })
+  public readonly factoryAddress!: Address;
+
+  @ApiProperty({ type: String })
+  public readonly masterCopy!: Address;
+
+  @ApiProperty({ type: String })
+  public readonly saltNonce!: string;
+
+  @ApiProperty({ type: String })
+  public readonly safeVersion!: string;
+
+  @ApiProperty({ type: Number })
+  public readonly threshold!: number;
+
+  @ApiProperty({ type: [String] })
+  public readonly owners!: Array<Address>;
+
+  @ApiProperty({ type: String, nullable: true })
+  public readonly fallbackHandler!: Address | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  public readonly to!: Address | null;
+
+  @ApiProperty({ type: String })
+  public readonly data!: Hex;
+
+  @ApiProperty({ type: String, nullable: true })
+  public readonly paymentToken!: Address | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  public readonly payment!: string | null;
+
+  @ApiProperty({ type: String, nullable: true })
+  public readonly paymentReceiver!: Address | null;
+}
+
+@ApiExtraModels(GetCounterfactualSafeItem)
+export class GetCounterfactualSafesResponse {
+  @ApiProperty({
+    type: 'object',
+    additionalProperties: {
+      type: 'array',
+      items: {
+        $ref: getSchemaPath(GetCounterfactualSafeItem),
+      },
+    },
+    example: {
+      '{chainId}': [
+        {
+          address: '0x...',
+          factoryAddress: '0x...',
+          masterCopy: '0x...',
+          saltNonce: '1712000000000',
+          safeVersion: '1.4.1',
+          threshold: 1,
+          owners: ['0x...'],
+          fallbackHandler: '0x...',
+          to: null,
+          data: '0x...',
+          paymentToken: null,
+          payment: null,
+          paymentReceiver: null,
+        },
+      ],
+    },
+  })
+  public readonly safes!: {
+    [chainId: CounterfactualSafe['chainId']]: Array<GetCounterfactualSafeItem>;
+  };
+}

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.controller.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.controller.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import { SpaceCounterfactualSafesService } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.service';
+import { GetCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+import {
+  Controller,
+  Get,
+  Inject,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  ApiOperation,
+  ApiParam,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+
+@ApiTags('spaces')
+@Controller({
+  path: 'spaces/:spaceId/counterfactual-safes',
+  version: '1',
+})
+@UseGuards(AuthGuard)
+export class SpaceCounterfactualSafesController {
+  public constructor(
+    @Inject(SpaceCounterfactualSafesService)
+    private readonly spaceCounterfactualSafesService: SpaceCounterfactualSafesService,
+  ) {}
+
+  @ApiOperation({
+    summary: 'Get counterfactual Safes in a space',
+    description:
+      'Retrieves creation parameters for all counterfactual (undeployed) Safes that are associated with a space. Uses a join between space_safes and counterfactual_safes to provide full transparency on Safe ownership and deployment parameters to all space members.',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'number',
+    description: 'Space ID',
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Counterfactual Safes retrieved successfully',
+    type: GetCounterfactualSafesResponse,
+  })
+  @ApiUnauthorizedResponse({
+    description:
+      'Authentication required or user is not a member of this space',
+  })
+  @ApiNotFoundResponse({
+    description: 'Space not found',
+  })
+  @Get()
+  public async get(
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: number,
+    @Auth() authPayload: AuthPayload,
+  ): Promise<GetCounterfactualSafesResponse> {
+    return await this.spaceCounterfactualSafesService.get(spaceId, authPayload);
+  }
+}

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.service.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import { ISpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository.interface';
+import { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
+import { assertMember } from '@/modules/spaces/routes/utils/space-assert.utils';
+import { ICounterfactualSafesRepository } from '@/modules/counterfactual-safes/domain/counterfactual-safes.repository.interface';
+import { GetCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
+import { transformCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/counterfactual-safes.utils';
+import { Inject, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SpaceCounterfactualSafesService {
+  public constructor(
+    @Inject(IMembersRepository)
+    private readonly membersRepository: IMembersRepository,
+    @Inject(ISpaceSafesRepository)
+    private readonly spaceSafesRepository: ISpaceSafesRepository,
+    @Inject(ICounterfactualSafesRepository)
+    private readonly counterfactualSafesRepository: ICounterfactualSafesRepository,
+  ) {}
+
+  public async get(
+    spaceId: Space['id'],
+    authPayload: AuthPayload,
+  ): Promise<GetCounterfactualSafesResponse> {
+    const userId = getAuthenticatedUserIdOrFail(authPayload);
+    await assertMember(this.membersRepository, spaceId, userId);
+
+    const spaceSafes = await this.spaceSafesRepository.findBySpaceId(spaceId);
+
+    if (spaceSafes.length === 0) {
+      return { safes: {} };
+    }
+
+    const whereClause = spaceSafes.map((safe) => ({
+      chainId: safe.chainId,
+      address: safe.address,
+    }));
+
+    const counterfactualSafes = await this.counterfactualSafesRepository.find({
+      where: whereClause,
+    });
+
+    return {
+      safes: transformCounterfactualSafesResponse(counterfactualSafes),
+    };
+  }
+}

--- a/src/validation/entities/schemas/semver.schema.ts
+++ b/src/validation/entities/schemas/semver.schema.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import semver from 'semver';
+
+export const SemverSchema = z
+  .string()
+  .refine((value) => semver.parse(value) !== null, {
+    error: 'Invalid semver string',
+  });


### PR DESCRIPTION
> Creation params saved, localStorage no more,
> SET NULL keeps the data when users walk out the door,
> Space members can see through the join.

## What it solves

Counterfactual (undeployed) Safes are currently stored **only in browser localStorage**. If a user clears browser data or switches devices, they lose the CREATE2 parameters (factory, salt, signers, threshold, etc.) needed to deploy the Safe — and any funds sent to that predicted address become unrecoverable.

This PR adds a new CGW module to persist counterfactual Safe creation parameters in the database, enabling recovery from any device.

## How this PR fixes it

Adds a new `counterfactual-safes` NestJS module with:

### Database
- New `counterfactual_safes` table storing all CREATE2 deployment parameters
- `creator_id` FK to `users` with **SET NULL on delete** — creation params survive user deletion (they're immutable facts about a CREATE2 address)
- `UNIQUE(chain_id, address)` — a CREATE2 address is globally unique per chain
- No `space_id` column — space association uses the existing `space_safes` join table

### API Endpoints

**User-scoped (personal CRUD):**
- `POST /v1/users/counterfactual-safes` — save creation params
- `GET /v1/users/counterfactual-safes` — retrieve user's CF safes grouped by chain
- `DELETE /v1/users/counterfactual-safes` — remove after deployment

**Space-scoped (read-only, for transparency):**
- `GET /v1/spaces/:spaceId/counterfactual-safes` — joins `space_safes` with `counterfactual_safes` on `(chain_id, address)` so all space members can inspect owners, threshold, etc. before trusting a CF safe address

### Architecture
- Follows existing module patterns (repository interface + implementation, service, controller, DTOs with Zod validation)
- Registered in `app.module.ts` under the `users` feature flag
- DTO maps frontend naming (`to`/`data`) to DB naming (`setup_to`/`setup_data`) in the service layer

## How to test it

- [ ] Run `npx tsc --noEmit` — no new type errors from this module
- [ ] Run migrations against a test database and verify table creation
- [ ] POST to `/v1/users/counterfactual-safes` with valid creation params → 201
- [ ] GET `/v1/users/counterfactual-safes` → returns grouped by chainId
- [ ] DELETE `/v1/users/counterfactual-safes` → 204
- [ ] Add CF safe address to a space via existing `POST /v1/spaces/:spaceId/safes`
- [ ] GET `/v1/spaces/:spaceId/counterfactual-safes` → returns creation params via join
- [ ] Delete the creator user → verify creation params remain (SET NULL)

## Visual summary

```mermaid
flowchart LR
    subgraph "User-scoped endpoints"
        A[POST /users/counterfactual-safes] --> DB[(counterfactual_safes)]
        B[GET /users/counterfactual-safes] --> DB
        C[DELETE /users/counterfactual-safes] --> DB
    end

    subgraph "Space-scoped endpoint"
        D[GET /spaces/:id/counterfactual-safes] --> SS[(space_safes)]
        SS -->|JOIN on chain_id, address| DB
    end

    DB -->|creator_id FK SET NULL| U[(users)]
```

- [x] Tests added
- [x] Follows existing CGW module patterns
- [x] No new type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)