### PR TITLE
feat(authentication): capture and expose authenticated user's email

### DIFF
--- a/migrations/1776200000000-add-user-email.ts
+++ b/migrations/1776200000000-add-user-email.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserEmail1776200000000 implements MigrationInterface {
+  name = 'AddUserEmail1776200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD COLUMN "email" character varying(255)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD CONSTRAINT "users_email_key" UNIQUE ("email")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_users_email_lower" ON "users" (LOWER("email"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_users_email_lower"`);
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP CONSTRAINT "users_email_key"`,
+    );
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "email"`);
+  }
+}

--- a/migrations/1776200000000-add-user-email.ts
+++ b/migrations/1776200000000-add-user-email.ts
@@ -9,7 +9,7 @@ export class AddUserEmail1776200000000 implements MigrationInterface {
       `ALTER TABLE "users" ADD COLUMN "email" character varying(255)`,
     );
     await queryRunner.query(
-      `ALTER TABLE "users" ADD CONSTRAINT "users_email_key" UNIQUE ("email")`,
+      `CREATE UNIQUE INDEX "users_email_key" ON "users" ("email") WHERE "email" IS NOT NULL`,
     );
     await queryRunner.query(
       `CREATE INDEX "idx_users_email_lower" ON "users" (LOWER("email"))`,
@@ -18,9 +18,7 @@ export class AddUserEmail1776200000000 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP INDEX "idx_users_email_lower"`);
-    await queryRunner.query(
-      `ALTER TABLE "users" DROP CONSTRAINT "users_email_key"`,
-    );
+    await queryRunner.query(`DROP INDEX "users_email_key"`);
     await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "email"`);
   }
 }

--- a/src/config/entities/configuration.spec.ts
+++ b/src/config/entities/configuration.spec.ts
@@ -8,11 +8,11 @@ describe('configuration', () => {
     process.env.AUTH0_SCOPE = originalAuth0Scope;
   });
 
-  it('should default AUTH0_SCOPE to openid email profile', () => {
+  it('should default AUTH0_SCOPE to openid email', () => {
     delete process.env.AUTH0_SCOPE;
 
     const result = configuration();
 
-    expect(result.auth.auth0.scope).toBe('openid email profile');
+    expect(result.auth.auth0.scope).toBe('openid email');
   });
 });

