### PR TITLE
fix: address book response type

### DIFF
--- a/src/modules/spaces/routes/entities/space-address-book.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/space-address-book.dto.entity.ts
@@ -18,10 +18,10 @@ export class SpaceAddressBookItemDto {
   @ApiProperty({ type: String })
   public lastUpdatedBy!: AddressBookDbItem['lastUpdatedBy'];
 
-  @ApiProperty()
+  @ApiProperty({ type: Date })
   public createdAt!: AddressBookDbItem['createdAt'];
 
-  @ApiProperty()
+  @ApiProperty({ type: Date })
   public updatedAt!: AddressBookDbItem['updatedAt'];
 }
 


### PR DESCRIPTION
## Summary                                                                                                                                        
- Fix Swagger typing for `createdAt` and `updatedAt` in address book endpoint — was rendering as `object` (`{}`) instead of `string` (`date-time`)
- Root cause: `@ApiProperty()` without explicit `type` can't resolve lookup types (`AddressBookDbItem['createdAt']`) via reflection, falling back to `Object`                                                                                                                                       
                                                                                                                                                    
  ## Test plan                                                                                                                                      
  - [ ] Verify Swagger schema shows `"type": "string", "format": "date-time"` for `createdAt`/`updatedAt` in address book response
  - [x] Confirm autogenerated types from CGW match actual API response
