### PR TITLE
fix: drop stale counterfactual_safes table before recreating it

### DIFF
--- a/migrations/1775500000000-create-counterfactual-safes.ts
+++ b/migrations/1775500000000-create-counterfactual-safes.ts
@@ -3,6 +3,12 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateCounterfactualSafes1775500000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Drop the orphaned table left over from the deprecated Knex "accounts"
+    // module (removed in #2804). That schema is incompatible with the one
+    // below and its FK target (accounts) no longer exists.
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS counterfactual_safes CASCADE;`,
+    );
     await queryRunner.query(
       `CREATE TABLE counterfactual_safes (
         id SERIAL NOT NULL,


### PR DESCRIPTION
## Summary
- CGW staging has been restart-looping since #3011 merged because the counterfactual_safes migration hits `42P07 relation "counterfactual_safes" already exists`.
- The table is left over from the deprecated Knex "accounts" module, whose migration file was removed in #2804 without a DROP — so any DB that existed before Jan 2026 still carries the orphaned table and its dead FK to `accounts(id)`.
- The two schemas are incompatible (old: `creator`, `predicted_address`, `singleton_address`, `owners VARCHAR[]`, FK `accounts`; new: `creator_id`, `address`, `master_copy`, `owners JSONB`, FK `users`), so the existing rows can't be migrated — and nothing has read them for three months.
- Add `DROP TABLE IF EXISTS counterfactual_safes CASCADE;` at the top of the migration's `up()`. CASCADE also removes the stale `update_counterfactual_safes_updated_at` trigger. No-op on fresh DBs; unblocks staging (and any other env with the legacy table) on next deploy.

## Test plan
- [ ] CI migration integration tests pass on a fresh schema (no pre-existing table).
- [ ] Deploy to staging and confirm `DatabaseMigrator` finishes `onModuleInit` without the `42P07` error and the container stops restarting.
- [ ] Smoke the counterfactual-safes endpoints from #3011 (POST/GET/DELETE `/v1/users/counterfactual-safes`, GET `/v1/spaces/:spaceId/counterfactual-safes`) once staging is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)