### PR TITLE
chore: mark POST /v1/spaces/create-with-user as deprecated

### DIFF
--- a/src/modules/spaces/routes/spaces.controller.ts
+++ b/src/modules/spaces/routes/spaces.controller.ts
@@ -84,9 +84,10 @@ export class SpacesController {
   }
 
   @ApiOperation({
-    summary: 'Create space with user',
+    deprecated: true,
+    summary: 'Create space with user (deprecated)',
     description:
-      'Creates a new space for the authenticated user. Activates the user if their status is PENDING.',
+      'Creates a new space for the authenticated user. This endpoint is deprecated, please use POST /v1/spaces instead.',
   })
   @ApiBody({
     type: CreateSpaceDto,


### PR DESCRIPTION
## Summary 
[WA-1914](https://linear.app/safe-global/issue/WA-1914/deprecate-create-with-user-endpoint-update-frontend-to-use-spaces-post)

`POST /v1/spaces/create-with-user` is identical to `POST /v1/spaces`, so we are deprecating the first one

## Changes
Add Swagger `deprecateed` marker