### PR TITLE
fix: propagate error_description from oidc-provider

### DIFF
--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -286,6 +286,7 @@ describe('OidcAuthController', () => {
         response: request.Response,
         expectedError: string,
         expectedBaseUrl?: string,
+        expectedErrorDescription?: string,
       ): void {
         expect(response.status).toBe(302);
         const location = new URL(response.headers.location);
@@ -295,6 +296,13 @@ describe('OidcAuthController', () => {
           redirectBase.origin + redirectBase.pathname,
         );
         expect(location.searchParams.get('error')).toBe(expectedError);
+        if (expectedErrorDescription) {
+          expect(location.searchParams.get('error_description')).toBe(
+            expectedErrorDescription,
+          );
+        } else {
+          expect(location.searchParams.has('error_description')).toBe(false);
+        }
         // State cookie should always be cleared
         expect(response.headers['set-cookie']).toEqual(
           expect.arrayContaining([
@@ -478,7 +486,7 @@ describe('OidcAuthController', () => {
         expect(networkService.postForm).not.toHaveBeenCalled();
       });
 
-      it('should redirect with only error when the OIDC provider returns an error with description', async () => {
+      it('should redirect with error and error_description when the OIDC provider returns an error with description', async () => {
         const response = await request(app.getHttpServer())
           .get('/v1/auth/oidc/callback')
           .query({
@@ -486,7 +494,12 @@ describe('OidcAuthController', () => {
             error_description: 'User denied access',
           });
 
-        expectErrorRedirect(response, 'access_denied');
+        expectErrorRedirect(
+          response,
+          'access_denied',
+          undefined,
+          'User denied access',
+        );
         expect(networkService.postForm).not.toHaveBeenCalled();
       });
 
@@ -614,7 +627,12 @@ describe('OidcAuthController', () => {
             error_description: 'User denied access',
           });
 
-        expectErrorRedirect(response, 'access_denied', customRedirectUrl);
+        expectErrorRedirect(
+          response,
+          'access_denied',
+          customRedirectUrl,
+          'User denied access',
+        );
         expect(networkService.postForm).not.toHaveBeenCalled();
       });
     });

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.ts
@@ -168,7 +168,9 @@ export class OidcAuthController {
       this.loggingService.warn(
         `Auth callback: provider error: ${error}${errorDescription ? ` - ${errorDescription}` : ''}`,
       );
-      res.redirect(this.buildErrorRedirectUrl(error, expectedState));
+      res.redirect(
+        this.buildErrorRedirectUrl(error, expectedState, errorDescription),
+      );
       return;
     }
 
@@ -212,11 +214,19 @@ export class OidcAuthController {
    * @param state optional OIDC state value used to resolve the redirect URL
    * from the original authorization request. If omitted, falls back to the
    * configured default post-login redirect URI.
+   * @param errorDescription optional description of the error
    * @returns fully qualified URL to redirect the user to
    */
-  private buildErrorRedirectUrl(error: string, state?: string): string {
+  private buildErrorRedirectUrl(
+    error: string,
+    state?: string,
+    errorDescription?: string,
+  ): string {
     const url = new URL(this.oidcAuthService.getPostLoginRedirectUri(state));
     url.searchParams.set('error', error);
+    if (errorDescription) {
+      url.searchParams.set('error_description', errorDescription);
+    }
     return url.toString();
   }
 }


### PR DESCRIPTION
## Summary [WA-2046](https://linear.app/safe-global/issue/WA-2046/be-propagate-error-description-from-auth0)

## Changes
- propagate `error_description` in the callback redirect URL from Auth0 so app can distinguish errors and show a human-friendly notifications
- test updates
