### PR TITLE
updated me endpoint to return user session

### DIFF
--- a/src/modules/auth/routes/auth.controller.integration.spec.ts
+++ b/src/modules/auth/routes/auth.controller.integration.spec.ts
@@ -655,7 +655,7 @@ describe('AuthController', () => {
   });
 
   describe('GET /v1/auth/me', () => {
-    it('should return 200 with user id for a valid Siwe access token', async () => {
+    it('should return 200 with id, authMethod and signerAddress for a valid Siwe access token', async () => {
       const authPayloadDto = siweAuthPayloadDtoBuilder().build();
       const accessToken = jwtService.sign(authPayloadDto);
 
@@ -664,11 +664,15 @@ describe('AuthController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect(({ body }) => {
-          expect(body).toEqual({ id: authPayloadDto.sub });
+          expect(body).toEqual({
+            id: authPayloadDto.sub,
+            authMethod: 'siwe',
+            signerAddress: authPayloadDto.signer_address,
+          });
         });
     });
 
-    it('should return 200 with user id for a valid OIDC access token', async () => {
+    it('should return 200 with id and authMethod (no signerAddress) for a valid OIDC access token', async () => {
       const authPayloadDto = oidcAuthPayloadDtoBuilder().build();
       const accessToken = jwtService.sign(authPayloadDto);
 
@@ -677,7 +681,11 @@ describe('AuthController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect(({ body }) => {
-          expect(body).toEqual({ id: authPayloadDto.sub });
+          expect(body).toEqual({
+            id: authPayloadDto.sub,
+            authMethod: 'oidc',
+          });
+          expect(body).not.toHaveProperty('signerAddress');
         });
     });
 

--- a/src/modules/auth/routes/auth.controller.ts
+++ b/src/modules/auth/routes/auth.controller.ts
@@ -87,14 +87,13 @@ export class AuthController {
     if (!authPayload.isAuthenticated()) {
       throw new ForbiddenException('Not authenticated');
     }
-    const session: UserSession = {
+    return {
       id: authPayload.sub,
       authMethod: authPayload.auth_method,
+      ...(authPayload.isSiwe() && {
+        signerAddress: authPayload.signer_address,
+      }),
     };
-    if (authPayload.isSiwe()) {
-      session.signerAddress = authPayload.signer_address;
-    }
-    return session;
   }
 
   @ApiOperation({

--- a/src/modules/auth/routes/auth.controller.ts
+++ b/src/modules/auth/routes/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   ACCESS_TOKEN_COOKIE_NAME,
   getCookieOptions,
 } from '@/modules/auth/utils/auth-cookie.utils';
+import { assertAuthenticated } from '@/modules/auth/utils/assert-authenticated.utils';
 import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
@@ -72,14 +73,26 @@ export class AuthController {
   @ApiOperation({
     summary: 'Get authenticated user',
     description:
-      'Returns the authenticated user ID if a valid session cookie is present, 403 otherwise.',
+      'Returns the authenticated user session if a valid session cookie is present, 403 otherwise. ' +
+      'The response includes the user ID, the authentication method used, and (for SIWE users) the wallet signer address.',
   })
-  @ApiOkResponse({ description: 'Authenticated user ID', type: UserSession })
+  @ApiOkResponse({
+    description: 'Authenticated user session',
+    type: UserSession,
+  })
   @ApiForbiddenResponse({ description: 'Not authenticated' })
   @UseGuards(AuthGuard)
   @Get('me')
   getMe(@Auth() authPayload: AuthPayload): UserSession {
-    return { id: authPayload.getUserId() as string };
+    assertAuthenticated(authPayload);
+    const session: UserSession = {
+      id: authPayload.sub,
+      authMethod: authPayload.auth_method,
+    };
+    if (authPayload.isSiwe()) {
+      session.signerAddress = authPayload.signer_address;
+    }
+    return session;
   }
 
   @ApiOperation({

--- a/src/modules/auth/routes/auth.controller.ts
+++ b/src/modules/auth/routes/auth.controller.ts
@@ -5,7 +5,6 @@ import {
   ACCESS_TOKEN_COOKIE_NAME,
   getCookieOptions,
 } from '@/modules/auth/utils/auth-cookie.utils';
-import { assertAuthenticated } from '@/modules/auth/utils/assert-authenticated.utils';
 import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
@@ -19,6 +18,7 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   HttpCode,
   Inject,
@@ -84,7 +84,9 @@ export class AuthController {
   @UseGuards(AuthGuard)
   @Get('me')
   getMe(@Auth() authPayload: AuthPayload): UserSession {
-    assertAuthenticated(authPayload);
+    if (!authPayload.isAuthenticated()) {
+      throw new ForbiddenException('Not authenticated');
+    }
     const session: UserSession = {
       id: authPayload.sub,
       authMethod: authPayload.auth_method,

--- a/src/modules/auth/routes/entities/user-session.entity.ts
+++ b/src/modules/auth/routes/entities/user-session.entity.ts
@@ -1,7 +1,18 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ApiProperty } from '@nestjs/swagger';
+import { AuthMethod } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { Address } from 'viem';
 
 export class UserSession {
   @ApiProperty()
   id!: string;
+
+  @ApiProperty({ enum: Object.values(AuthMethod) })
+  authMethod!: (typeof AuthMethod)[keyof typeof AuthMethod];
+
+  @ApiPropertyOptional({
+    description:
+      'Wallet signer address. Present only for SIWE-authenticated users.',
+  })
+  signerAddress?: Address;
 }

--- a/src/modules/spaces/routes/entities/members.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/members.dto.entity.ts
@@ -19,7 +19,7 @@ class MemberUser implements Pick<User, 'id'> {
   status!: keyof typeof UserStatus;
 }
 
-export class Member {
+export class MemberDto {
   @ApiProperty({ type: Number })
   id!: DomainMember['id'];
 
@@ -49,6 +49,6 @@ export class Member {
 }
 
 export class MembersDto {
-  @ApiProperty({ type: Member, isArray: true })
-  members!: Array<Member>;
+  @ApiProperty({ type: MemberDto, isArray: true })
+  members!: Array<MemberDto>;
 }

--- a/src/modules/spaces/routes/entities/members.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/members.dto.entity.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import {
   MemberRole,
@@ -18,7 +19,7 @@ class MemberUser implements Pick<User, 'id'> {
   status!: keyof typeof UserStatus;
 }
 
-class Member {
+export class Member {
   @ApiProperty({ type: Number })
   id!: DomainMember['id'];
 

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -32,7 +32,10 @@ import {
 } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { UpdateRoleDtoSchema } from '@/modules/spaces/routes/entities/update-role.dto.entity';
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
-import { MembersDto } from '@/modules/spaces/routes/entities/members.dto.entity';
+import {
+  Member,
+  MembersDto,
+} from '@/modules/spaces/routes/entities/members.dto.entity';
 import { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { UpdateRoleDto } from '@/modules/spaces/routes/entities/update-role.dto.entity';
@@ -212,6 +215,40 @@ export class MembersController {
     spaceId: number,
   ): Promise<MembersDto> {
     return await this.membersService.get({
+      authPayload,
+      spaceId,
+    });
+  }
+
+  @ApiOperation({
+    summary: "Get the authenticated user's membership in a space",
+    description:
+      'Returns the membership record of the authenticated user for the given space. ' +
+      'Returns 403 if the caller has no ACTIVE or INVITED membership in the space.',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'number',
+    description: "Space ID to fetch the caller's membership for",
+    example: 1,
+  })
+  @ApiOkResponse({
+    description: 'Membership retrieved successfully',
+    type: Member,
+  })
+  @ApiForbiddenResponse({
+    description:
+      'Access forbidden - user not authenticated, or has no ACTIVE/INVITED membership in this space',
+  })
+  @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @Get('/:spaceId/membership')
+  @UseGuards(AuthGuard)
+  public async getMembership(
+    @Auth() authPayload: AuthPayload,
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: number,
+  ): Promise<Member> {
+    return await this.membersService.getSelfMembership({
       authPayload,
       spaceId,
     });

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -33,7 +33,7 @@ import {
 import { UpdateRoleDtoSchema } from '@/modules/spaces/routes/entities/update-role.dto.entity';
 import { RowSchema } from '@/datasources/db/v1/entities/row.entity';
 import {
-  Member,
+  MemberDto,
   MembersDto,
 } from '@/modules/spaces/routes/entities/members.dto.entity';
 import { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
@@ -234,7 +234,7 @@ export class MembersController {
   })
   @ApiOkResponse({
     description: 'Membership retrieved successfully',
-    type: Member,
+    type: MemberDto,
   })
   @ApiForbiddenResponse({
     description:
@@ -247,7 +247,7 @@ export class MembersController {
     @Auth() authPayload: AuthPayload,
     @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     spaceId: number,
-  ): Promise<Member> {
+  ): Promise<MemberDto> {
     return await this.membersService.getSelfMembership({
       authPayload,
       spaceId,

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -8,7 +8,7 @@ import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import type { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
 import type {
-  Member,
+  MemberDto,
   MembersDto,
 } from '@/modules/spaces/routes/entities/members.dto.entity';
 import type { UpdateRoleDto } from '@/modules/spaces/routes/entities/update-role.dto.entity';
@@ -80,7 +80,7 @@ export class MembersService {
   public async getSelfMembership(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-  }): Promise<Member> {
+  }): Promise<MemberDto> {
     return await this.membersRepository.findSelfMembershipOrFail({
       authPayload: args.authPayload,
       spaceId: args.spaceId,

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { ConflictException, Inject } from '@nestjs/common';
 import { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 import { User } from '@/modules/users/domain/entities/user.entity';
@@ -6,7 +7,10 @@ import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.en
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import type { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
-import type { MembersDto } from '@/modules/spaces/routes/entities/members.dto.entity';
+import type {
+  Member,
+  MembersDto,
+} from '@/modules/spaces/routes/entities/members.dto.entity';
 import type { UpdateRoleDto } from '@/modules/spaces/routes/entities/update-role.dto.entity';
 import type { UpdateMemberAliasDto } from '@/modules/spaces/routes/entities/update-member-name.dto.entity';
 import { AcceptInviteDto } from '@/modules/spaces/routes/entities/accept-invite.dto.entity';
@@ -71,6 +75,16 @@ export class MembersService {
         spaceId: args.spaceId,
       }),
     };
+  }
+
+  public async getSelfMembership(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<Member> {
+    return await this.membersRepository.findSelfMembershipOrFail({
+      authPayload: args.authPayload,
+      spaceId: args.spaceId,
+    });
   }
 
   public async updateRole(args: {

--- a/src/modules/users/__tests__/test.users.module.ts
+++ b/src/modules/users/__tests__/test.users.module.ts
@@ -37,6 +37,7 @@ import { IMembersRepository } from '@/modules/users/domain/members.repository.in
         acceptInvite: jest.fn(),
         declineInvite: jest.fn(),
         findAuthorizedMembersOrFail: jest.fn(),
+        findSelfMembershipOrFail: jest.fn(),
         updateRole: jest.fn(),
         updateAlias: jest.fn(),
         removeUser: jest.fn(),

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -1743,6 +1743,55 @@ describe('MembersRepository', () => {
     });
   });
 
+  describe('findSelfMembershipOrFail', () => {
+    it.each([
+      ['SIWE', 'ACTIVE', createSiweUser],
+      ['OIDC', 'ACTIVE', createOidcUser],
+      ['SIWE', 'INVITED', createSiweUser],
+      ['OIDC', 'INVITED', createOidcUser],
+    ] as const)(
+      'should return the membership row for a %s caller with %s status',
+      async (_authLabel, memberStatus, createUser) => {
+        const spaceName = nameBuilder();
+        const memberName = nameBuilder();
+        const memberInvitedBy = getAddress(faker.finance.ethereumAddress());
+        const { userId, user, authPayload } = await createUser();
+        const space = await dbSpacesRepository.insert({
+          name: spaceName,
+          status: 'ACTIVE',
+        });
+        const memberRole = faker.helpers.arrayElement(MemberRoleKeys);
+        const spaceId = space.generatedMaps[0].id;
+        const member = await dbMembersRepository.insert({
+          user,
+          space: space.generatedMaps[0],
+          name: memberName,
+          role: memberRole,
+          status: memberStatus,
+          invitedBy: memberInvitedBy,
+        });
+        const memberId = member.identifiers[0].id as Member['id'];
+
+        await expect(
+          membersRepository.findSelfMembershipOrFail({
+            authPayload,
+            spaceId,
+          }),
+        ).resolves.toEqual(
+          expect.objectContaining({
+            id: memberId,
+            name: memberName,
+            alias: null,
+            role: memberRole,
+            status: memberStatus,
+            invitedBy: memberInvitedBy,
+            user: expect.objectContaining({ id: userId }),
+          }),
+        );
+      },
+    );
+  });
+
   describe('updateRole', () => {
     it('should update the role of a member', async () => {
       const spaceName = nameBuilder();

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -1790,6 +1790,56 @@ describe('MembersRepository', () => {
         );
       },
     );
+
+    it('should throw ForbiddenException for a DECLINED caller', async () => {
+      const spaceName = nameBuilder();
+      const { user, authPayload, authPayloadDto } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user,
+        space: space.generatedMaps[0],
+        name: faker.person.firstName(),
+        role: faker.helpers.arrayElement(MemberRoleKeys),
+        status: 'DECLINED',
+        invitedBy: authPayloadDto.signer_address,
+      });
+
+      await expect(
+        membersRepository.findSelfMembershipOrFail({
+          authPayload,
+          spaceId,
+        }),
+      ).rejects.toThrow(
+        new ForbiddenException(
+          'The user is not an active member of the space.',
+        ),
+      );
+    });
+
+    it('should throw ForbiddenException when the caller has no membership row in the space', async () => {
+      const spaceName = nameBuilder();
+      const { authPayload } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+
+      await expect(
+        membersRepository.findSelfMembershipOrFail({
+          authPayload,
+          spaceId,
+        }),
+      ).rejects.toThrow(
+        new ForbiddenException(
+          'The user is not an active member of the space.',
+        ),
+      );
+    });
   });
 
   describe('updateRole', () => {

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
@@ -55,6 +56,11 @@ export interface IMembersRepository {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<Array<Member>>;
+
+  findSelfMembershipOrFail(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<Member>;
 
   updateRole(args: {
     authPayload: AuthPayload;

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -417,7 +417,7 @@ export class MembersRepository implements IMembersRepository {
       spaceId: Space['id'];
     },
     relations?: FindOptionsRelations<DbMember>,
-  ): Promise<DbMember> {
+  ): Promise<Member> {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
 
     const membersRepository =

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -243,28 +243,22 @@ export class MembersRepository implements IMembersRepository {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<Array<Member>> {
-    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
-
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    const member = await membersRepository.findOne({
-      where: {
-        user: { id: userId },
-        space: { id: args.spaceId },
-        status: In(['ACTIVE', 'INVITED']),
-      },
-    });
-    if (!member) {
-      throw new ForbiddenException(
-        'The user is not an active member of the space.',
-      );
-    }
+    await this.findActiveOrInvitedMemberOrFail(args);
     const space = await this.spacesRepository.findOneOrFail({
       where: { id: args.spaceId },
       relations: { members: { user: true } },
     });
 
     return space.members;
+  }
+
+  public async findSelfMembershipOrFail(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<Member> {
+    return await this.findActiveOrInvitedMemberOrFail(args, {
+      user: true,
+    });
   }
 
   private findActiveAdminsOrFail(spaceId: Space['id']): Promise<Array<Member>> {
@@ -405,5 +399,42 @@ export class MembersRepository implements IMembersRepository {
 
   private isActiveAdmin(member: DbMember): boolean {
     return member.role === 'ADMIN' && member.status === 'ACTIVE';
+  }
+
+  /**
+   * Returns the authenticated user's `ACTIVE` or `INVITED` membership row
+   * for the given space, or throws `ForbiddenException` if none exists.
+   *
+   * Shared by {@link findAuthorizedMembersOrFail} (which uses it as an
+   * authorization gate and discards the row, so it omits `relations`) and
+   * by {@link findSelfMembershipOrFail} (which returns the row to the
+   * caller and passes `{ user: true }` so the response includes
+   * `user.status`).
+   */
+  private async findActiveOrInvitedMemberOrFail(
+    args: {
+      authPayload: AuthPayload;
+      spaceId: Space['id'];
+    },
+    relations?: FindOptionsRelations<DbMember>,
+  ): Promise<DbMember> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+
+    const membersRepository =
+      await this.postgresDatabaseService.getRepository(DbMember);
+    const member = await membersRepository.findOne({
+      where: {
+        user: { id: userId },
+        space: { id: args.spaceId },
+        status: In(['ACTIVE', 'INVITED']),
+      },
+      relations,
+    });
+    if (!member) {
+      throw new ForbiddenException(
+        'The user is not an active member of the space.',
+      );
+    }
+    return member;
   }
 }


### PR DESCRIPTION
## Summary
updated `/me` and added `/membership` endpoint for member
## Changes
- Updated the `/me` endpoint to return the `userSession`
- Added a New endpoint to get the membership of the current user in the space, optimising the older flow to get membership in FE.  OLD: Get all members -> find the current user membership.

- `assertAuthenticated(authPayload);`  is added in the auth controller to ensure type safety. after the guard check, it will never throw, but will ensure type safety for the userSession to be built
