### PR TITLE
chore: bump dependabot to weekly with cooldown and raised PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,15 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
 version: 2
 
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
       day: 'monday'
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7 # Aligns with minimumReleaseAge / npmMinimalAgeGate
     groups:
       nest-js-core:
         patterns:
@@ -20,11 +24,15 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
       day: 'monday'
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7 # Aligns with minimumReleaseAge / npmMinimalAgeGate
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'weekly'
       day: 'monday'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Bump schedule from `monthly` to `weekly` for all three ecosystems (`npm`, `docker`, `github-actions`).
- Raise `open-pull-requests-limit` from the default (5) to 10 on all ecosystems.
- Add a 7-day `cooldown.default-days` to `npm` and `docker` to align with the existing `minimumReleaseAge` / `npmMinimalAgeGate` supply-chain policy.

## Test plan
- [ ] Verify Dependabot picks up the new config on the next scheduled run (Monday).
- [ ] Confirm no more than 10 open PRs per ecosystem after the first cycle.
- [ ] Confirm new npm/docker PRs are deferred until 7 days after upstream release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)