### PR TITLE
Fix/relay fee relayer safetxhash

### DIFF
--- a/src/modules/contracts/domain/__tests__/encoders/safe-encoder.builder.ts
+++ b/src/modules/contracts/domain/__tests__/encoders/safe-encoder.builder.ts
@@ -6,6 +6,7 @@ import { Builder } from '@/__tests__/builder';
 import type { IEncoder } from '@/__tests__/encoder-builder';
 import Safe130 from '@/abis/safe/v1.3.0/GnosisSafe.abi';
 import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
+import type { SafeTransactionWithSignature } from '@/modules/transactions/domain/entities/safe-transaction.entity';
 
 const ZERO_ADDRESS = pad('0x0', { size: 20 });
 const SENTINEL_ADDRESS = pad('0x1', { dir: 'left', size: 20 });
@@ -74,20 +75,9 @@ export function setupEncoder(): SetupEncoder<SetupArgs> {
 
 // execTransaction
 
-type ExecTransactionArgs = {
-  to: Hex;
-  value: bigint;
-  data: Hex;
-  operation: 0 | 1;
-  safeTxGas: bigint;
-  baseGas: bigint;
-  gasPrice: bigint;
-  gasToken: Hex;
-  refundReceiver: Hex;
-  signatures: Hex;
-};
+type ExecTransactionEncoderArgs = SafeTransactionWithSignature;
 
-class ExecTransactionEncoder<T extends ExecTransactionArgs>
+class ExecTransactionEncoder<T extends ExecTransactionEncoderArgs>
   extends Builder<T>
   implements IEncoder
 {
@@ -113,7 +103,7 @@ class ExecTransactionEncoder<T extends ExecTransactionArgs>
   }
 }
 