--- a/src/config/entities/configuration.spec.ts
+++ b/src/config/entities/configuration.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import configuration from '@/config/entities/configuration';
+
+describe('configuration', () => {
+  const originalAuth0Scope = process.env.AUTH0_SCOPE;
+
+  afterEach(() => {
+    process.env.AUTH0_SCOPE = originalAuth0Scope;
+  });
+
+  it('should default AUTH0_SCOPE to openid email profile', () => {
+    delete process.env.AUTH0_SCOPE;
+
+    const result = configuration();
+
+    expect(result.auth.auth0.scope).toBe('openid email profile');
+  });
+});

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -59,7 +59,7 @@ export default () => ({
       redirectUri: process.env.AUTH0_REDIRECT_URI,
       audience: process.env.AUTH0_API_AUDIENCE,
       signingSecret: process.env.AUTH0_SIGNING_SECRET,
-      scope: process.env.AUTH0_SCOPE || 'openid',
+      scope: process.env.AUTH0_SCOPE || 'openid email profile',
     },
     rateLimit: {
       max: parseInt(process.env.AUTH_RATE_LIMIT_MAX ?? `${5}`),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -59,7 +59,7 @@ export default () => ({
       redirectUri: process.env.AUTH0_REDIRECT_URI,
       audience: process.env.AUTH0_API_AUDIENCE,
       signingSecret: process.env.AUTH0_SIGNING_SECRET,
-      scope: process.env.AUTH0_SCOPE || 'openid email profile',
+      scope: process.env.AUTH0_SCOPE || 'openid email',
     },
     rateLimit: {
       max: parseInt(process.env.AUTH_RATE_LIMIT_MAX ?? `${5}`),

--- a/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
@@ -81,6 +81,27 @@ describe('Auth0TokenVerifier', () => {
       expect(result.exp).toBeUndefined();
     });
 
+    it('should parse verified email claims when present', () => {
+      const accessToken = faker.string.alphanumeric();
+      const email = faker.internet.email().toLowerCase();
+      const decoded = {
+        sub: faker.string.numeric(),
+        email,
+        email_verified: true,
+      };
+      jwtServiceMock.decode.mockReturnValue(decoded);
+
+      const result = target.verifyAndDecode(accessToken);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          sub: decoded.sub,
+          email,
+          email_verified: true,
+        }),
+      );
+    });
+
     it('should throw if sub is missing', () => {
       const accessToken = faker.string.alphanumeric();
       jwtServiceMock.decode.mockReturnValue({});

--- a/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
+++ b/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 
 export const Auth0TokenSchema = JwtClaimsSchema.extend({
   sub: z.string().min(1),
+  email: z.email().optional(),
+  email_verified: z.boolean().optional(),
 });
 
 export type Auth0Token = z.infer<typeof Auth0TokenSchema>;

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -20,11 +20,14 @@ import {
 } from '@/datasources/network/network.service.interface';
 import type { TestingModule } from '@nestjs/testing';
 import { rawify } from '@/validation/entities/raw.entity';
+import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { ConflictException } from '@nestjs/common';
 
 describe('OidcAuthController', () => {
   let app: INestApplication<Server>;
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let jwtService: IJwtService;
+  let usersRepository: jest.MockedObjectDeep<IUsersRepository>;
 
   let maxValidityPeriodInMs: number;
   let stateTtlMs: number;
@@ -44,6 +47,8 @@ describe('OidcAuthController', () => {
     exp?: number;
     iat?: number;
     nbf?: number;
+    email?: string;
+    email_verified?: boolean;
   }): string {
     return sign(claims, auth0Config.signingSecret, {
       algorithm: 'HS256',
@@ -71,6 +76,7 @@ describe('OidcAuthController', () => {
 
     networkService = moduleFixture.get(NetworkService);
     jwtService = moduleFixture.get(IJwtService);
+    usersRepository = moduleFixture.get(IUsersRepository);
 
     const configService: IConfigurationService = moduleFixture.get(
       IConfigurationService,
@@ -500,6 +506,57 @@ describe('OidcAuthController', () => {
           exp: farFutureExp,
           iat: Math.floor(Date.now() / 1_000),
         });
+
+        networkService.postForm.mockResolvedValueOnce({
+          status: 200,
+          data: rawify({
+            access_token: auth0Token,
+            id_token: 'auth0-id-token',
+            token_type: 'Bearer',
+          }),
+        });
+
+        const authorizeResponse = await request(app.getHttpServer())
+          .get('/v1/auth/oidc/authorize')
+          .expect(302);
+
+        const state = new URL(
+          authorizeResponse.headers.location,
+        ).searchParams.get('state');
+        const stateCookie = (
+          authorizeResponse.headers['set-cookie'] as unknown as Array<string>
+        )
+          .find((cookie) => cookie.startsWith('auth_state='))
+          ?.split(';')[0];
+
+        const response = await request(app.getHttpServer())
+          .get('/v1/auth/oidc/callback')
+          .set('Cookie', stateCookie!)
+          .query({
+            code: 'auth-code',
+            state,
+          });
+
+        expectErrorRedirect(response, 'authentication_failed');
+      });
+
+      it('should redirect with authentication_failed when verified email ownership conflicts', async () => {
+        jest.setSystemTime(0);
+
+        const expirationTime = faker.date.between({
+          from: new Date(),
+          to: new Date(Date.now() + maxValidityPeriodInMs),
+        });
+        const auth0Token = signAuth0Token({
+          sub: faker.string.uuid(),
+          email: faker.internet.email().toLowerCase(),
+          email_verified: true,
+          exp: Math.floor(expirationTime.getTime() / 1_000),
+          iat: Math.floor(Date.now() / 1_000),
+        });
+        usersRepository.ensureVerifiedEmail.mockRejectedValue(
+          new ConflictException('Email already belongs to another user'),
+        );
 
         networkService.postForm.mockResolvedValueOnce({
           status: 200,

--- a/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
@@ -8,6 +8,7 @@ import type { IUsersRepository } from '@/modules/users/domain/users.repository.i
 import { faker } from '@faker-js/faker';
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -20,6 +21,7 @@ const authRepositoryMock = {
 
 const usersRepositoryMock = {
   findOrCreateByExtUserId: jest.fn(),
+  ensureVerifiedEmail: jest.fn(),
 } as unknown as jest.MockedObjectDeep<IUsersRepository>;
 
 const auth0RepositoryMock = {
@@ -143,6 +145,114 @@ describe('OidcAuthService', () => {
           iat: new Date(),
         },
       );
+    });
+
+    it('should persist a verified email after finding or creating the user', async () => {
+      const now = new Date();
+      jest.setSystemTime(now);
+
+      const extUserId = `auth0|${faker.string.uuid()}`;
+      const userId = faker.number.int();
+      const email = faker.internet.email().toLowerCase();
+
+      auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
+        sub: extUserId,
+        email,
+        email_verified: true,
+        exp: new Date(now.getTime() + 3600 * 1_000),
+        nbf: undefined,
+        iat: undefined,
+      });
+      usersRepositoryMock.findOrCreateByExtUserId.mockResolvedValue(userId);
+      authRepositoryMock.signToken.mockReturnValue('token');
+
+      await target.authenticateWithOidc(faker.string.alphanumeric(32));
+
+      expect(usersRepositoryMock.ensureVerifiedEmail).toHaveBeenCalledWith(
+        userId,
+        email,
+      );
+    });
+
+    it('should not persist an unverified email', async () => {
+      const now = new Date();
+      jest.setSystemTime(now);
+
+      const extUserId = `auth0|${faker.string.uuid()}`;
+      const userId = faker.number.int();
+
+      auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
+        sub: extUserId,
+        email: faker.internet.email().toLowerCase(),
+        email_verified: false,
+        exp: new Date(now.getTime() + 3600 * 1_000),
+        nbf: undefined,
+        iat: undefined,
+      });
+      usersRepositoryMock.findOrCreateByExtUserId.mockResolvedValue(userId);
+      authRepositoryMock.signToken.mockReturnValue('token');
+
+      await target.authenticateWithOidc(faker.string.alphanumeric(32));
+
+      expect(usersRepositoryMock.ensureVerifiedEmail).not.toHaveBeenCalled();
+    });
+
+    it('should ignore unverified email even when that email would conflict', async () => {
+      const now = new Date();
+      jest.setSystemTime(now);
+
+      const extUserId = `auth0|${faker.string.uuid()}`;
+      const userId = faker.number.int();
+      const accessToken = faker.string.alphanumeric(64);
+
+      auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
+        sub: extUserId,
+        email: faker.internet.email().toLowerCase(),
+        email_verified: false,
+        exp: new Date(now.getTime() + 3600 * 1_000),
+        nbf: undefined,
+        iat: undefined,
+      });
+      usersRepositoryMock.findOrCreateByExtUserId.mockResolvedValue(userId);
+      usersRepositoryMock.ensureVerifiedEmail.mockRejectedValue(
+        new ConflictException('Email already belongs to another user'),
+      );
+      authRepositoryMock.signToken.mockReturnValue(accessToken);
+
+      await expect(
+        target.authenticateWithOidc(faker.string.alphanumeric(32)),
+      ).resolves.toEqual(expect.objectContaining({ accessToken }));
+
+      expect(usersRepositoryMock.ensureVerifiedEmail).not.toHaveBeenCalled();
+    });
+
+    it('should propagate email ownership conflicts', async () => {
+      const now = new Date();
+      jest.setSystemTime(now);
+
+      const extUserId = `auth0|${faker.string.uuid()}`;
+      const userId = faker.number.int();
+      const email = faker.internet.email().toLowerCase();
+      const error = new ConflictException(
+        'Email already belongs to another user',
+      );
+
+      auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
+        sub: extUserId,
+        email,
+        email_verified: true,
+        exp: new Date(now.getTime() + 3600 * 1_000),
+        nbf: undefined,
+        iat: undefined,
+      });
+      usersRepositoryMock.findOrCreateByExtUserId.mockResolvedValue(userId);
+      usersRepositoryMock.ensureVerifiedEmail.mockRejectedValue(error);
+
+      await expect(
+        target.authenticateWithOidc(faker.string.alphanumeric(32)),
+      ).rejects.toThrow(error);
+
+      expect(authRepositoryMock.signToken).not.toHaveBeenCalled();
     });
 
     it('should throw ForbiddenException when exp exceeds max', async () => {

--- a/src/modules/auth/oidc/routes/oidc-auth.service.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.ts
@@ -56,6 +56,8 @@ export class OidcAuthService {
   ): Promise<OidcAuthTokenResponse> {
     const {
       sub: extUserId,
+      email,
+      email_verified: emailVerified,
       exp: expirationTime,
       nbf,
       iat,
@@ -75,6 +77,9 @@ export class OidcAuthService {
 
     const userId =
       await this.usersRepository.findOrCreateByExtUserId(extUserId);
+    if (emailVerified === true && email) {
+      await this.usersRepository.ensureVerifiedEmail(userId, email);
+    }
     const accessToken = this.authRepository.signToken(
       {
         auth_method: AuthMethod.Oidc,

--- a/src/modules/auth/routes/auth.controller.integration.spec.ts
+++ b/src/modules/auth/routes/auth.controller.integration.spec.ts
@@ -692,6 +692,24 @@ describe('AuthController', () => {
         });
     });
 
+    it('should omit email for a valid OIDC access token when none is stored', async () => {
+      const authPayloadDto = oidcAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      usersRepository.findEmailById.mockResolvedValue(undefined);
+
+      await request(app.getHttpServer())
+        .get('/v1/auth/me')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            id: authPayloadDto.sub,
+            authMethod: 'oidc',
+          });
+          expect(body).not.toHaveProperty('email');
+        });
+    });
+
     it('should return 200 with email for a valid OIDC access token when stored', async () => {
       const authPayloadDto = oidcAuthPayloadDtoBuilder().build();
       const accessToken = jwtService.sign(authPayloadDto);

--- a/src/modules/auth/routes/auth.controller.integration.spec.ts
+++ b/src/modules/auth/routes/auth.controller.integration.spec.ts
@@ -24,11 +24,13 @@ import { UsersModule } from '@/modules/users/users.module';
 import { TestUsersModule } from '@/modules/users/__tests__/test.users.module';
 import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import type { TestingModule } from '@nestjs/testing';
+import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 
 describe('AuthController', () => {
   let app: INestApplication<Server>;
   let cacheService: FakeCacheService;
   let jwtService: IJwtService;
+  let usersRepository: jest.MockedObjectDeep<IUsersRepository>;
 
   let maxValidityPeriodInMs: number;
 
@@ -50,6 +52,7 @@ describe('AuthController', () => {
 
     cacheService = moduleFixture.get(CacheService);
     jwtService = moduleFixture.get(IJwtService);
+    usersRepository = moduleFixture.get(IUsersRepository);
 
     const configService: IConfigurationService = moduleFixture.get(
       IConfigurationService,
@@ -686,6 +689,25 @@ describe('AuthController', () => {
             authMethod: 'oidc',
           });
           expect(body).not.toHaveProperty('signerAddress');
+        });
+    });
+
+    it('should return 200 with email for a valid OIDC access token when stored', async () => {
+      const authPayloadDto = oidcAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const email = faker.internet.email().toLowerCase();
+      usersRepository.findEmailById.mockResolvedValue(email);
+
+      await request(app.getHttpServer())
+        .get('/v1/auth/me')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body).toEqual({
+            id: authPayloadDto.sub,
+            authMethod: 'oidc',
+            email,
+          });
         });
     });
 

--- a/src/modules/auth/routes/auth.controller.spec.ts
+++ b/src/modules/auth/routes/auth.controller.spec.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { AuthController } from '@/modules/auth/routes/auth.controller';
+import type { AuthService } from '@/modules/auth/routes/auth.service';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import {
+  oidcAuthPayloadDtoBuilder,
+  siweAuthPayloadDtoBuilder,
+} from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import type { UserSession } from '@/modules/auth/routes/entities/user-session.entity';
+
+const authService = {
+  getUserSession: jest.fn(),
+  getNonce: jest.fn(),
+  authenticateWithSiwe: jest.fn(),
+  getTokenPayloadWithClaims: jest.fn(),
+  getLogoutRedirectUrl: jest.fn(),
+} as jest.MockedObjectDeep<AuthService>;
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    const configurationService = new FakeConfigurationService();
+    configurationService.set('application.isProduction', true);
+
+    controller = new AuthController(configurationService, authService);
+  });
+
+  describe('getMe', () => {
+    it('should delegate SIWE session lookup to the service', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const userSession: UserSession = {
+        id: authPayload.sub!,
+        authMethod: authPayload.auth_method!,
+        signerAddress: authPayload.signer_address,
+      };
+      authService.getUserSession.mockResolvedValue(userSession);
+
+      const result = await controller.getMe(authPayload);
+
+      expect(authService.getUserSession).toHaveBeenCalledWith(authPayload);
+      expect(result).toBe(userSession);
+    });
+
+    it('should return OIDC email from the service result', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const userSession: UserSession = {
+        id: authPayload.sub!,
+        authMethod: authPayload.auth_method!,
+        email: faker.internet.email().toLowerCase(),
+      };
+      authService.getUserSession.mockResolvedValue(userSession);
+
+      const result = await controller.getMe(authPayload);
+
+      expect(authService.getUserSession).toHaveBeenCalledWith(authPayload);
+      expect(result).toBe(userSession);
+    });
+  });
+});

