### PR TITLE
feat: Mark safeTxHash query param optional

### DIFF
--- a/src/modules/relay/routes/relay.controller.ts
+++ b/src/modules/relay/routes/relay.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiOperation,
   ApiParam,
   ApiBody,
+  ApiQuery,
   ApiBadRequestResponse,
   ApiTooManyRequestsResponse,
   ApiNotFoundResponse,
@@ -136,6 +137,12 @@ export class RelayController {
     name: 'safeAddress',
     type: 'string',
     description: 'Safe contract address (0x prefixed hex string)',
+  })
+  @ApiQuery({
+    name: 'safeTxHash',
+    required: false,
+    description:
+      'Safe transaction hash (0x prefixed hex string). Required for chains enabled for relay-fee relayer',
   })
   @ApiOkResponse({
     type: RelaysRemaining,


### PR DESCRIPTION
## Summary

`safeTxHash` must be optional and is used only for `relay-fee` enabled chains.

## Issue


<img width="662" height="456" alt="Screenshot 2026-04-17 at 14 11 06" src="https://github.com/user-attachments/assets/2b2e82db-b73b-4ba3-bca2-239b6f229629" />


## Changes

Enhance the OpenAPI (Swagger) documentation by adding a new optional query parameter.

API Documentation Improvements:

* Added the `@ApiQuery` decorator to document the optional `safeTxHash` query parameter for the relay quota endpoint, clarifying its usage for chains enabled for relay-fee relayer.
* Imported `ApiQuery` from `@nestjs/swagger` to support the new query parameter documentation.