-export function execTransactionEncoder(): ExecTransactionEncoder<ExecTransactionArgs> {
+export function execTransactionEncoder(): ExecTransactionEncoder<ExecTransactionEncoderArgs> {
   return new ExecTransactionEncoder()
     .with('to', getAddress(faker.finance.ethereumAddress()))
     .with('value', BigInt(0))

--- a/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
+++ b/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
@@ -1,0 +1,802 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import type { Hex, PublicClient } from 'viem';
+import { getAddress } from 'viem';
+import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
+import configuration from '@/config/entities/configuration';
+import {
+  getMultiSendCallOnlyDeployments,
+  getMultiSendDeployments,
+  getProxyFactoryDeployments,
+  getSafeL2SingletonDeployments,
+  getSafeSingletonDeployments,
+} from '@/domain/common/utils/deployments';
+import type { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import {
+  execTransactionFromModuleEncoder,
+  executeNextTxEncoder,
+} from '@/modules/alerts/domain/contracts/__tests__/encoders/delay-modifier-encoder.builder';
+import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
+import {
+  multiSendEncoder,
+  multiSendTransactionsEncoder,
+} from '@/modules/contracts/domain/__tests__/encoders/multi-send-encoder.builder';
+import {
+  addOwnerWithThresholdEncoder,
+  changeThresholdEncoder,
+  execTransactionEncoder,
+  removeOwnerEncoder,
+  setupEncoder,
+  swapOwnerEncoder,
+} from '@/modules/contracts/domain/__tests__/encoders/safe-encoder.builder';
+import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
+import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
+import {
+  erc20TransferEncoder,
+  erc20TransferFromEncoder,
+} from '@/modules/relay/domain/contracts/__tests__/encoders/erc20-encoder.builder';
+import { createProxyWithNonceEncoder } from '@/modules/relay/domain/contracts/__tests__/encoders/proxy-factory-encoder.builder';
+import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
+import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
+import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
+import { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
+import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+
+const supportedChainIds = Object.keys(configuration().relay.apiKey);
+
+// Record<chainId, version[]>
+const PROXY_FACTORY_VERSIONS = getDeploymentVersionsByChainIds(
+  'ProxyFactory',
+  supportedChainIds,
+);
+const MULTI_SEND_CALL_ONLY_VERSIONS = getDeploymentVersionsByChainIds(
+  'MultiSendCallOnly',
+  supportedChainIds,
+);
+const MULTI_SEND_VERSIONS = getDeploymentVersionsByChainIds(
+  'MultiSend',
+  supportedChainIds,
+);
+const SAFE_VERSIONS = getDeploymentVersionsByChainIds(
+  'Safe',
+  supportedChainIds,
+);
+
+const mockLoggingService = jest.mocked({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>);
+
+const mockSafeRepository = jest.mocked({
+  getSafe: jest.fn(),
+  getSafesByModule: jest.fn(),
+} as jest.MockedObjectDeep<ISafeRepository>);
+
+const mockBlockchainApiManager = jest.mocked({
+  getApi: jest.fn(),
+  destroyApi: jest.fn(),
+} as jest.MockedObjectDeep<IBlockchainApiManager>);
+
+describe('RelayTransactionHelper', () => {
+  let helper: RelayTransactionHelper;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    helper = new RelayTransactionHelper(
+      mockSafeRepository,
+      mockLoggingService,
+      mockBlockchainApiManager,
+      new Erc20Decoder(),
+      new SafeDecoder(),
+      new MultiSendDecoder(mockLoggingService),
+      new ProxyFactoryDecoder(),
+      new DelayModifierDecoder(),
+      new SignerFactoryDecoder(),
+    );
+  });
+
+  describe('isValidExecTransactionCall', () => {
+    it('should return true for an ERC-20 transfer to a third party', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const recipient = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with('data', erc20TransferEncoder().with('to', recipient).encode())
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        true,
+      );
+    });
+
+    it('should return false for an ERC-20 transfer back to the Safe itself', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with('data', erc20TransferEncoder().with('to', safeAddress).encode())
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        false,
+      );
+    });
+
+    it('should return true for ERC-20 transferFrom where sender != recipient != Safe', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const sender = getAddress(faker.finance.ethereumAddress());
+      const recipient = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with(
+          'data',
+          erc20TransferFromEncoder()
+            .with('sender', sender)
+            .with('recipient', recipient)
+            .encode(),
+        )
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        true,
+      );
+    });
+
+    it('should return false for ERC-20 transferFrom where recipient is the Safe', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const sender = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with(
+          'data',
+          erc20TransferFromEncoder()
+            .with('sender', sender)
+            .with('recipient', safeAddress)
+            .encode(),
+        )
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        false,
+      );
+    });
+
+    it('should return false for ERC-20 transferFrom where sender equals recipient', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const sameAddress = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with(
+          'data',
+          erc20TransferFromEncoder()
+            .with('sender', sameAddress)
+            .with('recipient', sameAddress)
+            .encode(),
+        )
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        false,
+      );
+    });
+
+    it('should return true for a call to a third party (non-Safe) address', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const thirdParty = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder().with('to', thirdParty).encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        true,
+      );
+    });
+
+    it('should return false for a self-call with non-zero value', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with('to', safeAddress)
+        .with('value', BigInt(1))
+        .with('data', '0x')
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        false,
+      );
+    });
+
+    it('should return true for a cancellation (0x data, 0 value, to self)', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with('to', safeAddress)
+        .with('value', BigInt(0))
+        .with('data', '0x')
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        true,
+      );
+    });
+
+    it.each([
+      ['addOwnerWithThreshold', addOwnerWithThresholdEncoder],
+      ['removeOwner', removeOwnerEncoder],
+      ['swapOwner', swapOwnerEncoder],
+      ['changeThreshold', changeThresholdEncoder],
+    ])('should return true for a Safe owner management call (%s) to self', (_, encoderFn) => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const data = execTransactionEncoder()
+        .with('to', safeAddress)
+        .with('value', BigInt(0))
+        .with('data', encoderFn().encode())
+        .encode();
+
+      expect(helper.isValidExecTransactionCall({ to: safeAddress, data })).toBe(
+        true,
+      );
+    });
+
+    it('should return false for non-execTransaction calldata', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+
+      expect(
+        helper.isValidExecTransactionCall({ to: safeAddress, data: '0x' }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isSafeTxHashValid', () => {
+    function makePublicClientMock(args: {
+      nonce: bigint;
+      txHash: Hex;
+    }): jest.MockedObjectDeep<PublicClient> {
+      const readContract = jest
+        .fn()
+        .mockResolvedValueOnce(args.nonce)
+        .mockResolvedValueOnce(args.txHash);
+      return { readContract } as unknown as jest.MockedObjectDeep<PublicClient>;
+    }
+
+    it('should return true when on-chain hash matches the provided safeTxHash', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hex;
+      const decoded = helper.decodeExecTransaction(
+        execTransactionEncoder().encode(),
+      )!;
+      const mockPublicClient = makePublicClientMock({
+        nonce: BigInt(0),
+        txHash: safeTxHash,
+      });
+      mockBlockchainApiManager.getApi.mockResolvedValue(
+        mockPublicClient as unknown as PublicClient,
+      );
+
+      await expect(
+        helper.isSafeTxHashValid({
+          version,
+          chainId,
+          safeAddress,
+          decoded,
+          safeTxHash,
+        }),
+      ).resolves.toBe(true);
+    });
+
+    it('should return false when on-chain hash differs from provided safeTxHash', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hex;
+      const differentHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hex;
+      const decoded = helper.decodeExecTransaction(
+        execTransactionEncoder().encode(),
+      )!;
+      const mockPublicClient = makePublicClientMock({
+        nonce: BigInt(0),
+        txHash: differentHash,
+      });
+      mockBlockchainApiManager.getApi.mockResolvedValue(
+        mockPublicClient as unknown as PublicClient,
+      );
+
+      await expect(
+        helper.isSafeTxHashValid({
+          version,
+          chainId,
+          safeAddress,
+          decoded,
+          safeTxHash,
+        }),
+      ).resolves.toBe(false);
+
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('safeTxHash mismatch'),
+        }),
+      );
+    });
+
+    it('should return false when the RPC call fails', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hex;
+      const decoded = helper.decodeExecTransaction(
+        execTransactionEncoder().encode(),
+      )!;
+      mockBlockchainApiManager.getApi.mockRejectedValue(new Error('RPC error'));
+
+      await expect(
+        helper.isSafeTxHashValid({
+          version,
+          chainId,
+          safeAddress,
+          decoded,
+          safeTxHash,
+        }),
+      ).resolves.toBe(false);
+
+      expect(mockLoggingService.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('RPC error verifying safeTxHash'),
+        }),
+      );
+    });
+  });
+
+  describe('decodeExecTransaction', () => {
+    it('should return a SafeTransaction for valid execTransaction calldata', () => {
+      const data = execTransactionEncoder().encode();
+      const result = helper.decodeExecTransaction(data);
+      expect(result).not.toBeNull();
+      expect(result).toMatchObject({
+        to: expect.any(String),
+        value: expect.any(BigInt),
+        data: expect.any(String),
+        operation: expect.any(Number),
+        safeTxGas: expect.any(BigInt),
+        baseGas: expect.any(BigInt),
+        gasPrice: expect.any(BigInt),
+        gasToken: expect.any(String),
+        refundReceiver: expect.any(String),
+      });
+    });
+
+    it('should return null for non-execTransaction calldata', () => {
+      expect(helper.decodeExecTransaction('0x')).toBeNull();
+    });
+  });
+
+  describe('isOwnerManagementTransaction', () => {
+    it.each([
+      ['addOwnerWithThreshold', addOwnerWithThresholdEncoder],
+      ['removeOwner', removeOwnerEncoder],
+      ['swapOwner', swapOwnerEncoder],
+      ['changeThreshold', changeThresholdEncoder],
+    ])('should return true for %s wrapped in execTransaction', (_, encoderFn) => {
+      const data = execTransactionEncoder()
+        .with('data', encoderFn().encode())
+        .encode();
+
+      expect(helper.isOwnerManagementTransaction(data)).toBe(true);
+    });
+
+    it('should return false for a non-owner-management execTransaction', () => {
+      const data = execTransactionEncoder()
+        .with('data', erc20TransferEncoder().encode())
+        .encode();
+
+      expect(helper.isOwnerManagementTransaction(data)).toBe(false);
+    });
+
+    it('should return false for non-execTransaction calldata', () => {
+      expect(helper.isOwnerManagementTransaction('0x')).toBe(false);
+    });
+  });
+
+  describe('getSafeBeingRecovered', () => {
+    describe.each([
+      ['execTransactionFromModule', execTransactionFromModuleEncoder],
+      ['executeNextTx', executeNextTxEncoder],
+    ])('%s', (_, encoder) => {
+      it('should return the Safe address for a valid single owner-management call', async () => {
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const moduleAddress = getAddress(faker.finance.ethereumAddress());
+        const data = encoder()
+          .with('to', safeAddress)
+          .with(
+            'data',
+            execTransactionEncoder()
+              .with('data', addOwnerWithThresholdEncoder().encode())
+              .encode(),
+          )
+          .encode();
+
+        mockSafeRepository.getSafesByModule.mockResolvedValue({
+          safes: [safeAddress],
+        });
+
+        await expect(
+          helper.getSafeBeingRecovered({
+            version: faker.system.semver(),
+            chainId: faker.helpers.arrayElement(supportedChainIds),
+            to: moduleAddress,
+            data,
+          }),
+        ).resolves.toBe(safeAddress);
+      });
+
+      it('should return null for a non-owner-management call', async () => {
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const moduleAddress = getAddress(faker.finance.ethereumAddress());
+        const data = encoder()
+          .with('to', safeAddress)
+          .with('data', execTransactionEncoder().encode())
+          .encode();
+
+        mockSafeRepository.getSafesByModule.mockResolvedValue({
+          safes: [safeAddress],
+        });
+
+        await expect(
+          helper.getSafeBeingRecovered({
+            version: faker.system.semver(),
+            chainId: faker.helpers.arrayElement(supportedChainIds),
+            to: moduleAddress,
+            data,
+          }),
+        ).resolves.toBeNull();
+      });
+
+      it('should return null when the module is not enabled on the Safe', async () => {
+        const safeAddress = getAddress(faker.finance.ethereumAddress());
+        const moduleAddress = getAddress(faker.finance.ethereumAddress());
+        const data = encoder()
+          .with('to', safeAddress)
+          .with(
+            'data',
+            execTransactionEncoder()
+              .with('data', addOwnerWithThresholdEncoder().encode())
+              .encode(),
+          )
+          .encode();
+
+        mockSafeRepository.getSafesByModule.mockResolvedValue({ safes: [] });
+
+        await expect(
+          helper.getSafeBeingRecovered({
+            version: faker.system.semver(),
+            chainId: faker.helpers.arrayElement(supportedChainIds),
+            to: moduleAddress,
+            data,
+          }),
+        ).resolves.toBeNull();
+      });
+    });
+
+    it('should return null for non-DelayModifier calldata', async () => {
+      await expect(
+        helper.getSafeBeingRecovered({
+          version: faker.system.semver(),
+          chainId: faker.helpers.arrayElement(supportedChainIds),
+          to: getAddress(faker.finance.ethereumAddress()),
+          data: '0x',
+        }),
+      ).resolves.toBeNull();
+
+      expect(mockSafeRepository.getSafesByModule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isOfficialMultiSendDeployment', () => {
+    describe.each(supportedChainIds)('Chain %s', (chainId) => {
+      it.each(
+        MULTI_SEND_CALL_ONLY_VERSIONS[chainId],
+      )('should return true for official MultiSendCallOnly at version %s', (version) => {
+        const [address] = getMultiSendCallOnlyDeployments({
+          version,
+          chainId,
+        });
+
+        expect(
+          helper.isOfficialMultiSendDeployment({
+            version,
+            chainId,
+            address,
+          }),
+        ).toBe(true);
+      });
+
+      it.each(
+        MULTI_SEND_VERSIONS[chainId],
+      )('should return true for official MultiSend at version %s', (version) => {
+        const [address] = getMultiSendDeployments({ version, chainId });
+
+        expect(
+          helper.isOfficialMultiSendDeployment({
+            version,
+            chainId,
+            address,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it('should return false for an unofficial address', () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      expect(
+        helper.isOfficialMultiSendDeployment({
+          version: faker.system.semver(),
+          chainId,
+          address,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isOfficialProxyFactoryDeployment', () => {
+    describe.each(supportedChainIds)('Chain %s', (chainId) => {
+      it.each(
+        PROXY_FACTORY_VERSIONS[chainId],
+      )('should return true for official ProxyFactory at version %s', (version) => {
+        const [address] = getProxyFactoryDeployments({ version, chainId });
+
+        expect(
+          helper.isOfficialProxyFactoryDeployment({
+            version,
+            chainId,
+            address,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it('should return false for an unofficial address', () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      expect(
+        helper.isOfficialProxyFactoryDeployment({
+          version: faker.system.semver(),
+          chainId,
+          address,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isValidCreateProxyWithNonceCall', () => {
+    describe.each(supportedChainIds)('Chain %s', (chainId) => {
+      it.each(
+        PROXY_FACTORY_VERSIONS[chainId],
+      )('should return true for createProxyWithNonce with official L1 singleton at version %s', (version) => {
+        const [singleton] = getSafeSingletonDeployments({ version, chainId });
+        if (!singleton) return;
+        const data = createProxyWithNonceEncoder()
+          .with('singleton', singleton)
+          .encode();
+
+        expect(
+          helper.isValidCreateProxyWithNonceCall({
+            version,
+            chainId,
+            data,
+          }),
+        ).toBe(true);
+      });
+
+      it.each(
+        PROXY_FACTORY_VERSIONS[chainId],
+      )('should return true for createProxyWithNonce with official L2 singleton at version %s', (version) => {
+        const [singleton] = getSafeL2SingletonDeployments({
+          version,
+          chainId,
+        });
+        if (!singleton) return;
+        const data = createProxyWithNonceEncoder()
+          .with('singleton', singleton)
+          .encode();
+
+        expect(
+          helper.isValidCreateProxyWithNonceCall({
+            version,
+            chainId,
+            data,
+          }),
+        ).toBe(true);
+      });
+    });
+
+    it('should return false for an unofficial singleton address', () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = PROXY_FACTORY_VERSIONS[chainId][0];
+      const data = createProxyWithNonceEncoder()
+        .with('singleton', getAddress(faker.finance.ethereumAddress()))
+        .encode();
+
+      expect(
+        helper.isValidCreateProxyWithNonceCall({ version, chainId, data }),
+      ).toBe(false);
+    });
+
+    it('should return false for non-createProxyWithNonce calldata', () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = PROXY_FACTORY_VERSIONS[chainId][0];
+
+      expect(
+        helper.isValidCreateProxyWithNonceCall({
+          version,
+          chainId,
+          data: '0x',
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('isOfficialMastercopy', () => {
+    it('should return true when the Safe repository resolves', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const address = getAddress(faker.finance.ethereumAddress());
+      mockSafeRepository.getSafe.mockResolvedValue(undefined as never);
+
+      await expect(
+        helper.isOfficialMastercopy({ chainId, address }),
+      ).resolves.toBe(true);
+    });
+
+    it('should return false when the Safe repository rejects', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const address = getAddress(faker.finance.ethereumAddress());
+      mockSafeRepository.getSafe.mockRejectedValue(
+        new Error('Not official mastercopy'),
+      );
+
+      await expect(
+        helper.isOfficialMastercopy({ chainId, address }),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe('getSafeAddressFromMultiSend', () => {
+    it('should return the common Safe address from a valid batch', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const innerTx = execTransactionEncoder()
+        .with('to', getAddress(faker.finance.ethereumAddress()))
+        .encode();
+      const data = multiSendEncoder()
+        .with(
+          'transactions',
+          multiSendTransactionsEncoder([
+            { to: safeAddress, value: BigInt(0), data: innerTx, operation: 0 },
+            { to: safeAddress, value: BigInt(0), data: innerTx, operation: 0 },
+          ]),
+        )
+        .encode();
+
+      expect(helper.getSafeAddressFromMultiSend(data)).toBe(safeAddress);
+    });
+
+    it('should throw InvalidMultiSendError when transactions target different addresses', () => {
+      const innerTx = execTransactionEncoder().encode();
+      const data = multiSendEncoder()
+        .with(
+          'transactions',
+          multiSendTransactionsEncoder([
+            {
+              to: getAddress(faker.finance.ethereumAddress()),
+              value: BigInt(0),
+              data: innerTx,
+              operation: 0,
+            },
+            {
+              to: getAddress(faker.finance.ethereumAddress()),
+              value: BigInt(0),
+              data: innerTx,
+              operation: 0,
+            },
+          ]),
+        )
+        .encode();
+
+      expect(() => helper.getSafeAddressFromMultiSend(data)).toThrow(
+        InvalidMultiSendError,
+      );
+    });
+
+    it('should throw InvalidMultiSendError when a transaction is not a valid execTransaction', () => {
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const invalidData: Hex = '0xdeadbeef';
+      const data = multiSendEncoder()
+        .with(
+          'transactions',
+          multiSendTransactionsEncoder([
+            {
+              to: safeAddress,
+              value: BigInt(0),
+              data: invalidData,
+              operation: 0,
+            },
+          ]),
+        )
+        .encode();
+
+      expect(() => helper.getSafeAddressFromMultiSend(data)).toThrow(
+        InvalidMultiSendError,
+      );
+    });
+  });
+
+  describe('getOwnersFromCreateProxyWithNonce', () => {
+    describe.each(supportedChainIds)('Chain %s', (chainId) => {
+      it.each(
+        PROXY_FACTORY_VERSIONS[chainId],
+      )('should return owners from a createProxyWithNonce call with official L1 singleton at version %s', (version) => {
+        const [singleton] = getSafeSingletonDeployments({ version, chainId });
+        if (!singleton) return;
+        const owners = [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ];
+        const data = createProxyWithNonceEncoder()
+          .with('singleton', singleton)
+          .with('initializer', setupEncoder().with('owners', owners).encode())
+          .encode();
+
+        expect(helper.getOwnersFromCreateProxyWithNonce(data)).toEqual(owners);
+      });
+
+      it.each(
+        PROXY_FACTORY_VERSIONS[chainId],
+      )('should return owners from a createProxyWithNonce call with official L2 singleton at version %s', (version) => {
+        const [singleton] = getSafeL2SingletonDeployments({
+          version,
+          chainId,
+        });
+        if (!singleton) return;
+        const owners = [
+          getAddress(faker.finance.ethereumAddress()),
+          getAddress(faker.finance.ethereumAddress()),
+        ];
+        const data = createProxyWithNonceEncoder()
+          .with('singleton', singleton)
+          .with('initializer', setupEncoder().with('owners', owners).encode())
+          .encode();
+
+        expect(helper.getOwnersFromCreateProxyWithNonce(data)).toEqual(owners);
+      });
+    });
+
+    it('should throw when data is not a createProxyWithNonce call', () => {
+      expect(() => helper.getOwnersFromCreateProxyWithNonce('0x')).toThrow();
+    });
+
+    it('should throw when the initializer is not a setup call', () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = PROXY_FACTORY_VERSIONS[chainId][0];
+      const [singleton] = getSafeSingletonDeployments({ version, chainId });
+      if (!singleton) return;
+      // execTransaction is a valid Safe ABI function but not 'setup'
+      const data = createProxyWithNonceEncoder()
+        .with('singleton', singleton)
+        .with('initializer', execTransactionEncoder().encode())
+        .encode();
+
+      expect(() => helper.getOwnersFromCreateProxyWithNonce(data)).toThrow(
+        'Not a setup call',
+      );
+    });
+  });
+});

--- a/src/modules/relay/domain/errors/safe-tx-hash-mismatch.error.ts
+++ b/src/modules/relay/domain/errors/safe-tx-hash-mismatch.error.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { UnprocessableEntityException } from '@nestjs/common';
+import type { Hex } from 'viem';
+
+export class SafeTxHashMismatchError extends UnprocessableEntityException {
+  constructor(readonly safeTxHash: Hex) {
+    super(
+      `Safe transaction hash mismatch: provided hash ${safeTxHash} does not match the transaction data`,
+    );
+  }
+}

--- a/src/modules/relay/domain/exception-filters/__tests__/safe-tx-hash-mismatch.exception-filter.spec.ts
+++ b/src/modules/relay/domain/exception-filters/__tests__/safe-tx-hash-mismatch.exception-filter.spec.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import type { ArgumentsHost } from '@nestjs/common';
+import { HttpStatus } from '@nestjs/common';
+import type { Hex } from 'viem';
+import { SafeTxHashMismatchError } from '@/modules/relay/domain/errors/safe-tx-hash-mismatch.error';
+import { SafeTxHashMismatchExceptionFilter } from '@/modules/relay/domain/exception-filters/safe-tx-hash-mismatch.exception-filter';
+
+function buildMockHost(): {
+  host: ArgumentsHost;
+  mockStatus: jest.Mock;
+  mockJson: jest.Mock;
+} {
+  const mockJson = jest.fn();
+  const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
+  const mockGetResponse = jest.fn().mockReturnValue({ status: mockStatus });
+  const mockSwitchToHttp = jest
+    .fn()
+    .mockReturnValue({ getResponse: mockGetResponse });
+  const host = {
+    switchToHttp: mockSwitchToHttp,
+  } as unknown as ArgumentsHost;
+  return { host, mockStatus, mockJson };
+}
+
+describe('SafeTxHashMismatchExceptionFilter', () => {
+  let filter: SafeTxHashMismatchExceptionFilter;
+
+  beforeEach(() => {
+    filter = new SafeTxHashMismatchExceptionFilter();
+  });
+
+  it('should respond with HTTP 422 and the error message', () => {
+    const safeTxHash = faker.string.hexadecimal({
+      length: 64,
+      casing: 'lower',
+    }) as Hex;
+    const error = new SafeTxHashMismatchError(safeTxHash);
+    const { host, mockStatus, mockJson } = buildMockHost();
+
+    filter.catch(error, host);
+
+    expect(mockStatus).toHaveBeenCalledWith(HttpStatus.UNPROCESSABLE_ENTITY);
+    expect(mockJson).toHaveBeenCalledWith({
+      message: error.message,
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+    });
+  });
+
+  it('should include the safeTxHash in the response message', () => {
+    const safeTxHash = faker.string.hexadecimal({
+      length: 64,
+      casing: 'lower',
+    }) as Hex;
+    const error = new SafeTxHashMismatchError(safeTxHash);
+    const { host, mockJson } = buildMockHost();
+
+    filter.catch(error, host);
+
+    const { message } = mockJson.mock.calls[0][0] as { message: string };
+    expect(message).toContain(safeTxHash);
+  });
+});

--- a/src/modules/relay/domain/exception-filters/safe-tx-hash-mismatch.exception-filter.ts
+++ b/src/modules/relay/domain/exception-filters/safe-tx-hash-mismatch.exception-filter.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { ArgumentsHost } from '@nestjs/common';
+import { Catch, ExceptionFilter, HttpStatus } from '@nestjs/common';
+import type { Response } from 'express';
+import { SafeTxHashMismatchError } from '@/modules/relay/domain/errors/safe-tx-hash-mismatch.error';
+
+@Catch(SafeTxHashMismatchError)
+export class SafeTxHashMismatchExceptionFilter implements ExceptionFilter {
+  catch(error: SafeTxHashMismatchError, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.UNPROCESSABLE_ENTITY).json({
+      message: error.message,
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+    });
+  }
+}

--- a/src/modules/relay/domain/limit-addresses.mapper.spec.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.spec.ts
@@ -52,6 +52,7 @@ import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-d
 import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
 import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 import { LimitAddressesMapper } from '@/modules/relay/domain/limit-addresses.mapper';
+import { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
 import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
 import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 
@@ -93,22 +94,19 @@ describe('LimitAddressesMapper', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    const erc20Decoder = new Erc20Decoder();
-    const safeDecoder = new SafeDecoder();
-    const multiSendDecoder = new MultiSendDecoder(mockLoggingService);
-    const proxyFactoryDecoder = new ProxyFactoryDecoder();
-    const delayModifierDecoder = new DelayModifierDecoder();
-    const signerFactoryDecoder = new SignerFactoryDecoder();
-
-    target = new LimitAddressesMapper(
+    const relayTransactionHelper = new RelayTransactionHelper(
       mockSafeRepository,
-      erc20Decoder,
-      safeDecoder,
-      multiSendDecoder,
-      proxyFactoryDecoder,
-      delayModifierDecoder,
-      signerFactoryDecoder,
+      mockLoggingService,
+      { getApi: jest.fn(), destroyApi: jest.fn() } as never,
+      new Erc20Decoder(),
+      new SafeDecoder(),
+      new MultiSendDecoder(mockLoggingService),
+      new ProxyFactoryDecoder(),
+      new DelayModifierDecoder(),
+      new SignerFactoryDecoder(),
     );
+
+    target = new LimitAddressesMapper(relayTransactionHelper);
   });
 
   describe('Recovery', () => {

--- a/src/modules/relay/domain/limit-addresses.mapper.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.ts
@@ -1,83 +1,56 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Inject, Injectable } from '@nestjs/common';
-import {
-  type Address,
-  encodeAbiParameters,
-  getAddress,
-  keccak256,
-  parseAbiParameters,
-} from 'viem';
-import {
-  getMultiSendCallOnlyDeployments,
-  getMultiSendDeployments,
-  getProxyFactoryDeployments,
-  getSafeL2SingletonDeployments,
-  getSafeSingletonDeployments,
-  getSignerFactoryDeployments,
-} from '@/domain/common/utils/deployments';
-import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
-import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
-import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
-import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
-import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
-import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
-import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
+import { Injectable } from '@nestjs/common';
+import type { Address, Hex } from 'viem';
 import { InvalidTransferError } from '@/modules/relay/domain/errors/invalid-transfer.error';
 import { UnofficialMasterCopyError } from '@/modules/relay/domain/errors/unofficial-master-copy.error';
 import { UnofficialMultiSendError } from '@/modules/relay/domain/errors/unofficial-multisend.error';
 import { UnofficialProxyFactoryError } from '@/modules/relay/domain/errors/unofficial-proxy-factory.error';
 import { UnofficialSignerFactoryError } from '@/modules/relay/domain/errors/unofficial-signer-factory.error';
-import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+import { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
 
 @Injectable()
 export class LimitAddressesMapper {
   constructor(
-    @Inject(ISafeRepository)
-    private readonly safeRepository: ISafeRepository,
-    private readonly erc20Decoder: Erc20Decoder,
-    private readonly safeDecoder: SafeDecoder,
-    private readonly multiSendDecoder: MultiSendDecoder,
-    private readonly proxyFactoryDecoder: ProxyFactoryDecoder,
-    private readonly delayModifierDecoder: DelayModifierDecoder,
-    private readonly signerFactoryDecoder: SignerFactoryDecoder,
+    private readonly relayTransactionHelper: RelayTransactionHelper,
   ) {}
 
   async getLimitAddresses(args: {
     version: string;
     chainId: string;
     to: Address;
-    data: Address;
+    data: Hex;
   }): Promise<ReadonlyArray<Address>> {
-    const safeBeingRecovered = await this.getSafeBeingRecovered(args);
+    const safeBeingRecovered =
+      await this.relayTransactionHelper.getSafeBeingRecovered(args);
     if (safeBeingRecovered) {
       return [safeBeingRecovered];
     }
 
     // Calldata matches that of execTransaction and meets validity requirements
     if (
-      this.isValidExecTransactionCall({
+      this.relayTransactionHelper.isValidExecTransactionCall({
         to: args.to,
         data: args.data,
       })
     ) {
       // Safe attempting to relay is official
-      const isOfficial = await this.isOfficialMastercopy({
-        chainId: args.chainId,
-        address: args.to,
-      });
+      const isOfficial = await this.relayTransactionHelper.isOfficialMastercopy(
+        {
+          chainId: args.chainId,
+          address: args.to,
+        },
+      );
 
       if (!isOfficial) {
         throw new UnofficialMasterCopyError();
       }
 
-      // Safe targeted by execTransaction will be limited
       return [args.to];
     }
 
-    // Calldata matches that of multiSend and is from an official MultiSend contract
-    if (this.multiSendDecoder.helpers.isMultiSend(args.data)) {
+    if (this.relayTransactionHelper.isMultiSend(args.data)) {
       if (
-        !this.isOfficialMultiSendDeployment({
+        !this.relayTransactionHelper.isOfficialMultiSendDeployment({
           version: args.version,
           chainId: args.chainId,
           address: args.to,
@@ -87,13 +60,16 @@ export class LimitAddressesMapper {
       }
 
       // multiSend calldata meets the validity requirements
-      const safeAddress = this.getSafeAddressFromMultiSend(args.data);
+      const safeAddress =
+        this.relayTransactionHelper.getSafeAddressFromMultiSend(args.data);
 
       // Safe attempting to relay is official
-      const isOfficial = await this.isOfficialMastercopy({
-        chainId: args.chainId,
-        address: safeAddress,
-      });
+      const isOfficial = await this.relayTransactionHelper.isOfficialMastercopy(
+        {
+          chainId: args.chainId,
+          address: safeAddress,
+        },
+      );
 
       if (!isOfficial) {
         throw new UnofficialMasterCopyError();
@@ -105,14 +81,14 @@ export class LimitAddressesMapper {
 
     // Calldata matches that of createProxyWithNonce and meets validity requirements
     if (
-      this.isValidCreateProxyWithNonceCall({
+      this.relayTransactionHelper.isValidCreateProxyWithNonceCall({
         version: args.version,
         chainId: args.chainId,
         data: args.data,
       })
     ) {
       if (
-        !this.isOfficialProxyFactoryDeployment({
+        !this.relayTransactionHelper.isOfficialProxyFactoryDeployment({
           version: args.version,
           chainId: args.chainId,
           address: args.to,
@@ -121,23 +97,26 @@ export class LimitAddressesMapper {
         throw new UnofficialProxyFactoryError();
       }
       // Owners of safe-to-be-created will be limited
-      return this.getOwnersFromCreateProxyWithNonce(args.data);
+      return this.relayTransactionHelper.getOwnersFromCreateProxyWithNonce(
+        args.data,
+      );
     }
 
     // Calldata matches createSigner on an official SafeWebAuthnSignerFactory.
     // The branch is self-contained: every outcome of the createSigner path
     // (unofficial factory, malformed args, success) terminates here so future
     // branches added below this point can't be reached by createSigner data.
-    if (this.signerFactoryDecoder.helpers.isCreateSigner(args.data)) {
+    if (this.relayTransactionHelper.isCreateSigner(args.data)) {
       if (
-        !this.isOfficialSignerFactoryDeployment({
+        !this.relayTransactionHelper.isOfficialSignerFactoryDeployment({
           chainId: args.chainId,
           address: args.to,
         })
       ) {
         throw new UnofficialSignerFactoryError();
       }
-      const signerLimitAddress = this.getSignerFactoryLimitAddress(args.data);
+      const signerLimitAddress =
+        this.relayTransactionHelper.getSignerFactoryLimitAddress(args.data);
       if (!signerLimitAddress) {
         // Selector matched but the args failed to decode (malformed payload).
         throw new InvalidTransferError();
@@ -146,410 +125,5 @@ export class LimitAddressesMapper {
     }
 
     throw new InvalidTransferError();
-  }
-
-  /**
-   * Returns the address of the Safe being recovered, if the recovery transaction is valid:
-   *
-   * - DelayModifier proposal (execTransactionFromModule) or execution (executeNextTx)
-   * - (Batch) transaction(s) to add/remove/swap owners or change threshold on _a_ Safe
-   * - Via an enabled module on said Safe
-   *
-   * @param {string} args.chainId - Chain ID
-   * @param {string} args.version - Safe version
-   * @param {string} args.to - Transaction recipient
-   * @param {string} args.data - Transaction data
-   *
-   * @returns {string | null} - Safe address being recovered, if valid
-   */
-  private async getSafeBeingRecovered(args: {
-    chainId: string;
-    version: string;
-    to: Address;
-    data: Address;
-  }): Promise<Address | null> {
-    let to: Address;
-    let data: Address;
-
-    try {
-      const decoded = this.delayModifierDecoder.decodeFunctionData({
-        data: args.data,
-      });
-
-      if (
-        // Proposal
-        decoded.functionName !== 'execTransactionFromModule' &&
-        // Execution
-        decoded.functionName !== 'executeNextTx'
-      ) {
-        return null;
-      }
-
-      // No need to check value/operation as call is to Safe itself
-      to = decoded.args[0];
-      data = decoded.args[2];
-    } catch {
-      return null;
-    }
-
-    // (Batched) transaction(s) of transaction
-    const transactions = this.decodeTransactions({
-      address: to,
-      version: args.version,
-      chainId: args.chainId,
-      data,
-    });
-
-    const isEveryTransactionOwnerManagement = transactions.every(
-      (transaction) => {
-        return this.isOwnerManagementTransaction(transaction.data);
-      },
-    );
-
-    if (!isEveryTransactionOwnerManagement) {
-      return null;
-    }
-
-    const { safes } = await this.safeRepository.getSafesByModule({
-      chainId: args.chainId,
-      moduleAddress: args.to,
-    });
-
-    // Module enabled on Safe, and batch transactions target the same Safe
-    const isEnabledSafe = transactions.every((transaction, _, arr) => {
-      return transaction.to === arr[0].to && safes.includes(transaction.to);
-    });
-
-    if (!isEnabledSafe) {
-      return null;
-    }
-
-    return transactions[0].to;
-  }
-
-  /**
-   * Maps batched transactions if the data of an official multiSend call
-   * @param {string} args.address - Address of the recipient
-   * @param {string} args.version - Safe version
-   * @param {string} args.chainId - Chain ID
-   * @param {string} args.data - Data of the transaction
-   * @returns {Array<{ to: string; data: string }>} - Array of transactions
-   */
-  private decodeTransactions(args: {
-    address: Address;
-    version: string;
-    chainId: string;
-    data: Address;
-  }): Array<{
-    to: Address;
-    data: Address;
-  }> {
-    if (
-      this.isOfficialMultiSendDeployment(args) &&
-      this.multiSendDecoder.helpers.isMultiSend(args.data)
-    ) {
-      return this.multiSendDecoder.mapMultiSendTransactions(args.data);
-    }
-
-    return [{ to: args.address, data: args.data }];
-  }
-
-  /**
-   * Checks if the data of a transaction is an owner management transaction
-   * @param {string} data - Data of the transaction
-   * @returns {boolean} - Whether the data is of owner management
-   */
-  private isOwnerManagementTransaction(data: Address): boolean {
-    try {
-      const decoded = this.safeDecoder.decodeFunctionData({
-        data,
-      });
-
-      if (decoded.functionName !== 'execTransaction') {
-        return false;
-      }
-
-      const execTransactionData = decoded.args[2];
-
-      if (
-        !(
-          this.safeDecoder.helpers.isAddOwnerWithThreshold(
-            execTransactionData,
-          ) ||
-          this.safeDecoder.helpers.isRemoveOwner(execTransactionData) ||
-          this.safeDecoder.helpers.isSwapOwner(execTransactionData) ||
-          this.safeDecoder.helpers.isChangeThreshold(execTransactionData)
-        )
-      ) {
-        return false;
-      }
-
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private isValidExecTransactionCall(args: {
-    to: Address;
-    data: Address;
-  }): boolean {
-    const execTransactionArgs = this.getExecTransactionArgs(args.data);
-    // Not a valid execTransaction call
-    if (!execTransactionArgs) {
-      return false;
-    }
-
-    // Only ERC-20 transfer to other party is valid
-    if (this.erc20Decoder.helpers.isTransfer(execTransactionArgs.data)) {
-      return this.isValidErc20Transfer({
-        to: args.to,
-        data: execTransactionArgs.data,
-      });
-    }
-
-    // Only ERC-20 transferFrom to other party is valid
-    if (this.erc20Decoder.helpers.isTransferFrom(execTransactionArgs.data)) {
-      return this.isValidErc20TransferFrom({
-        to: args.to,
-        data: execTransactionArgs.data,
-      });
-    }
-
-    // Only transaction to other party is valid
-    const toSelf = execTransactionArgs.to === args.to;
-    if (!toSelf) {
-      return true;
-    }
-
-    // Only transaction with no value is valid
-    const hasValue = execTransactionArgs.value > BigInt(0);
-    if (hasValue) {
-      return false;
-    }
-
-    // Cancellations and Safe calls (e.g. owner management) are valid
-    const isCancellation = execTransactionArgs.data === '0x';
-    return isCancellation || this.safeDecoder.isCall(execTransactionArgs.data);
-  }
-
-  private getExecTransactionArgs(data: Address): {
-    to: Address;
-    value: bigint;
-    data: Address;
-  } | null {
-    try {
-      const safeDecodedData = this.safeDecoder.decodeFunctionData({
-        data,
-      });
-
-      if (safeDecodedData.functionName !== 'execTransaction') {
-        return null;
-      }
-
-      return {
-        to: safeDecodedData.args[0],
-        value: safeDecodedData.args[1],
-        data: safeDecodedData.args[2],
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  private isValidErc20Transfer(args: { to: Address; data: Address }): boolean {
-    // Can throw but called after this.erc20Decoder.helpers.isTransfer
-    const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
-      data: args.data,
-    });
-
-    if (erc20DecodedData.functionName !== 'transfer') {
-      return false;
-    }
-
-    const [to] = erc20DecodedData.args;
-    // to 'self' (the Safe) is not allowed
-    return to !== args.to;
-  }
-
-  private isValidErc20TransferFrom(args: {
-    to: Address;
-    data: Address;
-  }): boolean {
-    // Can throw but called after this.erc20Decoder.helpers.isTransferFrom
-    const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
-      data: args.data,
-    });
-
-    if (erc20DecodedData.functionName !== 'transferFrom') {
-      return false;
-    }
-
-    const [sender, recipient] = erc20DecodedData.args;
-    // to 'self' (the Safe) or from sender to sender as recipient is not allowed
-    return sender !== recipient && recipient !== args.to;
-  }
-
-  private async isOfficialMastercopy(args: {
-    chainId: string;
-    address: Address;
-  }): Promise<boolean> {
-    try {
-      await this.safeRepository.getSafe(args);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private isOfficialMultiSendDeployment(args: {
-    version: string;
-    chainId: string;
-    address: Address;
-  }): boolean {
-    return (
-      getMultiSendCallOnlyDeployments(args).includes(args.address) ||
-      getMultiSendDeployments(args).includes(args.address)
-    );
-  }
-
-  private getSafeAddressFromMultiSend = (data: Address): Address => {
-    // Decode transactions within MultiSend
-    const transactions = this.multiSendDecoder.mapMultiSendTransactions(data);
-
-    // Every transaction is a valid execTransaction
-    const isEveryValid = transactions.every((transaction) => {
-      return this.isValidExecTransactionCall(transaction);
-    });
-
-    if (!isEveryValid) {
-      throw new InvalidMultiSendError();
-    }
-
-    const firstRecipient = transactions[0].to;
-
-    const isSameRecipient = transactions.every((transaction) => {
-      return transaction.to === firstRecipient;
-    });
-
-    // Transactions calls execTransaction on varying addresses
-    if (!isSameRecipient) {
-      throw new InvalidMultiSendError();
-    }
-
-    return firstRecipient;
-  };
-
-  private isOfficialProxyFactoryDeployment(args: {
-    version: string;
-    chainId: string;
-    address: Address;
-  }): boolean {
-    const proxyFactoryDeployments = getProxyFactoryDeployments(args);
-    return proxyFactoryDeployments.includes(args.address);
-  }
-
-  private isOfficialSignerFactoryDeployment(args: {
-    chainId: string;
-    address: Address;
-  }): boolean {
-    return getSignerFactoryDeployments({ chainId: args.chainId }).includes(
-      args.address,
-    );
-  }
-
-  /**
-   * For `createSigner` calldata, returns a per-passkey limit key derived from
-   * the call arguments.
-   *
-   * The key is the last 20 bytes of `keccak256(abi.encode(x, y, verifiers))`
-   * cast to an Address-shaped string. This gives each unique passkey
-   * (x, y, verifiers) its own daily relay quota, instead of every user
-   * sharing the factory address as a limit key.
-   *
-   * Returns `null` if the args fail to decode (e.g. selector matches but the
-   * payload is malformed). Caller must have already verified the selector
-   * matches `createSigner` and that `to` is an official factory.
-   *
-   * Note: the `isCreateSigner` selector pre-check at the call site is not
-   * redundant with the `decodeFunctionData` + `functionName` check here —
-   * `getSigner` is also in the ABI and would decode cleanly.
-   */
-  private getSignerFactoryLimitAddress(data: Address): Address | null {
-    let x: bigint;
-    let y: bigint;
-    let verifiers: bigint;
-    try {
-      const decoded = this.signerFactoryDecoder.decodeFunctionData({
-        data,
-      });
-      if (decoded.functionName !== 'createSigner') {
-        return null;
-      }
-      [x, y, verifiers] = decoded.args;
-    } catch {
-      return null;
-    }
-
-    const hash = keccak256(
-      encodeAbiParameters(parseAbiParameters('uint256, uint256, uint176'), [
-        x,
-        y,
-        verifiers,
-      ]),
-    );
-    return getAddress(`0x${hash.slice(-40)}`);
-  }
-
-  private isValidCreateProxyWithNonceCall(args: {
-    version: string;
-    chainId: string;
-    data: Address;
-  }): boolean {
-    let singleton: Address | null = null;
-
-    try {
-      const decoded = this.proxyFactoryDecoder.decodeFunctionData({
-        data: args.data,
-      });
-
-      if (decoded.functionName !== 'createProxyWithNonce') {
-        return false;
-      }
-
-      singleton = decoded.args[0];
-    } catch {
-      return false;
-    }
-
-    return (
-      getSafeSingletonDeployments(args).includes(singleton) ||
-      getSafeL2SingletonDeployments(args).includes(singleton)
-    );
-  }
-
-  private getOwnersFromCreateProxyWithNonce(
-    data: Address,
-  ): ReadonlyArray<Address> {
-    const decodedProxyFactory = this.proxyFactoryDecoder.decodeFunctionData({
-      data,
-    });
-
-    if (decodedProxyFactory.functionName !== 'createProxyWithNonce') {
-      // Should never happen but check is needed to satisfy TypeScript
-      throw Error('Not a createProxyWithNonce call');
-    }
-
-    const initializer = decodedProxyFactory.args[1];
-    const decodedSafe = this.safeDecoder.decodeFunctionData({
-      data: initializer,
-    });
-
-    if (decodedSafe.functionName !== 'setup') {
-      // No custom error thrown, as caller subsequently throws InvalidTransferError
-      throw Error('Not a setup call');
-    }
-
-    return decodedSafe.args[0];
   }
 }

--- a/src/modules/relay/domain/relay-decoders.module.ts
+++ b/src/modules/relay/domain/relay-decoders.module.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
+import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
 import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
 import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
@@ -12,6 +13,7 @@ import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/
     Erc20Decoder,
     MultiSendDecoder,
     ProxyFactoryDecoder,
+    DelayModifierDecoder,
     SignerFactoryDecoder,
   ],
   exports: [
@@ -19,6 +21,7 @@ import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/
     Erc20Decoder,
     MultiSendDecoder,
     ProxyFactoryDecoder,
+    DelayModifierDecoder,
     SignerFactoryDecoder,
   ],
 })

--- a/src/modules/relay/domain/relay-transaction-helper.ts
+++ b/src/modules/relay/domain/relay-transaction-helper.ts
@@ -1,0 +1,540 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import semverSatisfies from 'semver/functions/satisfies';
+import type { Address, Hex } from 'viem';
+import {
+  encodeAbiParameters,
+  getAddress,
+  keccak256,
+  parseAbiParameters,
+} from 'viem';
+import Safe130 from '@/abis/safe/v1.3.0/GnosisSafe.abi';
+import Safe141 from '@/abis/safe/v1.4.1/Safe.abi';
+import Safe150 from '@/abis/safe/v1.5.0/Safe.abi';
+import { LogType } from '@/domain/common/entities/log-type.entity';
+import {
+  getMultiSendCallOnlyDeployments,
+  getMultiSendDeployments,
+  getProxyFactoryDeployments,
+  getSafeL2SingletonDeployments,
+  getSafeSingletonDeployments,
+  getSignerFactoryDeployments,
+} from '@/domain/common/utils/deployments';
+import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
+import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
+import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
+import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
+import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
+import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
+import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
+import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+import type { SafeTransaction } from '@/modules/transactions/domain/entities/safe-transaction.entity';
+
+type SafeAbi = typeof Safe130 | typeof Safe141 | typeof Safe150;
+
+@Injectable()
+export class RelayTransactionHelper {
+  constructor(
+    @Inject(ISafeRepository)
+    private readonly safeRepository: ISafeRepository,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
+    @Inject(IBlockchainApiManager)
+    private readonly blockchainApiManager: IBlockchainApiManager,
+    private readonly erc20Decoder: Erc20Decoder,
+    private readonly safeDecoder: SafeDecoder,
+    private readonly multiSendDecoder: MultiSendDecoder,
+    private readonly proxyFactoryDecoder: ProxyFactoryDecoder,
+    private readonly delayModifierDecoder: DelayModifierDecoder,
+    private readonly signerFactoryDecoder: SignerFactoryDecoder,
+  ) {}
+
+  private getSafeAbi(version: string): SafeAbi {
+    if (semverSatisfies(version, '>=1.5.0')) return Safe150;
+    if (semverSatisfies(version, '>=1.4.1')) return Safe141;
+    if (semverSatisfies(version, '>=1.0.0')) return Safe130;
+    this.loggingService.warn({
+      type: LogType.TxRelayEligibility,
+      message: `getSafeAbi: unrecognised Safe version ${version}, falling back to 1.3.0 ABI`,
+    });
+    return Safe130;
+  }
+
+  isValidExecTransactionCall(args: { to: Address; data: Hex }): boolean {
+    const decoded = this.decodeExecTransaction(args.data);
+    if (!decoded) return false;
+    return this.isValidDecodedExecTransaction({ to: args.to, decoded });
+  }
+
+  isValidDecodedExecTransaction(args: {
+    to: Address;
+    decoded: SafeTransaction;
+  }): boolean {
+    const { decoded } = args;
+
+    // Only ERC-20 transfer to other party is valid
+    if (this.erc20Decoder.helpers.isTransfer(decoded.data)) {
+      return this.isValidErc20Transfer({ to: args.to, data: decoded.data });
+    }
+
+    // Only ERC-20 transferFrom to other party is valid
+    if (this.erc20Decoder.helpers.isTransferFrom(decoded.data)) {
+      return this.isValidErc20TransferFrom({ to: args.to, data: decoded.data });
+    }
+
+    const toSelf = decoded.to === args.to;
+    if (!toSelf) {
+      return true;
+    }
+
+    return this.isValidSelfTransaction(decoded);
+  }
+
+  private isValidSelfTransaction(decoded: SafeTransaction): boolean {
+    // Only transaction with no value is valid
+    const hasValue = decoded.value > BigInt(0);
+    if (hasValue) {
+      return false;
+    }
+
+    // Cancellations and Safe calls (e.g. owner management) are valid
+    const isCancellation = decoded.data === '0x';
+    return isCancellation || this.safeDecoder.isCall(decoded.data);
+  }
+
+  decodeExecTransaction(data: Hex): SafeTransaction | null {
+    try {
+      const safeDecodedData = this.safeDecoder.decodeFunctionData({
+        data,
+      });
+
+      if (safeDecodedData.functionName !== 'execTransaction') {
+        return null;
+      }
+
+      const [
+        to,
+        value,
+        innerData,
+        operation,
+        safeTxGas,
+        baseGas,
+        gasPrice,
+        gasToken,
+        refundReceiver,
+      ] = safeDecodedData.args;
+
+      return {
+        to,
+        value,
+        data: innerData,
+        operation,
+        safeTxGas,
+        baseGas,
+        gasPrice,
+        gasToken,
+        refundReceiver,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private isValidErc20Transfer(args: { to: Address; data: Hex }): boolean {
+    // Can throw but called after this.erc20Decoder.helpers.isTransfer
+    const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
+      data: args.data,
+    });
+
+    if (erc20DecodedData.functionName !== 'transfer') {
+      return false;
+    }
+
+    const [to] = erc20DecodedData.args;
+    // to 'self' (the Safe) is not allowed
+    return to !== args.to;
+  }
+
+  private isValidErc20TransferFrom(args: { to: Address; data: Hex }): boolean {
+    // Can throw but called after this.erc20Decoder.helpers.isTransferFrom
+    const erc20DecodedData = this.erc20Decoder.decodeFunctionData({
+      data: args.data,
+    });
+
+    if (erc20DecodedData.functionName !== 'transferFrom') {
+      return false;
+    }
+
+    const [sender, recipient] = erc20DecodedData.args;
+    // to 'self' (the Safe) or from sender to sender as recipient is not allowed
+    return sender !== recipient && recipient !== args.to;
+  }
+
+  async isOfficialMastercopy(args: {
+    chainId: string;
+    address: Address;
+  }): Promise<boolean> {
+    try {
+      await this.safeRepository.getSafe(args);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  isMultiSend(data: Hex): boolean {
+    return this.multiSendDecoder.helpers.isMultiSend(data);
+  }
+
+  isOfficialMultiSendDeployment(args: {
+    version: string;
+    chainId: string;
+    address: Address;
+  }): boolean {
+    return (
+      getMultiSendCallOnlyDeployments(args).includes(args.address) ||
+      getMultiSendDeployments(args).includes(args.address)
+    );
+  }
+
+  getSafeAddressFromMultiSend(data: Hex): Address {
+    // Decode transactions within MultiSend
+    const transactions = this.multiSendDecoder.mapMultiSendTransactions(data);
+
+    // Every transaction is a valid execTransaction
+    const isEveryValid = transactions.every((transaction) => {
+      return this.isValidExecTransactionCall(transaction);
+    });
+
+    if (!isEveryValid) {
+      throw new InvalidMultiSendError();
+    }
+
+    const firstRecipient = transactions[0].to;
+
+    const isSameRecipient = transactions.every((transaction) => {
+      return transaction.to === firstRecipient;
+    });
+
+    // Transactions calls execTransaction on varying addresses
+    if (!isSameRecipient) {
+      throw new InvalidMultiSendError();
+    }
+
+    return firstRecipient;
+  }
+
+  isOfficialProxyFactoryDeployment(args: {
+    version: string;
+    chainId: string;
+    address: Address;
+  }): boolean {
+    const proxyFactoryDeployments = getProxyFactoryDeployments(args);
+    return proxyFactoryDeployments.includes(args.address);
+  }
+
+  isCreateSigner(data: Hex): boolean {
+    return this.signerFactoryDecoder.helpers.isCreateSigner(data);
+  }
+
+  isOfficialSignerFactoryDeployment(args: {
+    chainId: string;
+    address: Address;
+  }): boolean {
+    return getSignerFactoryDeployments({ chainId: args.chainId }).includes(
+      args.address,
+    );
+  }
+
+  /**
+   * For `createSigner` calldata, returns a per-passkey limit key derived from
+   * the call arguments.
+   *
+   * The key is the last 20 bytes of `keccak256(abi.encode(x, y, verifiers))`
+   * cast to an Address-shaped string. This gives each unique passkey
+   * (x, y, verifiers) its own daily relay quota, instead of every user
+   * sharing the factory address as a limit key.
+   *
+   * Returns `null` if the args fail to decode (e.g. selector matches but the
+   * payload is malformed). Caller must have already verified the selector
+   * matches `createSigner` and that `to` is an official factory.
+   *
+   * Note: the `isCreateSigner` selector pre-check at the call site is not
+   * redundant with the `decodeFunctionData` + `functionName` check here —
+   * `getSigner` is also in the ABI and would decode cleanly.
+   */
+  getSignerFactoryLimitAddress(data: Hex): Address | null {
+    let x: bigint;
+    let y: bigint;
+    let verifiers: bigint;
+    try {
+      const decoded = this.signerFactoryDecoder.decodeFunctionData({
+        data,
+      });
+      if (decoded.functionName !== 'createSigner') {
+        return null;
+      }
+      [x, y, verifiers] = decoded.args;
+    } catch {
+      return null;
+    }
+
+    const hash = keccak256(
+      encodeAbiParameters(parseAbiParameters('uint256, uint256, uint176'), [
+        x,
+        y,
+        verifiers,
+      ]),
+    );
+    return getAddress(`0x${hash.slice(-40)}`);
+  }
+
+  isValidCreateProxyWithNonceCall(args: {
+    version: string;
+    chainId: string;
+    data: Hex;
+  }): boolean {
+    let singleton: Address | null = null;
+
+    try {
+      const decoded = this.proxyFactoryDecoder.decodeFunctionData({
+        data: args.data,
+      });
+
+      if (decoded.functionName !== 'createProxyWithNonce') {
+        return false;
+      }
+
+      singleton = decoded.args[0];
+    } catch {
+      return false;
+    }
+
+    return (
+      getSafeSingletonDeployments(args).includes(singleton) ||
+      getSafeL2SingletonDeployments(args).includes(singleton)
+    );
+  }
+
+  getOwnersFromCreateProxyWithNonce(data: Hex): ReadonlyArray<Address> {
+    const decodedProxyFactory = this.proxyFactoryDecoder.decodeFunctionData({
+      data,
+    });
+
+    if (decodedProxyFactory.functionName !== 'createProxyWithNonce') {
+      // Should never happen but check is needed to satisfy TypeScript
+      throw Error('Not a createProxyWithNonce call');
+    }
+
+    const initializer = decodedProxyFactory.args[1];
+    const decodedSafe = this.safeDecoder.decodeFunctionData({
+      data: initializer,
+    });
+
+    if (decodedSafe.functionName !== 'setup') {
+      // No custom error thrown, as caller subsequently throws InvalidTransferError
+      throw Error('Not a setup call');
+    }
+
+    return decodedSafe.args[0];
+  }
+
+  /**
+   * Returns the address of the Safe being recovered, if the recovery transaction is valid:
+   *
+   * - DelayModifier proposal (execTransactionFromModule) or execution (executeNextTx)
+   * - (Batch) transaction(s) to add/remove/swap owners or change threshold on _a_ Safe
+   * - Via an enabled module on said Safe
+   *
+   * @param {string} args.chainId - Chain ID
+   * @param {string} args.version - Safe version
+   * @param {string} args.to - Transaction recipient
+   * @param {string} args.data - Transaction data
+   *
+   * @returns {Address | null} - Safe address being recovered, if valid
+   */
+  async getSafeBeingRecovered(args: {
+    chainId: string;
+    version: string;
+    to: Address;
+    data: Hex;
+  }): Promise<Address | null> {
+    let to: Address;
+    let data: Hex;
+
+    try {
+      const decoded = this.delayModifierDecoder.decodeFunctionData({
+        data: args.data,
+      });
+
+      if (
+        // Proposal
+        decoded.functionName !== 'execTransactionFromModule' &&
+        // Execution
+        decoded.functionName !== 'executeNextTx'
+      ) {
+        return null;
+      }
+
+      // No need to check value/operation as call is to Safe itself
+      to = decoded.args[0];
+      data = decoded.args[2];
+    } catch {
+      return null;
+    }
+
+    // (Batched) transaction(s) of transaction
+    const transactions = this.decodeTransactions({
+      address: to,
+      version: args.version,
+      chainId: args.chainId,
+      data,
+    });
+
+    const isEveryTransactionOwnerManagement = transactions.every(
+      (transaction) => {
+        return this.isOwnerManagementTransaction(transaction.data);
+      },
+    );
+
+    if (!isEveryTransactionOwnerManagement) {
+      return null;
+    }
+
+    const { safes } = await this.safeRepository.getSafesByModule({
+      chainId: args.chainId,
+      moduleAddress: args.to,
+    });
+
+    // Module enabled on Safe, and batch transactions target the same Safe
+    const isEnabledSafe = transactions.every((transaction, _, arr) => {
+      return transaction.to === arr[0].to && safes.includes(transaction.to);
+    });
+
+    if (!isEnabledSafe) {
+      return null;
+    }
+
+    return transactions[0].to;
+  }
+
+  /**
+   * Maps batched transactions if the data of an official multiSend call
+   * @param {string} args.address - Address of the recipient
+   * @param {string} args.version - Safe version
+   * @param {string} args.chainId - Chain ID
+   * @param {string} args.data - Data of the transaction
+   * @returns {Array<{ to: string; data: string }>} - Array of transactions
+   */
+  private decodeTransactions(args: {
+    address: Address;
+    version: string;
+    chainId: string;
+    data: Hex;
+  }): Array<{
+    to: Address;
+    data: Hex;
+  }> {
+    if (
+      this.isOfficialMultiSendDeployment(args) &&
+      this.multiSendDecoder.helpers.isMultiSend(args.data)
+    ) {
+      return this.multiSendDecoder.mapMultiSendTransactions(args.data);
+    }
+
+    return [{ to: args.address, data: args.data }];
+  }
+
+  /**
+   * Checks if the data of a transaction is an owner management transaction
+   * @param {string} data - Data of the transaction
+   * @returns {boolean} - Whether the data is of owner management
+   */
+  isOwnerManagementTransaction(data: Hex): boolean {
+    try {
+      const decoded = this.safeDecoder.decodeFunctionData({
+        data,
+      });
+
+      if (decoded.functionName !== 'execTransaction') {
+        return false;
+      }
+
+      const execTransactionData = decoded.args[2];
+
+      if (
+        !(
+          this.safeDecoder.helpers.isAddOwnerWithThreshold(
+            execTransactionData,
+          ) ||
+          this.safeDecoder.helpers.isRemoveOwner(execTransactionData) ||
+          this.safeDecoder.helpers.isSwapOwner(execTransactionData) ||
+          this.safeDecoder.helpers.isChangeThreshold(execTransactionData)
+        )
+      ) {
+        return false;
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isSafeTxHashValid(args: {
+    version: string;
+    chainId: string;
+    safeAddress: Address;
+    decoded: SafeTransaction;
+    safeTxHash: Hex;
+  }): Promise<boolean> {
+    const { decoded } = args;
+    const abi = this.getSafeAbi(args.version);
+
+    try {
+      const publicClient = await this.blockchainApiManager.getApi(args.chainId);
+
+      const nonce = await publicClient.readContract({
+        address: args.safeAddress,
+        abi,
+        functionName: 'nonce',
+      });
+
+      const onChainHash = await publicClient.readContract({
+        address: args.safeAddress,
+        abi,
+        functionName: 'getTransactionHash',
+        args: [
+          decoded.to,
+          decoded.value,
+          decoded.data,
+          decoded.operation,
+          decoded.safeTxGas,
+          decoded.baseGas,
+          decoded.gasPrice,
+          decoded.gasToken,
+          decoded.refundReceiver,
+          nonce,
+        ],
+      });
+
+      if (onChainHash !== args.safeTxHash) {
+        this.loggingService.warn({
+          type: LogType.TxRelayEligibility,
+          message: `relay-fee safeTxHash mismatch for ${args.safeAddress} on chain ${args.chainId}`,
+        });
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      this.loggingService.error({
+        type: LogType.TxRelayEligibility,
+        message: `relay-fee RPC error verifying safeTxHash for ${args.safeAddress} on chain ${args.chainId}: ${String(error)}`,
+      });
+      return false;
+    }
+  }
+}

--- a/src/modules/relay/domain/relay.domain.module.ts
+++ b/src/modules/relay/domain/relay.domain.module.ts
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
 import { FeeServiceApiModule } from '@/datasources/fee-service-api/fee-service-api.module';
-import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
 import { BalancesModule } from '@/modules/balances/balances.module';
+import { BlockchainModule } from '@/modules/blockchain/blockchain.module';
 import { RelayApiModule } from '@/modules/relay/datasources/relay-api.module';
 import { IRelayManager } from '@/modules/relay/domain/interfaces/relay-manager.interface';
 import { LimitAddressesMapper } from '@/modules/relay/domain/limit-addresses.mapper';
 import { RelayManager } from '@/modules/relay/domain/relay.manager';
 import { RelayRepository } from '@/modules/relay/domain/relay.repository';
 import { RelayDecodersModule } from '@/modules/relay/domain/relay-decoders.module';
+import { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
 import { DailyLimitRelayer } from '@/modules/relay/domain/relayers/daily-limit.relayer';
 import { NoFeeCampaignRelayer } from '@/modules/relay/domain/relayers/no-fee-campaign.relayer';
 import { RelayFeeRelayer } from '@/modules/relay/domain/relayers/relay-fee.relayer';
@@ -21,11 +22,12 @@ import { SafeRepositoryModule } from '@/modules/safe/domain/safe.repository.inte
     SafeRepositoryModule,
     BalancesModule,
     FeeServiceApiModule,
+    BlockchainModule,
   ],
   providers: [
+    RelayTransactionHelper,
     LimitAddressesMapper,
     RelayRepository,
-    DelayModifierDecoder,
     DailyLimitRelayer,
     NoFeeCampaignRelayer,
     RelayFeeRelayer,

--- a/src/modules/relay/domain/relay.manager.ts
+++ b/src/modules/relay/domain/relay.manager.ts
@@ -78,7 +78,7 @@ export class RelayManager implements IRelayManager {
       return this.noFeeCampaignRelayer;
     }
 
-    // Fallback, to use daily limit relayer. This is to ensure backward compatibility if dailyLimitRelayChainIds is not set becuase of missing environment variable.
+    // Fallback, to use daily limit relayer. This is to ensure backward compatibility if dailyLimitRelayChainIds is not set because of missing environment variable.
     return this.dailyLimitRelayer;
   }
 }

--- a/src/modules/relay/domain/relay.repository.ts
+++ b/src/modules/relay/domain/relay.repository.ts
@@ -17,7 +17,7 @@ export class RelayRepository {
     version: string;
     chainId: string;
     to: Address;
-    data: Address;
+    data: Hex;
     gasLimit: bigint | null;
     safeTxHash?: Hex;
   }): Promise<Relay> {

--- a/src/modules/relay/domain/relayers/__tests__/relay-fee.relayer.spec.ts
+++ b/src/modules/relay/domain/relayers/__tests__/relay-fee.relayer.spec.ts
@@ -8,7 +8,10 @@ import type { IFeeServiceApi } from '@/domain/interfaces/fee-service-api.interfa
 import type { IRelayApi } from '@/domain/interfaces/relay-api.interface';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { RelayTxDeniedError } from '@/modules/relay/domain/errors/relay-tx-denied.error';
-import { RelayFeeRelayer } from '@/modules/relay/domain/relayers/relay-fee.relayer';
+import { SafeTxHashMismatchError } from '@/modules/relay/domain/errors/safe-tx-hash-mismatch.error';
+import { UnofficialProxyFactoryError } from '@/modules/relay/domain/errors/unofficial-proxy-factory.error';
+import type { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
+import { RelayFeeRelayer } from '../relay-fee.relayer';
 
 const mockLoggingService = jest.mocked({
   info: jest.fn(),
@@ -26,6 +29,23 @@ const mockRelayApi = jest.mocked({
 const mockFeeServiceApi = jest.mocked({
   canRelay: jest.fn(),
 } as jest.MockedObjectDeep<IFeeServiceApi>);
+
+const mockRelayTransactionHelper = jest.mocked({
+  decodeExecTransaction: jest.fn(),
+  isValidDecodedExecTransaction: jest.fn(),
+  isValidExecTransactionCall: jest.fn(),
+  isSafeTxHashValid: jest.fn(),
+  isValidCreateProxyWithNonceCall: jest.fn(),
+  isOfficialProxyFactoryDeployment: jest.fn(),
+} as jest.MockedObjectDeep<RelayTransactionHelper>);
+
+function fakeSafeTxHash(): Hex {
+  return faker.string.hexadecimal({ length: 64, casing: 'lower' }) as Hex;
+}
+
+function fakeAddress(): Address {
+  return getAddress(faker.finance.ethereumAddress());
+}
 
 describe('RelayFeeRelayer', () => {
   let target: RelayFeeRelayer;
@@ -47,6 +67,7 @@ describe('RelayFeeRelayer', () => {
       fakeConfigurationService,
       mockRelayApi,
       mockFeeServiceApi,
+      mockRelayTransactionHelper,
     );
   });
 
@@ -54,7 +75,7 @@ describe('RelayFeeRelayer', () => {
     it('should return false for chains not enabled for relay-fee', async () => {
       const result = await target.canRelay({
         chainId: faker.string.numeric({ length: 5 }),
-        address: getAddress(faker.finance.ethereumAddress()),
+        address: fakeAddress(),
       });
 
       expect(result).toEqual({ result: false, currentCount: 0, limit: 0 });
@@ -64,7 +85,7 @@ describe('RelayFeeRelayer', () => {
     it('should return false when no safeTxHash is provided', async () => {
       const result = await target.canRelay({
         chainId: enabledChainId,
-        address: getAddress(faker.finance.ethereumAddress()),
+        address: fakeAddress(),
       });
 
       expect(result).toEqual({ result: false, currentCount: 0, limit: 0 });
@@ -72,16 +93,12 @@ describe('RelayFeeRelayer', () => {
     });
 
     it('should return true when FeeService approves', async () => {
-      const address = getAddress(faker.finance.ethereumAddress());
-      const safeTxHash = faker.string.hexadecimal({
-        length: 64,
-        casing: 'lower',
-      }) as Hex;
+      const safeTxHash = fakeSafeTxHash();
       mockFeeServiceApi.canRelay.mockResolvedValueOnce({ canRelay: true });
 
       const result = await target.canRelay({
         chainId: enabledChainId,
-        address,
+        address: fakeAddress(),
         safeTxHash,
       });
 
@@ -93,16 +110,12 @@ describe('RelayFeeRelayer', () => {
     });
 
     it('should return false when FeeService denies', async () => {
-      const address = getAddress(faker.finance.ethereumAddress());
-      const safeTxHash = faker.string.hexadecimal({
-        length: 64,
-        casing: 'lower',
-      }) as Hex;
+      const safeTxHash = fakeSafeTxHash();
       mockFeeServiceApi.canRelay.mockResolvedValueOnce({ canRelay: false });
 
       const result = await target.canRelay({
         chainId: enabledChainId,
-        address,
+        address: fakeAddress(),
         safeTxHash,
       });
 
@@ -116,80 +129,302 @@ describe('RelayFeeRelayer', () => {
   });
 
   describe('relay', () => {
-    it('should throw RelayTxDeniedError when no safeTxHash is provided', async () => {
-      const address = getAddress(faker.finance.ethereumAddress());
+    // Shared fake decoded object for execTransaction tests
+    const fakeDecoded = {
+      to: '0x0000000000000000000000000000000000000001' as const,
+      value: BigInt(0),
+      data: '0x' as const,
+      operation: 0,
+      safeTxGas: BigInt(0),
+      baseGas: BigInt(0),
+      gasPrice: BigInt(0),
+      gasToken: '0x0000000000000000000000000000000000000000' as const,
+      refundReceiver: '0x0000000000000000000000000000000000000000' as const,
+    };
+
+    it('should throw RelayTxDeniedError when no safeTxHash is provided for execTransaction', async () => {
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(
+        fakeDecoded,
+      );
+      mockRelayTransactionHelper.isValidDecodedExecTransaction.mockReturnValue(
+        true,
+      );
 
       await expect(
         target.relay({
           version: '1.3.0',
           chainId: enabledChainId,
-          to: address,
-          data: '0x' as Address,
+          to: fakeAddress(),
+          data: '0x' as Hex,
           gasLimit: null,
         }),
       ).rejects.toThrow(RelayTxDeniedError);
 
+      expect(
+        mockRelayTransactionHelper.isSafeTxHashValid,
+      ).not.toHaveBeenCalled();
       expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
       expect(mockRelayApi.relay).not.toHaveBeenCalled();
     });
 
-    it('should relay when FeeService approves all addresses', async () => {
-      const address = getAddress(faker.finance.ethereumAddress());
-      const safeTxHash = faker.string.hexadecimal({ length: 64 }) as Hex;
+    it('should relay when isSafeTxHashValid returns true and fee service approves', async () => {
+      const safeAddress = fakeAddress();
+      const safeTxHash = fakeSafeTxHash();
       const taskId = faker.string.uuid();
+
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(
+        fakeDecoded,
+      );
+      mockRelayTransactionHelper.isValidDecodedExecTransaction.mockReturnValue(
+        true,
+      );
+      mockRelayTransactionHelper.isSafeTxHashValid.mockResolvedValue(true);
       mockFeeServiceApi.canRelay.mockResolvedValueOnce({ canRelay: true });
       mockRelayApi.relay.mockResolvedValueOnce({ taskId });
 
       const result = await target.relay({
         version: '1.3.0',
         chainId: enabledChainId,
-        to: address,
-        data: '0x' as Address,
+        to: safeAddress,
+        data: '0x' as Hex,
         gasLimit: null,
         safeTxHash,
       });
 
       expect(result).toEqual({ taskId });
+      expect(mockRelayTransactionHelper.isSafeTxHashValid).toHaveBeenCalledWith(
+        {
+          version: '1.3.0',
+          chainId: enabledChainId,
+          safeAddress,
+          decoded: fakeDecoded,
+          safeTxHash,
+        },
+      );
       expect(mockFeeServiceApi.canRelay).toHaveBeenCalledWith({
         chainId: enabledChainId,
         safeTxHash,
       });
       expect(mockRelayApi.relay).toHaveBeenCalledWith({
         chainId: enabledChainId,
-        to: address,
+        to: safeAddress,
         data: '0x',
       });
     });
 
-    it('should throw RelayDeniedError when Fee Service denies', async () => {
-      const address = getAddress(faker.finance.ethereumAddress());
-      const safeTxHash = faker.string.hexadecimal({ length: 64 }) as Hex;
+    it('should throw SafeTxHashMismatchError when isSafeTxHashValid returns false', async () => {
+      const safeTxHash = fakeSafeTxHash();
+
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(
+        fakeDecoded,
+      );
+      mockRelayTransactionHelper.isValidDecodedExecTransaction.mockReturnValue(
+        true,
+      );
+      mockRelayTransactionHelper.isSafeTxHashValid.mockResolvedValue(false);
+
+      await expect(
+        target.relay({
+          version: '1.3.0',
+          chainId: enabledChainId,
+          to: fakeAddress(),
+          data: '0x' as Hex,
+          gasLimit: null,
+          safeTxHash,
+        }),
+      ).rejects.toThrow(SafeTxHashMismatchError);
+
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+      expect(mockRelayApi.relay).not.toHaveBeenCalled();
+    });
+
+    it('should throw RelayTxDeniedError when fee service denies after hash validation passes', async () => {
+      const safeAddress = fakeAddress();
+      const safeTxHash = fakeSafeTxHash();
+
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(
+        fakeDecoded,
+      );
+      mockRelayTransactionHelper.isValidDecodedExecTransaction.mockReturnValue(
+        true,
+      );
+      mockRelayTransactionHelper.isSafeTxHashValid.mockResolvedValue(true);
       mockFeeServiceApi.canRelay.mockResolvedValueOnce({ canRelay: false });
 
       await expect(
         target.relay({
           version: '1.3.0',
           chainId: enabledChainId,
-          to: address,
-          data: '0x' as Address,
+          to: safeAddress,
+          data: '0x' as Hex,
           gasLimit: null,
           safeTxHash,
         }),
       ).rejects.toThrow(RelayTxDeniedError);
 
       expect(mockRelayApi.relay).not.toHaveBeenCalled();
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('fee service rejected'),
+        }),
+      );
+    });
+
+    it('should relay a Safe creation when factory is official', async () => {
+      const safeAddress = fakeAddress();
+      const safeTxHash = fakeSafeTxHash();
+      const taskId = faker.string.uuid();
+
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(null);
+      mockRelayTransactionHelper.isValidCreateProxyWithNonceCall.mockReturnValue(
+        true,
+      );
+      mockRelayTransactionHelper.isOfficialProxyFactoryDeployment.mockReturnValue(
+        true,
+      );
+      mockRelayApi.relay.mockResolvedValueOnce({ taskId });
+
+      const result = await target.relay({
+        version: '1.3.0',
+        chainId: enabledChainId,
+        to: safeAddress,
+        data: '0x' as Hex,
+        gasLimit: null,
+        safeTxHash,
+      });
+
+      expect(result).toEqual({ taskId });
+      expect(
+        mockRelayTransactionHelper.isSafeTxHashValid,
+      ).not.toHaveBeenCalled();
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+      expect(mockRelayApi.relay).toHaveBeenCalled();
+    });
+
+    it('should relay a Safe creation without safeTxHash when factory is official', async () => {
+      const taskId = faker.string.uuid();
+
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(null);
+      mockRelayTransactionHelper.isValidCreateProxyWithNonceCall.mockReturnValue(
+        true,
+      );
+      mockRelayTransactionHelper.isOfficialProxyFactoryDeployment.mockReturnValue(
+        true,
+      );
+      mockRelayApi.relay.mockResolvedValueOnce({ taskId });
+
+      const result = await target.relay({
+        version: '1.3.0',
+        chainId: enabledChainId,
+        to: fakeAddress(),
+        data: '0x' as Hex,
+        gasLimit: null,
+      });
+
+      expect(result).toEqual({ taskId });
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+      expect(mockRelayApi.relay).toHaveBeenCalled();
+    });
+
+    it('should throw UnofficialProxyFactoryError for unofficial proxy factory', async () => {
+      const to = fakeAddress();
+
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(null);
+      mockRelayTransactionHelper.isValidCreateProxyWithNonceCall.mockReturnValue(
+        true,
+      );
+      mockRelayTransactionHelper.isOfficialProxyFactoryDeployment.mockReturnValue(
+        false,
+      );
+
+      await expect(
+        target.relay({
+          version: '1.3.0',
+          chainId: enabledChainId,
+          to,
+          data: '0x' as Hex,
+          gasLimit: null,
+          safeTxHash: fakeSafeTxHash(),
+        }),
+      ).rejects.toThrow(UnofficialProxyFactoryError);
+
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('unofficial proxy factory'),
+        }),
+      );
+    });
+
+    it('should throw RelayTxDeniedError with invalid-execTransaction message when decoded but isValidDecodedExecTransaction returns false', async () => {
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(
+        fakeDecoded,
+      );
+      mockRelayTransactionHelper.isValidDecodedExecTransaction.mockReturnValue(
+        false,
+      );
+
+      await expect(
+        target.relay({
+          version: '1.3.0',
+          chainId: enabledChainId,
+          to: fakeAddress(),
+          data: '0x' as Hex,
+          gasLimit: null,
+          safeTxHash: fakeSafeTxHash(),
+        }),
+      ).rejects.toThrow(RelayTxDeniedError);
+
+      expect(
+        mockRelayTransactionHelper.isValidCreateProxyWithNonceCall,
+      ).not.toHaveBeenCalled();
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+      expect(mockRelayApi.relay).not.toHaveBeenCalled();
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('invalid execTransaction'),
+        }),
+      );
+    });
+
+    it('should throw RelayTxDeniedError for unrecognised transaction type', async () => {
+      mockRelayTransactionHelper.decodeExecTransaction.mockReturnValue(null);
+      mockRelayTransactionHelper.isValidCreateProxyWithNonceCall.mockReturnValue(
+        false,
+      );
+
+      await expect(
+        target.relay({
+          version: '1.3.0',
+          chainId: enabledChainId,
+          to: fakeAddress(),
+          data: '0x' as Hex,
+          gasLimit: null,
+          safeTxHash: fakeSafeTxHash(),
+        }),
+      ).rejects.toThrow(RelayTxDeniedError);
+
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+      expect(mockRelayApi.relay).not.toHaveBeenCalled();
     });
   });
 
   describe('getRelaysRemaining', () => {
+    it('should return optimistic 1 when no safeTxHash is provided on an enabled chain', async () => {
+      const result = await target.getRelaysRemaining({
+        chainId: enabledChainId,
+        address: fakeAddress(),
+      });
+
+      expect(result).toEqual({ remaining: 1, limit: 1 });
+      expect(mockFeeServiceApi.canRelay).not.toHaveBeenCalled();
+    });
+
     it('should return 0 for chains not enabled for relay-fee', async () => {
       const result = await target.getRelaysRemaining({
         chainId: faker.string.numeric({ length: 5 }),
-        address: getAddress(faker.finance.ethereumAddress()),
-        safeTxHash: faker.string.hexadecimal({
-          length: 64,
-          casing: 'lower',
-        }) as Hex,
+        address: fakeAddress(),
+        safeTxHash: fakeSafeTxHash(),
       });
 
       expect(result).toEqual({ remaining: 0, limit: 0 });
@@ -200,11 +435,8 @@ describe('RelayFeeRelayer', () => {
 
       const result = await target.getRelaysRemaining({
         chainId: enabledChainId,
-        address: getAddress(faker.finance.ethereumAddress()),
-        safeTxHash: faker.string.hexadecimal({
-          length: 64,
-          casing: 'lower',
-        }) as Hex,
+        address: fakeAddress(),
+        safeTxHash: fakeSafeTxHash(),
       });
 
       expect(result).toEqual({ remaining: 1, limit: 1 });
@@ -212,15 +444,12 @@ describe('RelayFeeRelayer', () => {
     });
 
     it('should pass safeTxHash to Fee Service when provided', async () => {
-      const address = getAddress(faker.finance.ethereumAddress());
-      const safeTxHash = faker.string.hexadecimal({
-        length: 64,
-      }) as `0x${string}`;
+      const safeTxHash = fakeSafeTxHash();
       mockFeeServiceApi.canRelay.mockResolvedValueOnce({ canRelay: true });
 
       const result = await target.getRelaysRemaining({
         chainId: enabledChainId,
-        address,
+        address: fakeAddress(),
         safeTxHash,
       });
 
@@ -236,8 +465,8 @@ describe('RelayFeeRelayer', () => {
 
       const result = await target.getRelaysRemaining({
         chainId: enabledChainId,
-        address: getAddress(faker.finance.ethereumAddress()),
-        safeTxHash: faker.string.hexadecimal({ length: 64 }) as `0x${string}`,
+        address: fakeAddress(),
+        safeTxHash: fakeSafeTxHash(),
       });
 
       expect(result).toEqual({ remaining: 0, limit: 0 });

--- a/src/modules/relay/domain/relayers/daily-limit.relayer.ts
+++ b/src/modules/relay/domain/relayers/daily-limit.relayer.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
-import type { Address } from 'viem';
+import type { Address, Hex } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { IRelayApi } from '@/domain/interfaces/relay-api.interface';
 import {
@@ -44,9 +44,9 @@ export class DailyLimitRelayer implements IRelayer {
     version: string;
     chainId: string;
     to: Address;
-    data: Address;
+    data: Hex;
     gasLimit: bigint | null;
-    safeTxHash?: string;
+    safeTxHash?: Hex;
   }): Promise<Relay> {
     const relayAddresses =
       await this.limitAddressesMapper.getLimitAddresses(args);

--- a/src/modules/relay/domain/relayers/no-fee-campaign.relayer.ts
+++ b/src/modules/relay/domain/relayers/no-fee-campaign.relayer.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
-import type { Address } from 'viem';
+import type { Address, Hex } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { IRelayApi } from '@/domain/interfaces/relay-api.interface';
 import {
@@ -71,9 +71,9 @@ export class NoFeeCampaignRelayer implements IRelayer {
     version: string;
     chainId: string;
     to: Address;
-    data: Address;
+    data: Hex;
     gasLimit: bigint | null;
-    safeTxHash?: string;
+    safeTxHash?: Hex;
   }): Promise<Relay> {
     const relayAddresses =
       await this.limitAddressesMapper.getLimitAddresses(args);

--- a/src/modules/relay/domain/relayers/relay-fee.relayer.ts
+++ b/src/modules/relay/domain/relayers/relay-fee.relayer.ts
@@ -16,7 +16,11 @@ import {
 } from '@/modules/relay/domain/entities/relay.entity';
 import type { RelayEligibility } from '@/modules/relay/domain/entities/relay-eligibility.entity';
 import { RelayTxDeniedError } from '@/modules/relay/domain/errors/relay-tx-denied.error';
+import { SafeTxHashMismatchError } from '@/modules/relay/domain/errors/safe-tx-hash-mismatch.error';
+import { UnofficialProxyFactoryError } from '@/modules/relay/domain/errors/unofficial-proxy-factory.error';
 import type { IRelayer } from '@/modules/relay/domain/interfaces/relayer.interface';
+import { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
+import { SafeTransaction } from '@/modules/transactions/domain/entities/safe-transaction.entity';
 
 @Injectable()
 export class RelayFeeRelayer implements IRelayer {
@@ -27,6 +31,7 @@ export class RelayFeeRelayer implements IRelayer {
     @Inject(IConfigurationService) configurationService: IConfigurationService,
     @Inject(IRelayApi) private readonly relayApi: IRelayApi,
     @Inject(IFeeServiceApi) private readonly feeServiceApi: IFeeServiceApi,
+    private readonly relayTransactionHelper: RelayTransactionHelper,
   ) {
     this.relayFeeConfiguration = configurationService.getOrThrow('relay.fee');
   }
@@ -74,8 +79,7 @@ export class RelayFeeRelayer implements IRelayer {
   }
 
   /**
-   * Relays a transaction after verifying all limit addresses are eligible via the fee service.
-   * Throws {@link RelayDeniedError} if any address is denied by the FeeService.
+   * Relays a transaction after verifying eligibility via the fee service.
    *
    * @param args.version - Safe contract version
    * @param args.chainId - Chain ID
@@ -84,6 +88,11 @@ export class RelayFeeRelayer implements IRelayer {
    * @param args.gasLimit - Gas limit, or null for automatic estimation
    * @param args.safeTxHash - Safe transaction hash for relay-fee eligibility
    * @returns Relay result from the relay API
+   * @throws {@link RelayTxDeniedError} if no safeTxHash is provided for an execTransaction, the
+   *   fee service rejects the safeTxHash, the execTransaction fails validity rules, the proxy
+   *   factory is not an official deployment, or the transaction type is not recognised
+   * @throws {@link SafeTxHashMismatchError} if the provided safeTxHash does not match the
+   *   on-chain hash computed from the decoded execTransaction
    */
   async relay(args: {
     version: string;
@@ -93,32 +102,147 @@ export class RelayFeeRelayer implements IRelayer {
     gasLimit: bigint | null;
     safeTxHash?: Hex;
   }): Promise<Relay> {
-    if (!args.safeTxHash) {
-      throw new RelayTxDeniedError(args.safeTxHash);
+    const { version, chainId, to, data } = args;
+    const decoded = this.relayTransactionHelper.decodeExecTransaction(data);
+
+    // The relay request must match one of the supported transaction.
+    // Each branch below handles one possible classification of the decoded data:
+    if (
+      decoded !== null &&
+      this.relayTransactionHelper.isValidDecodedExecTransaction({ to, decoded })
+    ) {
+      // Branch 1: a valid execTransaction call on a Safe.
+      // Verify the safeTxHash matches the decoded payload and that the fee
+      // service permits relaying this specific transaction.
+      await this.validateExecTransaction({
+        version,
+        chainId,
+        to,
+        decoded,
+        safeTxHash: args.safeTxHash,
+      });
+    } else if (decoded !== null) {
+      // Branch 2: the data decoded as execTransaction but failed validity rules.
+      // e.g. Fee service rejected relaying because of not enough signatures.
+      this.denyInvalidExecTransaction({
+        to,
+        chainId,
+        safeTxHash: args.safeTxHash,
+      });
+    } else if (
+      this.relayTransactionHelper.isValidCreateProxyWithNonceCall({
+        version,
+        chainId,
+        data,
+      })
+    ) {
+      // Branch 3: a Safe creation call (createProxyWithNonce) on a known
+      // ProxyFactory. Confirm the target is an official deployment for the
+      // given version + chain before relaying.
+      this.validateSafeCreation({
+        version,
+        chainId,
+        to,
+      });
+    } else {
+      // Branch 4: data does not match any supported transaction types.
+      // 1. Not a valid execTransaction call
+      // 2. Not a valid createProxyWithNonce call.
+      this.denyUnrecognisedTxType({ to, chainId, safeTxHash: args.safeTxHash });
+    }
+
+    return this.relayApi
+      .relay({
+        chainId,
+        to,
+        data,
+      })
+      .then(RelaySchema.parse);
+  }
+
+  private async validateExecTransaction(args: {
+    version: string;
+    chainId: string;
+    to: Address;
+    decoded: SafeTransaction;
+    safeTxHash: Hex | undefined;
+  }): Promise<void> {
+    const { version, chainId, to, decoded, safeTxHash } = args;
+
+    if (!safeTxHash) {
+      throw new RelayTxDeniedError(undefined);
+    }
+
+    const isValid = await this.relayTransactionHelper.isSafeTxHashValid({
+      version,
+      chainId,
+      safeAddress: to,
+      decoded,
+      safeTxHash,
+    });
+
+    if (!isValid) {
+      throw new SafeTxHashMismatchError(safeTxHash);
     }
 
     const feeServiceResult = await this.feeServiceApi.canRelay({
-      chainId: args.chainId,
-      safeTxHash: args.safeTxHash,
+      chainId,
+      safeTxHash,
     });
 
     if (!feeServiceResult.canRelay) {
-      this.loggingService.error({
+      this.loggingService.warn({
         type: LogType.TxRelayEligibility,
-        message: `relay-fee relay denied for ${args.safeTxHash}`,
+        message: `relay-fee relay denied for ${to} on chain ${chainId}: fee service rejected safeTxHash ${safeTxHash}`,
       });
-      throw new RelayTxDeniedError(args.safeTxHash);
+      throw new RelayTxDeniedError(safeTxHash);
     }
+  }
 
-    const relayResponse = await this.relayApi
-      .relay({
-        chainId: args.chainId,
-        to: args.to,
-        data: args.data,
+  private denyInvalidExecTransaction(args: {
+    to: Address;
+    chainId: string;
+    safeTxHash: Hex | undefined;
+  }): never {
+    this.loggingService.warn({
+      type: LogType.TxRelayEligibility,
+      message: `relay-fee relay denied for invalid execTransaction: to=${args.to} on chain ${args.chainId}`,
+    });
+    throw new RelayTxDeniedError(args.safeTxHash);
+  }
+
+  private validateSafeCreation(args: {
+    version: string;
+    chainId: string;
+    to: Address;
+  }): void {
+    const { version, chainId, to } = args;
+
+    if (
+      !this.relayTransactionHelper.isOfficialProxyFactoryDeployment({
+        version,
+        chainId,
+        address: to,
       })
-      .then(RelaySchema.parse);
+    ) {
+      this.loggingService.warn({
+        type: LogType.TxRelayEligibility,
+        message: `relay-fee relay denied for unofficial proxy factory ${to} on chain ${chainId}`,
+      });
+      throw new UnofficialProxyFactoryError();
+    }
+  }
 
-    return relayResponse;
+  private denyUnrecognisedTxType(args: {
+    to: Address;
+    chainId: string;
+    safeTxHash: Hex | undefined;
+  }): never {
+    this.loggingService.warn({
+      type: LogType.TxRelayEligibility,
+      message: `relay-fee relay denied for unrecognised tx type: to=${args.to} on chain ${args.chainId}`,
+    });
+    throw new RelayTxDeniedError(args.safeTxHash);
   }
 
   /**
@@ -133,10 +257,16 @@ export class RelayFeeRelayer implements IRelayer {
   async getRelaysRemaining(args: {
     chainId: string;
     address: Address;
-    safeTxHash: Hex;
+    safeTxHash?: Hex;
   }): Promise<{ remaining: number; limit: number }> {
     if (!this.relayFeeConfiguration.enabledChainIds.includes(args.chainId)) {
       return { remaining: 0, limit: 0 };
+    }
+
+    // Without a safeTxHash we cannot query the fee service; report optimistically
+    // since per-transaction eligibility is enforced in relay().
+    if (!args.safeTxHash) {
+      return { remaining: 1, limit: 1 };
     }
 
     // For relay-fee, the FeeService API is the authority on relay eligibility.

--- a/src/modules/relay/routes/relay.controller.ts
+++ b/src/modules/relay/routes/relay.controller.ts
@@ -11,6 +11,7 @@ import {
 import {
   ApiBadRequestResponse,
   ApiBody,
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -18,12 +19,14 @@ import {
   ApiQuery,
   ApiTags,
   ApiTooManyRequestsResponse,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 import type { Address, Hex } from 'viem';
 import { InvalidMultiSendExceptionFilter } from '@/modules/relay/domain/exception-filters/invalid-multisend.exception-filter';
 import { InvalidTransferExceptionFilter } from '@/modules/relay/domain/exception-filters/invalid-transfer.exception-filter';
 import { RelayDeniedExceptionFilter } from '@/modules/relay/domain/exception-filters/relay-denied.exception-filter';
 import { RelayLimitReachedExceptionFilter } from '@/modules/relay/domain/exception-filters/relay-limit-reached.exception-filter';
+import { SafeTxHashMismatchExceptionFilter } from '@/modules/relay/domain/exception-filters/safe-tx-hash-mismatch.exception-filter';
 import { UnofficialMasterCopyExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-master-copy.exception-filter';
 import { UnofficialMultiSendExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-multisend.error';
 import { UnofficialProxyFactoryExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-proxy-factory.exception-filter';
@@ -50,7 +53,9 @@ export class RelayController {
   @ApiOperation({
     summary: 'Relay transaction',
     description:
-      'Relays a Safe transaction using the relay service, which pays for gas fees. The transaction must meet certain criteria and the Safe must have remaining relay quota.',
+      'Relays a Safe transaction or Safe creation transaction using the relay service, which pays for gas fees. ' +
+      'Supports execTransaction (Safe tx) and createProxyWithNonce (Safe creation) calldata. ' +
+      'On relay-fee chains, safeTxHash is required and must match the hash derived on-chain from the submitted calldata.',
   })
   @ApiParam({
     name: 'chainId',
@@ -61,15 +66,22 @@ export class RelayController {
   @ApiBody({
     type: RelayDto,
     description:
-      'Transaction data to relay including Safe address, transaction details, and signatures',
+      'Transaction data to relay. safeTxHash is required on relay-fee chains and must correspond to the to + data fields.',
   })
   @ApiOkResponse({
     type: Relay,
-    description: 'Transaction relayed successfully with transaction hash',
+    description: 'Transaction relayed successfully',
   })
   @ApiBadRequestResponse({
+    description: 'Request body failed schema validation',
+  })
+  @ApiForbiddenResponse({
     description:
-      'Invalid transaction data, unofficial contracts, or unsupported operation',
+      'Relay denied: safeTxHash missing, fee service rejected, or unofficial proxy factory',
+  })
+  @ApiUnprocessableEntityResponse({
+    description:
+      'safeTxHash does not match the transaction data, or unrecognised transaction type',
   })
   @ApiTooManyRequestsResponse({
     description: 'Relay limit reached for this Safe',
@@ -78,6 +90,7 @@ export class RelayController {
   @UseFilters(
     RelayLimitReachedExceptionFilter,
     RelayDeniedExceptionFilter,
+    SafeTxHashMismatchExceptionFilter,
     InvalidMultiSendExceptionFilter,
     InvalidTransferExceptionFilter,
     UnofficialMasterCopyExceptionFilter,
@@ -127,7 +140,10 @@ export class RelayController {
   @ApiOperation({
     summary: 'Get remaining relays',
     description:
-      'Retrieves the number of remaining relay transactions available for a specific Safe on the given chain.',
+      'Retrieves the number of remaining relay transactions available for a specific Safe on the given chain. ' +
+      'On relay-fee chains, safeTxHash is forwarded to the fee service to determine per-transaction eligibility ' +
+      '(returns remaining=1 when eligible, 0 when not). ' +
+      'On daily-limit and no-fee-campaign chains, a count-based quota is returned.',
   })
   @ApiParam({
     name: 'chainId',
@@ -144,7 +160,9 @@ export class RelayController {
     name: 'safeTxHash',
     required: false,
     description:
-      'Safe transaction hash (0x prefixed hex string). Required for chains enabled for relay-fee relayer',
+      'Safe transaction hash (0x prefixed hex string). ' +
+      'Required on relay-fee chains to check per-transaction eligibility with the fee service. ' +
+      'Optional on daily-limit and no-fee-campaign chains.',
   })
   @ApiOkResponse({
     type: RelaysRemaining,

--- a/src/modules/transactions/domain/entities/safe-transaction.entity.ts
+++ b/src/modules/transactions/domain/entities/safe-transaction.entity.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { Operation } from '@/modules/safe/domain/entities/operation.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { BigIntSchema } from '@/validation/entities/schemas/bigint.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+
+export const SafeTransactionSchema = z.object({
+  to: AddressSchema,
+  value: BigIntSchema,
+  data: HexSchema,
+  operation: z.enum(Operation),
+  safeTxGas: BigIntSchema,
+  baseGas: BigIntSchema,
+  gasPrice: BigIntSchema,
+  gasToken: AddressSchema,
+  refundReceiver: AddressSchema,
+});
+
+export type SafeTransaction = z.infer<typeof SafeTransactionSchema>;
+
+export type SafeTransactionWithSignature = SafeTransaction & {
+  signatures: z.infer<typeof HexSchema>;
+};

--- a/src/validation/entities/schemas/bigint.schema.ts
+++ b/src/validation/entities/schemas/bigint.schema.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+// Zod does not support bigint natively, so we use string and transform
+export const BigIntSchema = z.string().transform((val, ctx) => {
+  try {
+    return BigInt(val);
+  } catch {
+    ctx.addIssue({ code: 'custom', message: 'Invalid bigint string' });
+    return z.NEVER;
+  }
+});


### PR DESCRIPTION
## Summary

Closes: https://linear.app/safe-global/issue/PLA-1268/cgw-bug-relay-fee-relayer-does-not-validate-to-data-value-params

Closes: https://linear.app/safe-global/issue/PLA-1277/cgw-allow-relaying-safe-creation-tx-for-gtf-enabled-chains

The relay-fee relayer was sponsoring transactions based solely on the fee service's `canRelay` response, without verifying that the submitted `to`/`data` actually corresponds to the claimed `safeTxHash`. An attacker could construct calldata that the fee service approves (via a legitimate hash) but execute different transaction parameters. This PR fixes that by verifying the `safeTxHash` on-chain before sponsoring, and consolidates the relay validation logic that was duplicated between `LimitAddressesMapper` and the relay-fee path.

## Changes

### On-chain `safeTxHash` verification in `relay-fee` relayer

`RelayFeeRelayer.relay()` now dispatches on transaction type before calling the fee service:

- **`execTransaction`**: requires `safeTxHash`. Calls `getTransactionHash` on the Safe contract with the decoded calldata args and the current on-chain nonce, then compares against the submitted hash. Mismatch throws `SafeTxHashMismatchError` (HTTP 422) before the fee service is ever called.
- **`createProxyWithNonce`**: verifies the proxy factory is an official deployment.
- **Anything else**: denied with `RelayTxDeniedError` (HTTP 403).

`SafeTxHashMismatchError` and its exception filter are new; the filter returns HTTP 422 and is registered on `RelayController`.

### `RelayTransactionHelper`

All transaction-inspection logic previously in `LimitAddressesMapper` (`isValidExecTransactionCall`, `isOfficialMastercopy`, `isMultiSend`, `isOfficialMultiSendDeployment`, `getSafeAddressFromMultiSend`, `isOfficialProxyFactoryDeployment`, `isValidCreateProxyWithNonceCall`, `getOwnersFromCreateProxyWithNonce`, `getSafeBeingRecovered`) has been extracted into a dedicated `RelayTransactionHelper` injectable. `isSafeTxHashValid` is added here as the new on-chain verification method.

`LimitAddressesMapper` now delegates entirely to `RelayTransactionHelper`, eliminating the duplicate decoders and RPC dependencies it previously held directly.

### `SafeTransaction*` entities

`SafeTransaction` and `SafeTransactionWithSignature` type added to capture the full `execTransaction` argument tuple (including `signatures`), enabling the `safe-encoder.builder` test helper to be typed against the canonical entity rather than a locally-defined duplicate.