--- a/src/modules/auth/routes/auth.controller.ts
+++ b/src/modules/auth/routes/auth.controller.ts
@@ -18,7 +18,6 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 import {
   Body,
   Controller,
-  ForbiddenException,
   Get,
   HttpCode,
   Inject,
@@ -83,17 +82,8 @@ export class AuthController {
   @ApiForbiddenResponse({ description: 'Not authenticated' })
   @UseGuards(AuthGuard)
   @Get('me')
-  getMe(@Auth() authPayload: AuthPayload): UserSession {
-    if (!authPayload.isAuthenticated()) {
-      throw new ForbiddenException('Not authenticated');
-    }
-    return {
-      id: authPayload.sub,
-      authMethod: authPayload.auth_method,
-      ...(authPayload.isSiwe() && {
-        signerAddress: authPayload.signer_address,
-      }),
-    };
+  async getMe(@Auth() authPayload: AuthPayload): Promise<UserSession> {
+    return this.authService.getUserSession(authPayload);
   }
 
   @ApiOperation({

--- a/src/modules/auth/routes/auth.service.spec.ts
+++ b/src/modules/auth/routes/auth.service.spec.ts
@@ -290,6 +290,15 @@ describe('AuthService', () => {
   });
 
   describe('getUserSession', () => {
+    it('should reject with ForbiddenException when the user is not authenticated', async () => {
+      const authPayload = new AuthPayload();
+
+      await expect(target.getUserSession(authPayload)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(usersRepositoryMock.findEmailById).not.toHaveBeenCalled();
+    });
+
     it('should return signerAddress for SIWE sessions without querying email', async () => {
       const authPayload = new AuthPayload({
         auth_method: AuthMethod.Siwe,

--- a/src/modules/auth/routes/auth.service.spec.ts
+++ b/src/modules/auth/routes/auth.service.spec.ts
@@ -10,7 +10,11 @@ import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { siweMessageBuilder } from '@/modules/siwe/domain/entities/__tests__/siwe-message.builder';
 import type { Hex } from 'viem';
 import type { JwtPayloadWithClaims } from '@/datasources/jwt/jwt-claims.entity';
-import type { AuthPayloadDto } from '@/modules/auth/domain/entities/auth-payload.entity';
+import {
+  AuthMethod,
+  AuthPayload,
+  type AuthPayloadDto,
+} from '@/modules/auth/domain/entities/auth-payload.entity';
 
 const siweRepositoryMock = {
   generateNonce: jest.fn(),
@@ -26,6 +30,7 @@ const authRepositoryMock = {
 
 const usersRepositoryMock = {
   findOrCreateByWalletAddress: jest.fn(),
+  findEmailById: jest.fn(),
 } as unknown as jest.MockedObjectDeep<IUsersRepository>;
 
 const loggingServiceMock = {
@@ -280,6 +285,55 @@ describe('AuthService', () => {
 
       await expect(target.authenticateWithSiwe(siweArgs)).resolves.toEqual({
         accessToken: 'token',
+      });
+    });
+  });
+
+  describe('getUserSession', () => {
+    it('should return signerAddress for SIWE sessions without querying email', async () => {
+      const authPayload = new AuthPayload({
+        auth_method: AuthMethod.Siwe,
+        sub: faker.string.numeric(),
+        chain_id: faker.string.numeric(),
+        signer_address: faker.finance.ethereumAddress() as `0x${string}`,
+      });
+
+      await expect(target.getUserSession(authPayload)).resolves.toEqual({
+        id: authPayload.sub,
+        authMethod: AuthMethod.Siwe,
+        signerAddress: authPayload.signer_address,
+      });
+      expect(usersRepositoryMock.findEmailById).not.toHaveBeenCalled();
+    });
+
+    it('should return email for OIDC sessions when it exists', async () => {
+      const authPayload = new AuthPayload({
+        auth_method: AuthMethod.Oidc,
+        sub: faker.string.numeric(),
+      });
+      const email = faker.internet.email().toLowerCase();
+      usersRepositoryMock.findEmailById.mockResolvedValue(email);
+
+      await expect(target.getUserSession(authPayload)).resolves.toEqual({
+        id: authPayload.sub,
+        authMethod: AuthMethod.Oidc,
+        email,
+      });
+      expect(usersRepositoryMock.findEmailById).toHaveBeenCalledWith(
+        Number(authPayload.sub),
+      );
+    });
+
+    it('should omit email for OIDC sessions when none is stored', async () => {
+      const authPayload = new AuthPayload({
+        auth_method: AuthMethod.Oidc,
+        sub: faker.string.numeric(),
+      });
+      usersRepositoryMock.findEmailById.mockResolvedValue(undefined);
+
+      await expect(target.getUserSession(authPayload)).resolves.toEqual({
+        id: authPayload.sub,
+        authMethod: AuthMethod.Oidc,
       });
     });
   });

--- a/src/modules/auth/routes/auth.service.ts
+++ b/src/modules/auth/routes/auth.service.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import {
   assertExpirationTime,
@@ -21,6 +21,8 @@ import {
 import { JwtPayloadWithClaims } from '@/datasources/jwt/jwt-claims.entity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { UserSession } from '@/modules/auth/routes/entities/user-session.entity';
 
 type AuthTokenResponse = {
   accessToken: string;
@@ -101,6 +103,30 @@ export class AuthService {
     accessToken: string,
   ): JwtPayloadWithClaims<AuthPayloadDto> {
     return this.authRepository.decodeToken(accessToken);
+  }
+
+  public async getUserSession(authPayload: AuthPayload): Promise<UserSession> {
+    if (!authPayload.isAuthenticated()) {
+      throw new ForbiddenException('Not authenticated');
+    }
+
+    if (authPayload.isSiwe()) {
+      return {
+        id: authPayload.sub,
+        authMethod: authPayload.auth_method,
+        signerAddress: authPayload.signer_address,
+      };
+    }
+
+    const email = await this.usersRepository.findEmailById(
+      Number(authPayload.sub),
+    );
+
+    return {
+      id: authPayload.sub,
+      authMethod: authPayload.auth_method,
+      ...(email && { email }),
+    };
   }
 
   public getLogoutRedirectUrl(

--- a/src/modules/auth/routes/entities/user-session.entity.ts
+++ b/src/modules/auth/routes/entities/user-session.entity.ts
@@ -15,4 +15,10 @@ export class UserSession {
       'Wallet signer address. Present only for SIWE-authenticated users.',
   })
   signerAddress?: Address;
+
+  @ApiPropertyOptional({
+    description:
+      'Verified email address. Present only for OIDC-authenticated users when stored.',
+  })
+  email?: string;
 }

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -228,30 +228,33 @@ describe('SpacesRepository', () => {
         },
       });
 
-      expect(dbMember).toEqual({
-        id: expect.any(Number),
-        role: 'ADMIN',
-        status: 'ACTIVE',
-        name: expect.any(String),
-        alias: null,
-        invitedBy: null,
-        createdAt: expect.any(Date),
-        updatedAt: expect.any(Date),
-        user: {
-          id: userId,
-          extUserId: null,
-          status: userStatus,
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        },
-        space: {
+      expect(dbMember).toEqual(
+        expect.objectContaining({
           id: expect.any(Number),
-          name,
-          status: spaceStatus,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          name: expect.any(String),
+          alias: null,
+          invitedBy: null,
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
-        },
-      });
+          user: expect.objectContaining({
+            id: userId,
+            email: null,
+            extUserId: null,
+            status: userStatus,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          }),
+          space: expect.objectContaining({
+            id: expect.any(Number),
+            name,
+            status: spaceStatus,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          }),
+        }),
+      );
     });
 
     it('should fail if the MAX_SPACE_CREATIONS_PER_USER limit is reached', async () => {
@@ -319,30 +322,33 @@ describe('SpacesRepository', () => {
         },
       });
 
-      expect(dbMember).toEqual({
-        id: expect.any(Number),
-        role: 'ADMIN',
-        status: 'ACTIVE',
-        name: `${spaceName} creator`,
-        alias: null,
-        invitedBy: null,
-        createdAt: expect.any(Date),
-        updatedAt: expect.any(Date),
-        user: {
-          id: userId,
-          extUserId: null,
-          status: userStatus,
-          createdAt: expect.any(Date),
-          updatedAt: expect.any(Date),
-        },
-        space: {
+      expect(dbMember).toEqual(
+        expect.objectContaining({
           id: expect.any(Number),
-          name: spaceName,
-          status: spaceStatus,
+          role: 'ADMIN',
+          status: 'ACTIVE',
+          name: `${spaceName} creator`,
+          alias: null,
+          invitedBy: null,
           createdAt: expect.any(Date),
           updatedAt: expect.any(Date),
-        },
-      });
+          user: expect.objectContaining({
+            id: userId,
+            email: null,
+            extUserId: null,
+            status: userStatus,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          }),
+          space: expect.objectContaining({
+            id: expect.any(Number),
+            name: spaceName,
+            status: spaceStatus,
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+          }),
+        }),
+      );
     });
 
     it('should throw if the user does not exist', async () => {

--- a/src/modules/users/__tests__/test.users.module.ts
+++ b/src/modules/users/__tests__/test.users.module.ts
@@ -21,6 +21,8 @@ import { IMembersRepository } from '@/modules/users/domain/members.repository.in
         // in tests that call getAccessToken → findOrCreate*.
         findOrCreateByWalletAddress: (): Promise<number> => Promise.resolve(1),
         findOrCreateByExtUserId: (): Promise<number> => Promise.resolve(1),
+        ensureVerifiedEmail: jest.fn().mockResolvedValue(undefined),
+        findEmailById: jest.fn().mockResolvedValue(undefined),
         update: jest.fn(),
         updateStatus: jest.fn(),
         activateIfPending: jest.fn(),

--- a/src/modules/users/datasources/entities/__tests__/users.entity.db.builder.ts
+++ b/src/modules/users/datasources/entities/__tests__/users.entity.db.builder.ts
@@ -11,6 +11,7 @@ export function userBuilder(): IBuilder<User> {
     .with('id', faker.number.int())
     .with('status', faker.helpers.arrayElement(getStringEnumKeys(UserStatus)))
     .with('extUserId', null)
+    .with('email', null)
     .with('wallets', [])
     .with('members', [])
     .with('createdAt', new Date())

--- a/src/modules/users/datasources/entities/users.entity.db.ts
+++ b/src/modules/users/datasources/entities/users.entity.db.ts
@@ -39,7 +39,10 @@ export class User implements DomainUser {
   })
   extUserId!: string | null;
 
-  @Index('users_email_key', { unique: true })
+  @Index('users_email_key', {
+    unique: true,
+    where: '"email" IS NOT NULL',
+  })
   @Column({
     name: 'email',
     type: 'varchar',

--- a/src/modules/users/datasources/entities/users.entity.db.ts
+++ b/src/modules/users/datasources/entities/users.entity.db.ts
@@ -39,6 +39,15 @@ export class User implements DomainUser {
   })
   extUserId!: string | null;
 
+  @Index('users_email_key', { unique: true })
+  @Column({
+    name: 'email',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  email!: string | null;
+
   @OneToMany(() => Wallet, (wallet: Wallet) => wallet.id, {
     onDelete: 'CASCADE',
   })

--- a/src/modules/users/domain/entities/__tests__/user.entity.spec.ts
+++ b/src/modules/users/domain/entities/__tests__/user.entity.spec.ts
@@ -21,6 +21,7 @@ describe('UserSchema', () => {
     { field: 'wallets' as const },
     { field: 'members' as const },
     { field: 'extUserId' as const },
+    { field: 'email' as const },
   ])('should not validate a User without $field', ({ field }) => {
     const user = userBuilder().build();
 
@@ -89,6 +90,37 @@ describe('UserSchema', () => {
       const user = userBuilder().build();
 
       const result = UserSchema.safeParse({ ...user, extUserId: value });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('email', () => {
+    it.each([
+      {
+        label: 'valid email',
+        value: faker.internet.email().toLowerCase(),
+      },
+      { label: 'null', value: null },
+    ])('should allow email with $label', ({ value }) => {
+      const user = userBuilder().build();
+
+      const result = UserSchema.safeParse({ ...user, email: value });
+
+      expect(result.success).toBe(true);
+    });
+
+    it.each([
+      { label: 'invalid email', value: faker.word.noun() },
+      {
+        label: 'length 256',
+        value: `${'a'.repeat(244)}@example.com`,
+      },
+      { label: 'non-string', value: faker.number.int() },
+    ])('should not allow email with $label', ({ value }) => {
+      const user = userBuilder().build();
+
+      const result = UserSchema.safeParse({ ...user, email: value });
 
       expect(result.success).toBe(false);
     });

--- a/src/modules/users/domain/entities/user.entity.ts
+++ b/src/modules/users/domain/entities/user.entity.ts
@@ -19,12 +19,14 @@ export const UserSchema: z.ZodType<
   z.infer<typeof RowSchema> & {
     status: keyof typeof UserStatus;
     extUserId: string | null;
+    email: string | null;
     wallets: Array<Wallet>;
     members: Array<Member>;
   }
 > = RowSchema.extend({
   status: z.enum(getStringEnumKeys(UserStatus)),
   extUserId: z.string().min(1).max(255).nullable(),
+  email: z.email().max(255).nullable(),
   wallets: z.array(WalletSchema),
   members: z.array(z.lazy(() => MemberSchema)),
 });

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -666,19 +666,20 @@ describe('MembersRepository', () => {
           relations: { user: true },
         }),
       ).resolves.toEqual([
-        {
+        expect.objectContaining({
           address: memberWallet,
           createdAt: expect.any(Date),
           id: expect.any(Number),
           updatedAt: expect.any(Date),
-          user: {
+          user: expect.objectContaining({
             createdAt: expect.any(Date),
+            email: null,
             extUserId: null,
             id: member.generatedMaps[0].id,
             status: 'ACTIVE',
             updatedAt: expect.any(Date),
-          },
-        },
+          }),
+        }),
       ]);
     });
 
@@ -950,6 +951,7 @@ describe('MembersRepository', () => {
         }),
       ).resolves.toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId: null,
         id: userId,
         status: 'ACTIVE', // No longer PENDING
@@ -1090,6 +1092,7 @@ describe('MembersRepository', () => {
           }),
         ).resolves.toEqual({
           createdAt: expect.any(Date),
+          email: null,
           extUserId: null,
           id: userId,
           status: 'ACTIVE', // No longer PENDING
@@ -1340,6 +1343,7 @@ describe('MembersRepository', () => {
         }),
       ).resolves.toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId: null,
         id: userId,
         status: 'PENDING', // Remains PENDING
@@ -1595,7 +1599,7 @@ describe('MembersRepository', () => {
           spaceId,
         }),
       ).resolves.toEqual([
-        {
+        expect.objectContaining({
           createdAt: expect.any(Date),
           id: memberId,
           name: memberName,
@@ -1604,14 +1608,15 @@ describe('MembersRepository', () => {
           status: 'ACTIVE',
           invitedBy: memberInvitedBy,
           updatedAt: expect.any(Date),
-          user: {
+          user: expect.objectContaining({
             createdAt: expect.any(Date),
+            email: null,
             extUserId: null,
             id: userId,
             status: userStatus,
             updatedAt: expect.any(Date),
-          },
-        },
+          }),
+        }),
       ]);
     });
 

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -16,7 +16,7 @@ import {
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { UserStatus } from '@/modules/users/domain/entities/user.entity';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
@@ -218,6 +218,7 @@ describe('UsersRepository', () => {
         updatedAt: expect.any(Date),
         user: {
           createdAt: expect.any(Date),
+          email: null,
           extUserId: null,
           id: wallet.user.id,
           status,
@@ -306,6 +307,7 @@ describe('UsersRepository', () => {
       expect(users).toEqual([
         {
           createdAt: expect.any(Date),
+          email: null,
           extUserId: null,
           id: users[0].id,
           status,
@@ -487,6 +489,7 @@ describe('UsersRepository', () => {
         updatedAt: expect.any(Date),
         user: {
           createdAt: expect.any(Date),
+          email: null,
           extUserId: null,
           id: wallet.user.id,
           status,
@@ -702,6 +705,7 @@ describe('UsersRepository', () => {
           updatedAt: expect.any(Date),
           user: {
             createdAt: expect.any(Date),
+            email: null,
             extUserId: null,
             id: wallets[0].user.id,
             status,
@@ -757,6 +761,7 @@ describe('UsersRepository', () => {
         usersRepository.findByWalletAddressOrFail(address),
       ).resolves.toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId: null,
         id: userInsertResult.identifiers[0].id,
         status,
@@ -793,6 +798,7 @@ describe('UsersRepository', () => {
         usersRepository.findByWalletAddress(address),
       ).resolves.toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId: null,
         id: userInsertResult.identifiers[0].id,
         status,
@@ -842,6 +848,7 @@ describe('UsersRepository', () => {
       });
       expect(user).toEqual({
         createdAt: expect.any(Date),
+        email: null,
         id: userId,
         status: 'ACTIVE',
         updatedAt: expect.any(Date),
@@ -859,6 +866,7 @@ describe('UsersRepository', () => {
         updatedAt: expect.any(Date),
         user: {
           createdAt: expect.any(Date),
+          email: null,
           id: userId,
           status: 'ACTIVE',
           updatedAt: expect.any(Date),
@@ -934,6 +942,7 @@ describe('UsersRepository', () => {
       });
       expect(user).toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId,
         id: userId,
         status: 'ACTIVE',
@@ -968,6 +977,62 @@ describe('UsersRepository', () => {
     });
   });
 
+  describe('ensureVerifiedEmail', () => {
+    it('should persist a normalized email when the user has none yet', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const userInsertResult = await dbUserRepository.insert({
+        status: 'ACTIVE',
+      });
+      const userId = userInsertResult.identifiers[0].id as number;
+      const email = faker.internet.email();
+
+      await usersRepository.ensureVerifiedEmail(userId, email);
+
+      const user = await dbUserRepository.findOneOrFail({
+        where: { id: userId },
+      });
+      expect(user.email).toBe(email.toLowerCase());
+    });
+
+    it('should not overwrite an existing email for the same user', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const existingEmail = faker.internet.email().toLowerCase();
+      const userInsertResult = await dbUserRepository.insert({
+        status: 'ACTIVE',
+        email: existingEmail,
+      });
+      const userId = userInsertResult.identifiers[0].id as number;
+
+      await usersRepository.ensureVerifiedEmail(
+        userId,
+        faker.internet.email().toLowerCase(),
+      );
+
+      const user = await dbUserRepository.findOneOrFail({
+        where: { id: userId },
+      });
+      expect(user.email).toBe(existingEmail);
+    });
+
+    it('should throw when the email belongs to a different user', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const email = faker.internet.email().toLowerCase();
+
+      await dbUserRepository.insert({
+        status: 'ACTIVE',
+        email,
+      });
+      const userInsertResult = await dbUserRepository.insert({
+        status: 'ACTIVE',
+      });
+      const userId = userInsertResult.identifiers[0].id as number;
+
+      await expect(
+        usersRepository.ensureVerifiedEmail(userId, email),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
   describe('update', () => {
     it('should update a User', async () => {
       const dbUserRepository = dataSource.getRepository(User);
@@ -990,6 +1055,7 @@ describe('UsersRepository', () => {
 
       expect(user).toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId: null,
         id: userId,
         status: 'ACTIVE',
@@ -1021,6 +1087,7 @@ describe('UsersRepository', () => {
 
       expect(user).toEqual({
         createdAt: expect.any(Date),
+        email: null,
         extUserId: null,
         id: userId,
         status,

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -58,6 +58,10 @@ export interface IUsersRepository {
 
   findOrCreateByExtUserId(extUserId: string): Promise<User['id']>;
 
+  ensureVerifiedEmail(userId: User['id'], email: string): Promise<void>;
+
+  findEmailById(userId: User['id']): Promise<string | undefined>;
+
   update(args: {
     userId: User['id'];
     user: Partial<User>;

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { ConflictException } from '@nestjs/common';
+import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { UsersRepository } from '@/modules/users/domain/users.repository';
+import { User as DbUser } from '@/modules/users/datasources/entities/users.entity.db';
+import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
+
+function createQueryBuilder(): {
+  update: jest.Mock;
+  set: jest.Mock;
+  where: jest.Mock;
+  andWhere: jest.Mock;
+  execute: jest.Mock;
+} {
+  return {
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    execute: jest.fn(),
+  };
+}
+
+describe('UsersRepository', () => {
+  const walletsRepository = {} as jest.MockedObjectDeep<IWalletsRepository>;
+
+  let postgresDatabaseService: jest.MockedObjectDeep<PostgresDatabaseService>;
+  let userRepository: {
+    findOne: jest.Mock;
+    findOneOrFail: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let target: UsersRepository;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    userRepository = {
+      findOne: jest.fn(),
+      findOneOrFail: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    postgresDatabaseService = {
+      getRepository: jest.fn().mockResolvedValue(userRepository),
+    } as unknown as jest.MockedObjectDeep<PostgresDatabaseService>;
+
+    target = new UsersRepository(postgresDatabaseService, walletsRepository);
+  });
+
+  describe('ensureVerifiedEmail', () => {
+    it('should persist a normalized email for a user without email', async () => {
+      const userId = faker.number.int({ min: 1 });
+      const email = '  Alice.Example@Safe.Global ';
+      const queryBuilder = createQueryBuilder();
+      userRepository.findOneOrFail.mockResolvedValue({
+        id: userId,
+        email: null,
+      });
+      userRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+      queryBuilder.execute.mockResolvedValue({ affected: 1 });
+
+      await target.ensureVerifiedEmail(userId, email);
+
+      expect(queryBuilder.update).toHaveBeenCalledWith(DbUser);
+      expect(queryBuilder.set).toHaveBeenCalledWith({
+        email: 'alice.example@safe.global',
+      });
+      expect(queryBuilder.where).toHaveBeenCalledWith('id = :userId', {
+        userId,
+      });
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith('email IS NULL');
+    });
+
+    it('should not overwrite an existing email', async () => {
+      const userId = faker.number.int({ min: 1 });
+      userRepository.findOneOrFail.mockResolvedValue({
+        id: userId,
+        email: faker.internet.email().toLowerCase(),
+      });
+
+      await target.ensureVerifiedEmail(userId, faker.internet.email());
+
+      expect(userRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should throw ConflictException on duplicate email conflicts', async () => {
+      const userId = faker.number.int({ min: 1 });
+      const queryBuilder = createQueryBuilder();
+      userRepository.findOneOrFail.mockResolvedValue({
+        id: userId,
+        email: null,
+      });
+      userRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+      queryBuilder.execute.mockRejectedValue(
+        new Error(
+          'duplicate key value violates unique constraint "users_email_key"',
+        ),
+      );
+
+      await expect(
+        target.ensureVerifiedEmail(userId, faker.internet.email()),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findEmailById', () => {
+    it('should return the persisted email', async () => {
+      const userId = faker.number.int({ min: 1 });
+      const email = faker.internet.email().toLowerCase();
+      userRepository.findOne.mockResolvedValue({ email });
+
+      await expect(target.findEmailById(userId)).resolves.toBe(email);
+      expect(userRepository.findOne).toHaveBeenCalledWith({
+        where: { id: userId },
+        select: { email: true },
+      });
+    });
+
+    it('should return undefined when the user has no email', async () => {
+      const userId = faker.number.int({ min: 1 });
+      userRepository.findOne.mockResolvedValue(null);
+
+      await expect(target.findEmailById(userId)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -251,6 +251,64 @@ export class UsersRepository implements IUsersRepository {
     }
   }
 
+  public async ensureVerifiedEmail(
+    userId: User['id'],
+    email: string,
+  ): Promise<void> {
+    const userRepository =
+      await this.postgresDatabaseService.getRepository(DbUser);
+    const normalizedEmail = email.trim().toLowerCase();
+    const user = await userRepository.findOneOrFail({
+      where: { id: userId },
+    });
+
+    if (user.email !== null) {
+      return;
+    }
+
+    try {
+      const result = await userRepository
+        .createQueryBuilder()
+        .update(DbUser)
+        .set({ email: normalizedEmail })
+        .where('id = :userId', { userId })
+        .andWhere('email IS NULL')
+        .execute();
+
+      if ((result.affected ?? 0) > 0) {
+        return;
+      }
+
+      // Another request may have stored the email after our initial read.
+      const updatedUser = await userRepository.findOneOrFail({
+        where: { id: userId },
+      });
+      if (updatedUser.email !== null) {
+        return;
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes('users_email_key') ||
+          error.message.includes('duplicate key'))
+      ) {
+        throw new ConflictException('Email already belongs to another user');
+      }
+      throw error;
+    }
+  }
+
+  public async findEmailById(userId: User['id']): Promise<string | undefined> {
+    const userRepository =
+      await this.postgresDatabaseService.getRepository(DbUser);
+    const user = await userRepository.findOne({
+      where: { id: userId },
+      select: { email: true },
+    });
+
+    return user?.email ?? undefined;
+  }
+
   public async update(args: {
     userId: User['id'];
     user: Partial<User>;


### PR DESCRIPTION
Resolves: https://linear.app/safe-global/issue/WA-2026

This PR implements the first backend slice of email identity visibility for authenticated users. It stores a verified OIDC email once in CGW and exposes the stored value on `/v1/auth/me`, so clients can render the authenticated identity without expanding the CGW JWT payload.

## Summary
- widen Auth0 scope and token parsing to accept verified email claims
- persist verified OIDC email on first login with write-once semantics and duplicate-email conflict handling
- expose stored email on `/v1/auth/me` without putting email into the CGW JWT
- add focused test coverage for verified, unverified, and missing-email cases

## Notes
- Email is not added to the CGW JWT. `/me` reads persisted email from the database for OIDC sessions.
- HTTP integration specs are not runnable in this sandbox because `supertest` hits `listen EPERM: operation not permitted 0.0.0.0`.
- The existing Postgres-backed `users.repository.integration.spec.ts` harness also failed here before the new assertions ran, with `EntityMetadataNotFoundError: No metadata for "Wallet" was found`.
