### PR TITLE
feat: update default fee preview TTL to 10 seconds

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -544,7 +544,7 @@ export default () => ({
       enabledChainIds: process.env.RELAY_FEE_CHAIN_IDS?.split(',') ?? [],
       baseUri: process.env.FEE_SERVICE_BASE_URI,
       feePreviewTtlSeconds: parseInt(
-        process.env.RELAY_FEE_PREVIEW_TTL_SECONDS ?? `${0}`,
+        process.env.RELAY_FEE_PREVIEW_TTL_SECONDS ?? `${10}`,
       ),
     },
   },


### PR DESCRIPTION
## Summary

This pull request makes a small configuration change to the default TTL (time-to-live) for relay fee previews. The fallback value for `RELAY_FEE_PREVIEW_TTL_SECONDS` is increased from 0 to 10 seconds.

### Issue
See: https://github.com/safe-global/safe-client-gateway/pull/3019#discussion_r3099889206