### PR TITLE
feat: relay sponsorship for SafeWebAuthnSignerFactory.createSigner

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,11 @@ export default tseslint.config(
               message:
                 'Please import from @/domain/common/utils/deployments instead.',
             },
+            {
+              name: '@safe-global/safe-modules-deployments',
+              message:
+                'Please import from @/domain/common/utils/deployments instead.',
+            },
           ],
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import globals from 'globals';
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@nestjs/swagger": "11.2.6",
     "@nestjs/typeorm": "11.0.0",
     "@safe-global/safe-deployments": "1.37.51",
-    "@safe-global/safe-modules-deployments": "^3.0.1",
+    "@safe-global/safe-modules-deployments": "3.0.1",
     "amqp-connection-manager": "5.0.0",
     "amqplib": "0.10.8",
     "bullmq": "^5.56.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@nestjs/swagger": "11.2.6",
     "@nestjs/typeorm": "11.0.0",
     "@safe-global/safe-deployments": "1.37.51",
+    "@safe-global/safe-modules-deployments": "^3.0.1",
     "amqp-connection-manager": "5.0.0",
     "amqplib": "0.10.8",
     "bullmq": "^5.56.0",

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 // eslint-disable-next-line no-restricted-imports
 import {
   getMultiSendCallOnlyDeployments as _getMultiSendCallOnlyDeployments,

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -350,10 +350,25 @@ export function getSignerFactoryDeployments(args: {
 }
 
 /**
+ * Function signatures we type-cast the upstream ABI to in {@link SignerFactoryAbi}.
+ * Verified at module load by {@link getSignerFactoryAbi} so a future package
+ * release that drops/renames a function fails fast instead of silently.
+ */
+const REQUIRED_SIGNER_FACTORY_FUNCTIONS = [
+  { name: 'createSigner', inputs: ['uint256', 'uint256', 'uint176'] },
+  { name: 'getSigner', inputs: ['uint256', 'uint256', 'uint176'] },
+] as const;
+
+/**
  * Returns the SafeWebAuthnSignerFactory ABI as published by
  * `@safe-global/safe-modules-deployments`, pinned to
  * {@link SUPPORTED_SIGNER_FACTORY_VERSION}. Throws if the package is missing
- * the deployment (which would indicate a packaging regression upstream).
+ * the deployment or if its ABI no longer contains the function signatures
+ * encoded in {@link SignerFactoryAbi}.
+ *
+ * The runtime check guards against silent drift: the package types
+ * `Deployment.abi` as `any[]`, so the type cast can't catch upstream changes
+ * by itself.
  */
 export function getSignerFactoryAbi(): SignerFactoryAbi {
   const deployment = getSafeWebAuthnSignerFactoryDeployment({
@@ -364,5 +379,27 @@ export function getSignerFactoryAbi(): SignerFactoryAbi {
       `SafeWebAuthnSignerFactory v${SUPPORTED_SIGNER_FACTORY_VERSION} deployment not found in @safe-global/safe-modules-deployments`,
     );
   }
-  return deployment.abi as unknown as SignerFactoryAbi;
+
+  type AbiFunctionItem = {
+    type?: string;
+    name?: string;
+    inputs?: ReadonlyArray<{ type?: string }>;
+  };
+  const abi = deployment.abi as ReadonlyArray<AbiFunctionItem>;
+  for (const required of REQUIRED_SIGNER_FACTORY_FUNCTIONS) {
+    const match = abi.find(
+      (item) => item.type === 'function' && item.name === required.name,
+    );
+    const inputTypes = match?.inputs?.map((i) => i.type) ?? [];
+    const matches =
+      inputTypes.length === required.inputs.length &&
+      inputTypes.every((t, idx) => t === required.inputs[idx]);
+    if (!matches) {
+      throw new Error(
+        `SafeWebAuthnSignerFactory v${SUPPORTED_SIGNER_FACTORY_VERSION} ABI no longer matches the expected ${required.name}(${required.inputs.join(',')}) signature. The @safe-global/safe-modules-deployments package may have changed; update SignerFactoryAbi and SUPPORTED_SIGNER_FACTORY_VERSION accordingly.`,
+      );
+    }
+  }
+
+  return abi as unknown as SignerFactoryAbi;
 }

--- a/src/domain/common/utils/deployments.ts
+++ b/src/domain/common/utils/deployments.ts
@@ -10,11 +10,13 @@ import {
   getSafeToL2MigrationDeployments as _getSafeToL2MigrationDeployments,
   getSafeMigrationDeployments as _getSafeMigrationDeployments,
 } from '@safe-global/safe-deployments';
+// eslint-disable-next-line no-restricted-imports
+import { getSafeWebAuthnSignerFactoryDeployment } from '@safe-global/safe-modules-deployments';
 import {
   _SAFE_DEPLOYMENTS,
   _COMPAT_FALLBACK_HANDLER_DEPLOYMENTS,
 } from '@safe-global/safe-deployments/dist/deployments';
-import { getAddress, type Address } from 'viem';
+import { getAddress, type Address, type parseAbi } from 'viem';
 
 type Filter = {
   chainId: string;
@@ -30,6 +32,26 @@ type DeploymentGetter =
   | typeof _getFallbackHandlerDeployments
   | typeof _getSafeToL2SetupDeployments
   | typeof _getSafeToL2MigrationDeployments;
+
+/**
+ * Type-only declaration of the SafeWebAuthnSignerFactory function signatures
+ * that the relay limit logic depends on. The runtime ABI is loaded from
+ * `@safe-global/safe-modules-deployments` by `getSignerFactoryAbi`; this type
+ * exists solely to give viem the literal Abi shape needed for typed helpers
+ * (e.g. `helpers.isCreateSigner`).
+ *
+ * Note: this is a self-declared shape, not derived from the package's types
+ * (the package types `Deployment.abi` as `any[]`). Tests guard against the
+ * runtime selectors drifting; type-level drift is not caught.
+ */
+export type SignerFactoryAbi = ReturnType<
+  typeof parseAbi<
+    [
+      'function createSigner(uint256 x, uint256 y, uint176 verifiers) returns (address signer)',
+      'function getSigner(uint256 x, uint256 y, uint176 verifiers) view returns (address signer)',
+    ]
+  >
+>;
 
 /**
  * Returns a list of official ProxyFactory addresses based on given {@link Filter}.
@@ -291,3 +313,55 @@ export const isProxyFactoryDeployed = (
 export const isFallbackHandlerDeployed = (
   args: Filter & { address: Address },
 ): boolean => isDeployed(getFallbackHandlerDeployments, args);
+
+/**
+ * The SafeWebAuthnSignerFactory contract version supported by the relay.
+ *
+ * Pinned explicitly so that a future package release adding e.g. v0.3.0 does
+ * not silently change which factory addresses we accept (the package's
+ * `findDeployment` picks the latest released version when no filter is
+ * supplied). Bump this constant deliberately when adding support for a new
+ * factory version, after verifying the function signatures are unchanged or
+ * updating `SignerFactoryAbi` accordingly.
+ */
+const SUPPORTED_SIGNER_FACTORY_VERSION = '0.2.1';
+
+/**
+ * Returns a list of official SafeWebAuthnSignerFactory addresses for a chain.
+ * Uses @safe-global/safe-modules-deployments (separate from core safe-deployments).
+ *
+ * Pinned to {@link SUPPORTED_SIGNER_FACTORY_VERSION}.
+ *
+ * @param {string} args.chainId - the chain ID to filter deployments by
+ * @returns {Array<Address>} - a list of checksummed factory addresses
+ */
+export function getSignerFactoryDeployments(args: {
+  chainId: string;
+}): Array<Address> {
+  const deployment = getSafeWebAuthnSignerFactoryDeployment({
+    network: args.chainId,
+    version: SUPPORTED_SIGNER_FACTORY_VERSION,
+  });
+  if (!deployment) return [];
+  const address = deployment.networkAddresses[args.chainId];
+  if (!address) return [];
+  return [getAddress(address)];
+}
+
+/**
+ * Returns the SafeWebAuthnSignerFactory ABI as published by
+ * `@safe-global/safe-modules-deployments`, pinned to
+ * {@link SUPPORTED_SIGNER_FACTORY_VERSION}. Throws if the package is missing
+ * the deployment (which would indicate a packaging regression upstream).
+ */
+export function getSignerFactoryAbi(): SignerFactoryAbi {
+  const deployment = getSafeWebAuthnSignerFactoryDeployment({
+    version: SUPPORTED_SIGNER_FACTORY_VERSION,
+  });
+  if (!deployment) {
+    throw new Error(
+      `SafeWebAuthnSignerFactory v${SUPPORTED_SIGNER_FACTORY_VERSION} deployment not found in @safe-global/safe-modules-deployments`,
+    );
+  }
+  return deployment.abi as unknown as SignerFactoryAbi;
+}

--- a/src/modules/relay/domain/__tests__/relay.manager.spec.ts
+++ b/src/modules/relay/domain/__tests__/relay.manager.spec.ts
@@ -5,6 +5,8 @@ import { faker } from '@faker-js/faker';
 import type { DailyLimitRelayer } from '@/modules/relay/domain/relayers/daily-limit.relayer';
 import type { NoFeeCampaignRelayer } from '@/modules/relay/domain/relayers/no-fee-campaign.relayer';
 import type { RelayFeeRelayer } from '@/modules/relay/domain/relayers/relay-fee.relayer';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
+import { createSignerEncoder } from '@/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder';
 
 const mockDailyLimitRelayer = {
   canRelay: jest.fn(),
@@ -23,6 +25,8 @@ const mockRelayFeeRelayer = {
   relay: jest.fn(),
   getRelaysRemaining: jest.fn(),
 } as unknown as jest.MockedObjectDeep<RelayFeeRelayer>;
+
+const signerFactoryDecoder = new SignerFactoryDecoder();
 
 describe('RelayManager', () => {
   let fakeConfigurationService: FakeConfigurationService;
@@ -49,6 +53,7 @@ describe('RelayManager', () => {
         mockDailyLimitRelayer,
         mockNoFeeCampaignRelayer,
         mockRelayFeeRelayer,
+        signerFactoryDecoder,
       );
 
       // relay-fee takes priority even if chain is also in dailyLimitRelayChainIds
@@ -71,6 +76,7 @@ describe('RelayManager', () => {
         mockDailyLimitRelayer,
         mockNoFeeCampaignRelayer,
         mockRelayFeeRelayer,
+        signerFactoryDecoder,
       );
 
       expect(manager.getRelayer(dailyLimitChainId)).toBe(mockDailyLimitRelayer);
@@ -98,6 +104,7 @@ describe('RelayManager', () => {
         mockDailyLimitRelayer,
         mockNoFeeCampaignRelayer,
         mockRelayFeeRelayer,
+        signerFactoryDecoder,
       );
 
       expect(manager.getRelayer(campaignChainId)).toBe(
@@ -119,6 +126,7 @@ describe('RelayManager', () => {
         mockDailyLimitRelayer,
         mockNoFeeCampaignRelayer,
         mockRelayFeeRelayer,
+        signerFactoryDecoder,
       );
 
       expect(manager.getRelayer(unknownChainId)).toBe(mockDailyLimitRelayer);
@@ -146,9 +154,44 @@ describe('RelayManager', () => {
         mockDailyLimitRelayer,
         mockNoFeeCampaignRelayer,
         mockRelayFeeRelayer,
+        signerFactoryDecoder,
       );
 
       expect(manager.getRelayer(chainId)).toBe(mockRelayFeeRelayer);
+    });
+
+    it('should always route createSigner calldata to the daily-limit relayer, bypassing relay-fee and no-fee campaign', () => {
+      // Configure both relay-fee and no-fee campaign for the same chain so
+      // either would be chosen for non-createSigner calldata. The createSigner
+      // override must beat both.
+      const chainId = '1';
+      fakeConfigurationService.set('relay.noFeeCampaign', {
+        1: {
+          startsAtTimeStamp: 0,
+          endsAtTimeStamp: 0,
+          maxGasLimit: 0,
+          safeTokenAddress: '0x0000000000000000000000000000000000000000',
+          relayRules: [],
+        },
+      });
+      fakeConfigurationService.set('relay.dailyLimitRelayerChainsIds', []);
+      fakeConfigurationService.set('relay.fee', {
+        enabledChainIds: [chainId],
+        baseUri: faker.internet.url(),
+      });
+
+      const manager = new RelayManager(
+        fakeConfigurationService,
+        mockDailyLimitRelayer,
+        mockNoFeeCampaignRelayer,
+        mockRelayFeeRelayer,
+        signerFactoryDecoder,
+      );
+
+      const createSignerData = createSignerEncoder().encode();
+      expect(manager.getRelayer(chainId, createSignerData)).toBe(
+        mockDailyLimitRelayer,
+      );
     });
   });
 });

--- a/src/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder.ts
+++ b/src/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
 import { type Address, encodeFunctionData, parseAbi } from 'viem';
 import type { IEncoder } from '@/__tests__/encoder-builder';
@@ -34,8 +35,5 @@ export function createSignerEncoder(): CreateSignerEncoder<CreateSignerArgs> {
   return new CreateSignerEncoder<CreateSignerArgs>()
     .with('x', faker.number.bigInt())
     .with('y', faker.number.bigInt())
-    .with(
-      'verifiers',
-      faker.number.bigInt({ min: 0n, max: verifiersMax }),
-    );
+    .with('verifiers', faker.number.bigInt({ min: 0n, max: verifiersMax }));
 }

--- a/src/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder.ts
+++ b/src/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
-import { type Address, encodeFunctionData, parseAbi } from 'viem';
+import { type Hex, encodeFunctionData, parseAbi } from 'viem';
 import type { IEncoder } from '@/__tests__/encoder-builder';
 import { Builder } from '@/__tests__/builder';
 
@@ -18,7 +18,7 @@ class CreateSignerEncoder<T extends CreateSignerArgs>
   extends Builder<T>
   implements IEncoder
 {
-  encode(): Address {
+  encode(): Hex {
     const args = this.build();
 
     return encodeFunctionData({

--- a/src/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder.ts
+++ b/src/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder.ts
@@ -1,0 +1,41 @@
+import { faker } from '@faker-js/faker';
+import { type Address, encodeFunctionData, parseAbi } from 'viem';
+import type { IEncoder } from '@/__tests__/encoder-builder';
+import { Builder } from '@/__tests__/builder';
+
+const SignerFactoryAbi = parseAbi([
+  'function createSigner(uint256 x, uint256 y, uint176 verifiers) returns (address signer)',
+]);
+
+type CreateSignerArgs = {
+  x: bigint;
+  y: bigint;
+  verifiers: bigint;
+};
+
+class CreateSignerEncoder<T extends CreateSignerArgs>
+  extends Builder<T>
+  implements IEncoder
+{
+  encode(): Address {
+    const args = this.build();
+
+    return encodeFunctionData({
+      abi: SignerFactoryAbi,
+      functionName: 'createSigner',
+      args: [args.x, args.y, args.verifiers],
+    });
+  }
+}
+
+export function createSignerEncoder(): CreateSignerEncoder<CreateSignerArgs> {
+  // uint176 max
+  const verifiersMax = (1n << 176n) - 1n;
+  return new CreateSignerEncoder<CreateSignerArgs>()
+    .with('x', faker.number.bigInt())
+    .with('y', faker.number.bigInt())
+    .with(
+      'verifiers',
+      faker.number.bigInt({ min: 0n, max: verifiersMax }),
+    );
+}

--- a/src/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper.ts
+++ b/src/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { AbiDecoder } from '@/modules/contracts/domain/decoders/abi-decoder.helper';
+import {
+  getSignerFactoryAbi,
+  type SignerFactoryAbi,
+} from '@/domain/common/utils/deployments';
+
+@Injectable()
+export class SignerFactoryDecoder extends AbiDecoder<SignerFactoryAbi> {
+  constructor() {
+    super(getSignerFactoryAbi());
+  }
+}

--- a/src/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper.ts
+++ b/src/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Injectable } from '@nestjs/common';
 import { AbiDecoder } from '@/modules/contracts/domain/decoders/abi-decoder.helper';
 import {

--- a/src/modules/relay/domain/errors/unofficial-signer-factory.error.ts
+++ b/src/modules/relay/domain/errors/unofficial-signer-factory.error.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { UnprocessableEntityException } from '@nestjs/common';
+
+export class UnofficialSignerFactoryError extends UnprocessableEntityException {
+  constructor() {
+    super(
+      'SafeWebAuthnSignerFactory contract is not official. Only official SafeWebAuthnSignerFactory contracts are supported.',
+    );
+  }
+}

--- a/src/modules/relay/domain/exception-filters/unofficial-signer-factory.exception-filter.ts
+++ b/src/modules/relay/domain/exception-filters/unofficial-signer-factory.exception-filter.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Response } from 'express';
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  HttpStatus,
+} from '@nestjs/common';
+import { UnofficialSignerFactoryError } from '@/modules/relay/domain/errors/unofficial-signer-factory.error';
+
+@Catch(UnofficialSignerFactoryError)
+export class UnofficialSignerFactoryExceptionFilter implements ExceptionFilter {
+  catch(_: UnofficialSignerFactoryError, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    response.status(HttpStatus.UNPROCESSABLE_ENTITY).json({
+      message: 'Unofficial SafeWebAuthnSignerFactory contract.',
+      statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+    });
+  }
+}

--- a/src/modules/relay/domain/interfaces/relay-manager.interface.ts
+++ b/src/modules/relay/domain/interfaces/relay-manager.interface.ts
@@ -1,12 +1,20 @@
+import type { Address } from 'viem';
 import type { IRelayer } from '@/modules/relay/domain/interfaces/relayer.interface';
 
 export const IRelayManager = Symbol('IRelayManager');
 
 export interface IRelayManager {
   /**
-   * Gets the appropriate relayer for the given chain ID
+   * Gets the appropriate relayer for the given chain ID and (optionally) the
+   * transaction calldata. Some transaction types — notably passkey signer
+   * deployment via SafeWebAuthnSignerFactory.createSigner — are always
+   * sponsored by us and must bypass the noFeeCampaign balance-based rules,
+   * so the manager needs to peek at the calldata to route correctly.
+   *
    * @param chainId - Chain ID to get relayer for
+   * @param data - Transaction calldata. Optional — when omitted, only chain-
+   *   level routing applies (e.g. for `getRelaysRemaining`).
    * @returns The relayer instance to use
    */
-  getRelayer(chainId: string): IRelayer;
+  getRelayer(chainId: string, data?: Address): IRelayer;
 }

--- a/src/modules/relay/domain/interfaces/relay-manager.interface.ts
+++ b/src/modules/relay/domain/interfaces/relay-manager.interface.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { Address } from 'viem';
 import type { IRelayer } from '@/modules/relay/domain/interfaces/relayer.interface';
 

--- a/src/modules/relay/domain/limit-addresses.mapper.spec.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import {
   erc20ApproveEncoder,
   erc20TransferEncoder,

--- a/src/modules/relay/domain/limit-addresses.mapper.spec.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.spec.ts
@@ -1531,7 +1531,7 @@ describe('LimitAddressesMapper', () => {
         expect(limitAddress).not.toStrictEqual(to);
       });
 
-      it('should throw for createSigner on an unofficial factory', async () => {
+      it('should throw UnofficialSignerFactoryError for createSigner on an unofficial factory', async () => {
         const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
         const data = createSignerEncoder().encode();
         // Unofficial factory address
@@ -1545,7 +1545,7 @@ describe('LimitAddressesMapper', () => {
             to,
           }),
         ).rejects.toThrow(
-          'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+          'SafeWebAuthnSignerFactory contract is not official. Only official SafeWebAuthnSignerFactory contracts are supported.',
         );
       });
 
@@ -1589,6 +1589,38 @@ describe('LimitAddressesMapper', () => {
           'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
         );
       });
+    });
+  });
+
+  describe('SafeWebAuthnSignerFactory on chains without a factory deployment', () => {
+    // BSC (56) is configured for relay but has no SafeWebAuthnSignerFactory
+    // v0.2.1 deployment. A createSigner call on such a chain must surface a
+    // dedicated unofficial-factory error rather than silently masquerading as
+    // generic invalid calldata.
+    const chainIdWithoutFactory = '56';
+
+    it('should be a chain that the relay supports but has no factory deployment', () => {
+      expect(supportedChainIds).toContain(chainIdWithoutFactory);
+      expect(
+        getSignerFactoryDeployments({ chainId: chainIdWithoutFactory }),
+      ).toStrictEqual([]);
+    });
+
+    it('should throw UnofficialSignerFactoryError for createSigner on a chain without a factory', async () => {
+      const version = faker.system.semver();
+      const data = createSignerEncoder().encode();
+      const to = getAddress(faker.finance.ethereumAddress());
+
+      await expect(
+        target.getLimitAddresses({
+          version,
+          chainId: chainIdWithoutFactory,
+          data,
+          to,
+        }),
+      ).rejects.toThrow(
+        'SafeWebAuthnSignerFactory contract is not official. Only official SafeWebAuthnSignerFactory contracts are supported.',
+      );
     });
   });
 });

--- a/src/modules/relay/domain/limit-addresses.mapper.spec.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.spec.ts
@@ -1414,26 +1414,63 @@ describe('LimitAddressesMapper', () => {
       );
     });
 
-    describe('SafeWebAuthnSignerFactory', () => {
-      const expectedLimitKey = (
-        x: bigint,
-        y: bigint,
-        verifiers: bigint,
-      ): string =>
-        getAddress(
-          `0x${keccak256(
-            encodeAbiParameters(
-              parseAbiParameters('uint256, uint256, uint176'),
-              [x, y, verifiers],
-            ),
-          ).slice(-40)}`,
+    describe('Validation', () => {
+      it('should throw if not an execTransaction, multiSend or createProxyWithNonceCall', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const safe = safeBuilder().build();
+        const safeAddress = getAddress(safe.address);
+        const data = erc20TransferEncoder().encode();
+        // Official mastercopy
+        mockSafeRepository.getSafe.mockResolvedValue(safe);
+
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data,
+            to: safeAddress,
+          }),
+        ).rejects.toThrow(
+          'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
         );
+      });
+    });
+  });
 
-      const factoryAddresses = getSignerFactoryDeployments({ chainId });
+  describe('SafeWebAuthnSignerFactory', () => {
+    // Pick canonical relay-supported chains where v0.2.1 of the factory must
+    // be present. Listed explicitly so any future change that would silently
+    // break coverage (e.g. dropping mainnet from supportedChainIds, or a
+    // deployments package update that changes addresses) fails the suite
+    // loudly rather than skipping the tests.
+    const chainsWithFactory = ['1', '11155111'] as const;
 
-      // The SafeWebAuthnSignerFactory is only deployed on a subset of
-      // supported chains; skip the suite where it isn't.
-      if (factoryAddresses.length === 0) return;
+    const expectedLimitKey = (
+      x: bigint,
+      y: bigint,
+      verifiers: bigint,
+    ): string =>
+      getAddress(
+        `0x${keccak256(
+          encodeAbiParameters(parseAbiParameters('uint256, uint256, uint176'), [
+            x,
+            y,
+            verifiers,
+          ]),
+        ).slice(-40)}`,
+      );
+
+    describe.each(chainsWithFactory)('Chain %s', (chainId) => {
+      let factoryAddresses: ReadonlyArray<string>;
+
+      beforeAll(() => {
+        // Setup-time assertions: the chain must be relay-supported and the
+        // factory must be deployed on it. If either flips, fail loudly here
+        // instead of silently no-oping the tests below.
+        expect(supportedChainIds).toContain(chainId);
+        factoryAddresses = getSignerFactoryDeployments({ chainId });
+        expect(factoryAddresses).not.toHaveLength(0);
+      });
 
       it('should return a hash-derived limit address for createSigner on an official factory', async () => {
         const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
@@ -1448,7 +1485,7 @@ describe('LimitAddressesMapper', () => {
           .with('y', y)
           .with('verifiers', verifiers)
           .encode();
-        const to = faker.helpers.arrayElement(factoryAddresses);
+        const to = getAddress(faker.helpers.arrayElement(factoryAddresses));
 
         const limitAddresses = await target.getLimitAddresses({
           version,
@@ -1475,7 +1512,7 @@ describe('LimitAddressesMapper', () => {
           .with('y', y)
           .with('verifiers', verifiers)
           .encode();
-        const to = faker.helpers.arrayElement(factoryAddresses);
+        const to = getAddress(faker.helpers.arrayElement(factoryAddresses));
 
         const first = await target.getLimitAddresses({
           version,
@@ -1495,7 +1532,7 @@ describe('LimitAddressesMapper', () => {
 
       it('should return different limit addresses for different passkey args', async () => {
         const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
-        const to = faker.helpers.arrayElement(factoryAddresses);
+        const to = getAddress(faker.helpers.arrayElement(factoryAddresses));
 
         const dataA = createSignerEncoder().encode();
         const dataB = createSignerEncoder().encode();
@@ -1519,7 +1556,7 @@ describe('LimitAddressesMapper', () => {
       it('should not key on the factory address itself (preventing global quota sharing)', async () => {
         const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
         const data = createSignerEncoder().encode();
-        const to = faker.helpers.arrayElement(factoryAddresses);
+        const to = getAddress(faker.helpers.arrayElement(factoryAddresses));
 
         const [limitAddress] = await target.getLimitAddresses({
           version,
@@ -1554,7 +1591,7 @@ describe('LimitAddressesMapper', () => {
         const validData = createSignerEncoder().encode();
         // Keep the 4-byte selector (`0x` + 8 hex chars) but truncate the args
         const malformed = validData.slice(0, 10) as `0x${string}`;
-        const to = faker.helpers.arrayElement(factoryAddresses);
+        const to = getAddress(faker.helpers.arrayElement(factoryAddresses));
 
         await expect(
           target.getLimitAddresses({
@@ -1562,28 +1599,6 @@ describe('LimitAddressesMapper', () => {
             chainId,
             data: malformed,
             to,
-          }),
-        ).rejects.toThrow(
-          'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
-        );
-      });
-    });
-
-    describe('Validation', () => {
-      it('should throw if not an execTransaction, multiSend or createProxyWithNonceCall', async () => {
-        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
-        const safe = safeBuilder().build();
-        const safeAddress = getAddress(safe.address);
-        const data = erc20TransferEncoder().encode();
-        // Official mastercopy
-        mockSafeRepository.getSafe.mockResolvedValue(safe);
-
-        await expect(
-          target.getLimitAddresses({
-            version,
-            chainId,
-            data,
-            to: safeAddress,
           }),
         ).rejects.toThrow(
           'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',

--- a/src/modules/relay/domain/limit-addresses.mapper.spec.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.spec.ts
@@ -22,8 +22,10 @@ import {
 import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
 import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import { createProxyWithNonceEncoder } from '@/modules/relay/domain/contracts/__tests__/encoders/proxy-factory-encoder.builder';
+import { createSignerEncoder } from '@/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder';
 import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
 import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 import { LimitAddressesMapper } from '@/modules/relay/domain/limit-addresses.mapper';
 import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
 import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
@@ -34,8 +36,14 @@ import {
   getProxyFactoryDeployments,
   getSafeL2SingletonDeployments,
   getSafeSingletonDeployments,
+  getSignerFactoryDeployments,
 } from '@/domain/common/utils/deployments';
-import { getAddress } from 'viem';
+import {
+  encodeAbiParameters,
+  getAddress,
+  keccak256,
+  parseAbiParameters,
+} from 'viem';
 import configuration from '@/config/entities/configuration';
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 import type { ILoggingService } from '@/logging/logging.interface';
@@ -88,6 +96,7 @@ describe('LimitAddressesMapper', () => {
     const multiSendDecoder = new MultiSendDecoder(mockLoggingService);
     const proxyFactoryDecoder = new ProxyFactoryDecoder();
     const delayModifierDecoder = new DelayModifierDecoder();
+    const signerFactoryDecoder = new SignerFactoryDecoder();
 
     target = new LimitAddressesMapper(
       mockSafeRepository,
@@ -96,6 +105,7 @@ describe('LimitAddressesMapper', () => {
       multiSendDecoder,
       proxyFactoryDecoder,
       delayModifierDecoder,
+      signerFactoryDecoder,
     );
   });
 
@@ -1401,6 +1411,161 @@ describe('LimitAddressesMapper', () => {
           });
         },
       );
+    });
+
+    describe('SafeWebAuthnSignerFactory', () => {
+      const expectedLimitKey = (
+        x: bigint,
+        y: bigint,
+        verifiers: bigint,
+      ): string =>
+        getAddress(
+          `0x${keccak256(
+            encodeAbiParameters(
+              parseAbiParameters('uint256, uint256, uint176'),
+              [x, y, verifiers],
+            ),
+          ).slice(-40)}`,
+        );
+
+      const factoryAddresses = getSignerFactoryDeployments({ chainId });
+
+      // The SafeWebAuthnSignerFactory is only deployed on a subset of
+      // supported chains; skip the suite where it isn't.
+      if (factoryAddresses.length === 0) return;
+
+      it('should return a hash-derived limit address for createSigner on an official factory', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const x = faker.number.bigInt();
+        const y = faker.number.bigInt();
+        const verifiers = faker.number.bigInt({
+          min: 0n,
+          max: (1n << 176n) - 1n,
+        });
+        const data = createSignerEncoder()
+          .with('x', x)
+          .with('y', y)
+          .with('verifiers', verifiers)
+          .encode();
+        const to = faker.helpers.arrayElement(factoryAddresses);
+
+        const limitAddresses = await target.getLimitAddresses({
+          version,
+          chainId,
+          data,
+          to,
+        });
+
+        expect(limitAddresses).toStrictEqual([
+          expectedLimitKey(x, y, verifiers),
+        ]);
+      });
+
+      it('should return the same limit address for the same passkey args (deterministic)', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const x = faker.number.bigInt();
+        const y = faker.number.bigInt();
+        const verifiers = faker.number.bigInt({
+          min: 0n,
+          max: (1n << 176n) - 1n,
+        });
+        const data = createSignerEncoder()
+          .with('x', x)
+          .with('y', y)
+          .with('verifiers', verifiers)
+          .encode();
+        const to = faker.helpers.arrayElement(factoryAddresses);
+
+        const first = await target.getLimitAddresses({
+          version,
+          chainId,
+          data,
+          to,
+        });
+        const second = await target.getLimitAddresses({
+          version,
+          chainId,
+          data,
+          to,
+        });
+
+        expect(first).toStrictEqual(second);
+      });
+
+      it('should return different limit addresses for different passkey args', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const to = faker.helpers.arrayElement(factoryAddresses);
+
+        const dataA = createSignerEncoder().encode();
+        const dataB = createSignerEncoder().encode();
+
+        const a = await target.getLimitAddresses({
+          version,
+          chainId,
+          data: dataA,
+          to,
+        });
+        const b = await target.getLimitAddresses({
+          version,
+          chainId,
+          data: dataB,
+          to,
+        });
+
+        expect(a).not.toStrictEqual(b);
+      });
+
+      it('should not key on the factory address itself (preventing global quota sharing)', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const data = createSignerEncoder().encode();
+        const to = faker.helpers.arrayElement(factoryAddresses);
+
+        const [limitAddress] = await target.getLimitAddresses({
+          version,
+          chainId,
+          data,
+          to,
+        });
+
+        expect(limitAddress).not.toStrictEqual(to);
+      });
+
+      it('should throw for createSigner on an unofficial factory', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const data = createSignerEncoder().encode();
+        // Unofficial factory address
+        const to = getAddress(faker.finance.ethereumAddress());
+
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data,
+            to,
+          }),
+        ).rejects.toThrow(
+          'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+        );
+      });
+
+      it('should throw for createSigner-selector calldata with malformed args', async () => {
+        const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+        const validData = createSignerEncoder().encode();
+        // Keep the 4-byte selector (`0x` + 8 hex chars) but truncate the args
+        const malformed = validData.slice(0, 10) as `0x${string}`;
+        const to = faker.helpers.arrayElement(factoryAddresses);
+
+        await expect(
+          target.getLimitAddresses({
+            version,
+            chainId,
+            data: malformed,
+            to,
+          }),
+        ).rejects.toThrow(
+          'Invalid transfer. The proposed transfer is not an execTransaction/multiSend to another party or createProxyWithNonce call.',
+        );
+      });
     });
 
     describe('Validation', () => {

--- a/src/modules/relay/domain/limit-addresses.mapper.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.ts
@@ -125,9 +125,9 @@ export class LimitAddressesMapper {
     }
 
     // Calldata matches createSigner on an official SafeWebAuthnSignerFactory.
-    // If the selector matches but the target isn't official, throw a dedicated
-    // error so operators can distinguish unofficial-factory attempts from
-    // unrecognised calldata.
+    // The branch is self-contained: every outcome of the createSigner path
+    // (unofficial factory, malformed args, success) terminates here so future
+    // branches added below this point can't be reached by createSigner data.
     if (this.signerFactoryDecoder.helpers.isCreateSigner(args.data)) {
       if (
         !this.isOfficialSignerFactoryDeployment({
@@ -138,9 +138,11 @@ export class LimitAddressesMapper {
         throw new UnofficialSignerFactoryError();
       }
       const signerLimitAddress = this.getSignerFactoryLimitAddress(args.data);
-      if (signerLimitAddress) {
-        return [signerLimitAddress];
+      if (!signerLimitAddress) {
+        // Selector matched but the args failed to decode (malformed payload).
+        throw new InvalidTransferError();
       }
+      return [signerLimitAddress];
     }
 
     throw new InvalidTransferError();

--- a/src/modules/relay/domain/limit-addresses.mapper.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
 import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';

--- a/src/modules/relay/domain/limit-addresses.mapper.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.ts
@@ -3,12 +3,14 @@ import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-d
 import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
 import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 import {
   getSafeSingletonDeployments,
   getSafeL2SingletonDeployments,
   getMultiSendCallOnlyDeployments,
   getMultiSendDeployments,
   getProxyFactoryDeployments,
+  getSignerFactoryDeployments,
 } from '@/domain/common/utils/deployments';
 import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import { UnofficialMasterCopyError } from '@/modules/relay/domain/errors/unofficial-master-copy.error';
@@ -17,7 +19,13 @@ import { InvalidTransferError } from '@/modules/relay/domain/errors/invalid-tran
 import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
 import { UnofficialProxyFactoryError } from '@/modules/relay/domain/errors/unofficial-proxy-factory.error';
 import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
-import type { Address } from 'viem';
+import {
+  encodeAbiParameters,
+  getAddress,
+  keccak256,
+  parseAbiParameters,
+  type Address,
+} from 'viem';
 
 @Injectable()
 export class LimitAddressesMapper {
@@ -29,6 +37,7 @@ export class LimitAddressesMapper {
     private readonly multiSendDecoder: MultiSendDecoder,
     private readonly proxyFactoryDecoder: ProxyFactoryDecoder,
     private readonly delayModifierDecoder: DelayModifierDecoder,
+    private readonly signerFactoryDecoder: SignerFactoryDecoder,
   ) {}
 
   async getLimitAddresses(args: {
@@ -111,6 +120,16 @@ export class LimitAddressesMapper {
       }
       // Owners of safe-to-be-created will be limited
       return this.getOwnersFromCreateProxyWithNonce(args.data);
+    }
+
+    // Calldata matches createSigner on an official SafeWebAuthnSignerFactory
+    const signerLimitAddress = this.getSignerFactoryLimitAddress({
+      chainId: args.chainId,
+      to: args.to,
+      data: args.data,
+    });
+    if (signerLimitAddress) {
+      return [signerLimitAddress];
     }
 
     throw new InvalidTransferError();
@@ -413,6 +432,69 @@ export class LimitAddressesMapper {
   }): boolean {
     const proxyFactoryDeployments = getProxyFactoryDeployments(args);
     return proxyFactoryDeployments.includes(args.address);
+  }
+
+  private isOfficialSignerFactoryDeployment(args: {
+    chainId: string;
+    address: Address;
+  }): boolean {
+    return getSignerFactoryDeployments({ chainId: args.chainId }).includes(
+      args.address,
+    );
+  }
+
+  /**
+   * If `data` is a `createSigner` call to an official SafeWebAuthnSignerFactory,
+   * returns a per-passkey limit key derived from the call arguments.
+   *
+   * The key is the last 20 bytes of `keccak256(abi.encode(x, y, verifiers))`
+   * cast to an Address-shaped string. This gives each unique passkey
+   * (x, y, verifiers) its own daily relay quota, instead of every user
+   * sharing the factory address as a limit key.
+   *
+   * Returns `null` if the calldata is not a recognised `createSigner` call,
+   * the target is not an official factory, or the args fail to decode.
+   */
+  private getSignerFactoryLimitAddress(args: {
+    chainId: string;
+    to: Address;
+    data: Address;
+  }): Address | null {
+    if (!this.signerFactoryDecoder.helpers.isCreateSigner(args.data)) {
+      return null;
+    }
+    if (
+      !this.isOfficialSignerFactoryDeployment({
+        chainId: args.chainId,
+        address: args.to,
+      })
+    ) {
+      return null;
+    }
+
+    let x: bigint;
+    let y: bigint;
+    let verifiers: bigint;
+    try {
+      const decoded = this.signerFactoryDecoder.decodeFunctionData({
+        data: args.data,
+      });
+      if (decoded.functionName !== 'createSigner') {
+        return null;
+      }
+      [x, y, verifiers] = decoded.args;
+    } catch {
+      return null;
+    }
+
+    const hash = keccak256(
+      encodeAbiParameters(parseAbiParameters('uint256, uint256, uint176'), [
+        x,
+        y,
+        verifiers,
+      ]),
+    );
+    return getAddress(`0x${hash.slice(-40)}`);
   }
 
   private isValidCreateProxyWithNonceCall(args: {

--- a/src/modules/relay/domain/limit-addresses.mapper.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.ts
@@ -19,6 +19,7 @@ import { UnofficialMultiSendError } from '@/modules/relay/domain/errors/unoffici
 import { InvalidTransferError } from '@/modules/relay/domain/errors/invalid-transfer.error';
 import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
 import { UnofficialProxyFactoryError } from '@/modules/relay/domain/errors/unofficial-proxy-factory.error';
+import { UnofficialSignerFactoryError } from '@/modules/relay/domain/errors/unofficial-signer-factory.error';
 import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
 import {
   encodeAbiParameters,
@@ -123,14 +124,23 @@ export class LimitAddressesMapper {
       return this.getOwnersFromCreateProxyWithNonce(args.data);
     }
 
-    // Calldata matches createSigner on an official SafeWebAuthnSignerFactory
-    const signerLimitAddress = this.getSignerFactoryLimitAddress({
-      chainId: args.chainId,
-      to: args.to,
-      data: args.data,
-    });
-    if (signerLimitAddress) {
-      return [signerLimitAddress];
+    // Calldata matches createSigner on an official SafeWebAuthnSignerFactory.
+    // If the selector matches but the target isn't official, throw a dedicated
+    // error so operators can distinguish unofficial-factory attempts from
+    // unrecognised calldata.
+    if (this.signerFactoryDecoder.helpers.isCreateSigner(args.data)) {
+      if (
+        !this.isOfficialSignerFactoryDeployment({
+          chainId: args.chainId,
+          address: args.to,
+        })
+      ) {
+        throw new UnofficialSignerFactoryError();
+      }
+      const signerLimitAddress = this.getSignerFactoryLimitAddress(args.data);
+      if (signerLimitAddress) {
+        return [signerLimitAddress];
+      }
     }
 
     throw new InvalidTransferError();
@@ -445,40 +455,29 @@ export class LimitAddressesMapper {
   }
 
   /**
-   * If `data` is a `createSigner` call to an official SafeWebAuthnSignerFactory,
-   * returns a per-passkey limit key derived from the call arguments.
+   * For `createSigner` calldata, returns a per-passkey limit key derived from
+   * the call arguments.
    *
    * The key is the last 20 bytes of `keccak256(abi.encode(x, y, verifiers))`
    * cast to an Address-shaped string. This gives each unique passkey
    * (x, y, verifiers) its own daily relay quota, instead of every user
    * sharing the factory address as a limit key.
    *
-   * Returns `null` if the calldata is not a recognised `createSigner` call,
-   * the target is not an official factory, or the args fail to decode.
+   * Returns `null` if the args fail to decode (e.g. selector matches but the
+   * payload is malformed). Caller must have already verified the selector
+   * matches `createSigner` and that `to` is an official factory.
+   *
+   * Note: the `isCreateSigner` selector pre-check at the call site is not
+   * redundant with the `decodeFunctionData` + `functionName` check here —
+   * `getSigner` is also in the ABI and would decode cleanly.
    */
-  private getSignerFactoryLimitAddress(args: {
-    chainId: string;
-    to: Address;
-    data: Address;
-  }): Address | null {
-    if (!this.signerFactoryDecoder.helpers.isCreateSigner(args.data)) {
-      return null;
-    }
-    if (
-      !this.isOfficialSignerFactoryDeployment({
-        chainId: args.chainId,
-        address: args.to,
-      })
-    ) {
-      return null;
-    }
-
+  private getSignerFactoryLimitAddress(data: Address): Address | null {
     let x: bigint;
     let y: bigint;
     let verifiers: bigint;
     try {
       const decoded = this.signerFactoryDecoder.decodeFunctionData({
-        data: args.data,
+        data,
       });
       if (decoded.functionName !== 'createSigner') {
         return null;

--- a/src/modules/relay/domain/relay-decoders.module.ts
+++ b/src/modules/relay/domain/relay-decoders.module.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
 import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';

--- a/src/modules/relay/domain/relay-decoders.module.ts
+++ b/src/modules/relay/domain/relay-decoders.module.ts
@@ -3,9 +3,22 @@ import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.he
 import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-decoder.helper';
 import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
 import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 
 @Module({
-  providers: [SafeDecoder, Erc20Decoder, MultiSendDecoder, ProxyFactoryDecoder],
-  exports: [SafeDecoder, Erc20Decoder, MultiSendDecoder, ProxyFactoryDecoder],
+  providers: [
+    SafeDecoder,
+    Erc20Decoder,
+    MultiSendDecoder,
+    ProxyFactoryDecoder,
+    SignerFactoryDecoder,
+  ],
+  exports: [
+    SafeDecoder,
+    Erc20Decoder,
+    MultiSendDecoder,
+    ProxyFactoryDecoder,
+    SignerFactoryDecoder,
+  ],
 })
 export class RelayDecodersModule {}

--- a/src/modules/relay/domain/relay.manager.ts
+++ b/src/modules/relay/domain/relay.manager.ts
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
+import type { Address } from 'viem';
 import { IRelayManager } from '@/modules/relay/domain/interfaces/relay-manager.interface';
 import { IRelayer } from '@/modules/relay/domain/interfaces/relayer.interface';
 import { DailyLimitRelayer } from '@/modules/relay/domain/relayers/daily-limit.relayer';
 import { NoFeeCampaignRelayer } from '@/modules/relay/domain/relayers/no-fee-campaign.relayer';
 import { RelayFeeRelayer } from '@/modules/relay/domain/relayers/relay-fee.relayer';
+import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import {
   RelayFeeConfiguration,
@@ -22,6 +24,7 @@ export class RelayManager implements IRelayManager {
     private readonly dailyLimitRelayer: DailyLimitRelayer,
     private readonly noFeeCampaignRelayer: NoFeeCampaignRelayer,
     private readonly relayFeeRelayer: RelayFeeRelayer,
+    private readonly signerFactoryDecoder: SignerFactoryDecoder,
   ) {
     this.noFeeCampaignConfiguration = configurationService.getOrThrow(
       'relay.noFeeCampaign',
@@ -35,17 +38,29 @@ export class RelayManager implements IRelayManager {
   }
 
   /**
-   * Returns the appropriate relayer for the given chain.
-   * Priority order:
-   * 1. {@link RelayFeeRelayer} — when the chain is in `relay.fee.enabledChainIds`
-   * 2. {@link DailyLimitRelayer} — when the chain is in `relay.dailyLimitRelayerChainsIds`
-   * 3. {@link NoFeeCampaignRelayer} — when the chain has a no-fee campaign configuration
-   * 4. {@link DailyLimitRelayer} — fallback for backward compatibility
+   * Returns the appropriate relayer for the given chain and (optionally) the
+   * transaction calldata. Priority order:
+   * 1. {@link DailyLimitRelayer} — for `createSigner` calls (passkey signer
+   *    deployment is always sponsored, regardless of chain config)
+   * 2. {@link RelayFeeRelayer} — when the chain is in `relay.fee.enabledChainIds`
+   * 3. {@link DailyLimitRelayer} — when the chain is in `relay.dailyLimitRelayerChainsIds`
+   * 4. {@link NoFeeCampaignRelayer} — when the chain has a no-fee campaign configuration
+   * 5. {@link DailyLimitRelayer} — fallback for backward compatibility
    *
    * @param chainId - Chain ID to look up the relayer for
-   * @returns The relayer to use for this chain
+   * @param data - Transaction calldata; required to detect createSigner
+   * @returns The relayer to use
    */
-  public getRelayer(chainId: string): IRelayer {
+  public getRelayer(chainId: string, data?: Address): IRelayer {
+    // Passkey signer deployment via SafeWebAuthnSignerFactory.createSigner is
+    // always sponsored — it must not be subject to noFeeCampaign balance-based
+    // rules or relay-fee charges, so route it straight to the daily-limit
+    // relayer regardless of chain config. The factory address is verified
+    // downstream in LimitAddressesMapper.
+    if (data && this.signerFactoryDecoder.helpers.isCreateSigner(data)) {
+      return this.dailyLimitRelayer;
+    }
+
     // relay-fee takes first priority when enabled for the chain
     if (this.relayFeeConfiguration.enabledChainIds.includes(chainId)) {
       return this.relayFeeRelayer;

--- a/src/modules/relay/domain/relay.repository.ts
+++ b/src/modules/relay/domain/relay.repository.ts
@@ -21,7 +21,7 @@ export class RelayRepository {
     gasLimit: bigint | null;
     safeTxHash?: Hex;
   }): Promise<Relay> {
-    return this.relayManager.getRelayer(args.chainId).relay(args);
+    return this.relayManager.getRelayer(args.chainId, args.data).relay(args);
   }
 
   async getTaskStatus(args: {

--- a/src/modules/relay/routes/relay.controller.integration.spec.ts
+++ b/src/modules/relay/routes/relay.controller.integration.spec.ts
@@ -3566,13 +3566,15 @@ describe('Relay controller', () => {
   });
 
   // End-to-end coverage for the createSigner branch added to
-  // LimitAddressesMapper. Picked chains where SafeWebAuthnSignerFactory
-  // v0.2.1 must be deployed and which fall through to the daily-limit
-  // relayer in this suite's test config (noFeeCampaign in the test config
-  // covers '1' and '11155111', and noFeeCampaign uses balance-based limits
-  // that the hash-derived limit address can't satisfy). beforeAll asserts
-  // both relay support and factory presence so config drift fails loudly.
-  describe.each(['10', '8453'])(
+  // LimitAddressesMapper. The chosen chains exercise both routing paths:
+  //   - '1' and '11155111' are in the test-config noFeeCampaign and would
+  //     normally route through NoFeeCampaignRelayer. RelayManager overrides
+  //     this for createSigner so passkey deployment isn't subject to the
+  //     campaign's balance-based rules — these tests guard that override.
+  //   - '10' falls through to DailyLimitRelayer (no override needed) and
+  //     covers the non-campaign happy path.
+  // beforeAll asserts factory presence so config drift fails loudly.
+  describe.each(['1', '10', '11155111'])(
     'SafeWebAuthnSignerFactory: Chain %s',
     (chainId) => {
       let factoryAddresses: ReadonlyArray<string>;

--- a/src/modules/relay/routes/relay.controller.integration.spec.ts
+++ b/src/modules/relay/routes/relay.controller.integration.spec.ts
@@ -37,8 +37,10 @@ import {
   getProxyFactoryDeployments,
   getSafeL2SingletonDeployments,
   getSafeSingletonDeployments,
+  getSignerFactoryDeployments,
 } from '@/domain/common/utils/deployments';
 import { createProxyWithNonceEncoder } from '@/modules/relay/domain/contracts/__tests__/encoders/proxy-factory-encoder.builder';
+import { createSignerEncoder } from '@/modules/relay/domain/contracts/__tests__/encoders/signer-factory-encoder.builder';
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 import type { Server } from 'net';
 import {
@@ -3562,4 +3564,90 @@ describe('Relay controller', () => {
       },
     );
   });
+
+  // End-to-end coverage for the createSigner branch added to
+  // LimitAddressesMapper. Picked chains where SafeWebAuthnSignerFactory
+  // v0.2.1 must be deployed and which fall through to the daily-limit
+  // relayer in this suite's test config (noFeeCampaign in the test config
+  // covers '1' and '11155111', and noFeeCampaign uses balance-based limits
+  // that the hash-derived limit address can't satisfy). beforeAll asserts
+  // both relay support and factory presence so config drift fails loudly.
+  describe.each(['10', '8453'])(
+    'SafeWebAuthnSignerFactory: Chain %s',
+    (chainId) => {
+      let factoryAddresses: ReadonlyArray<string>;
+
+      beforeAll(() => {
+        expect(allSupportedChainIds).toContain(chainId);
+        factoryAddresses = getSignerFactoryDeployments({ chainId });
+        expect(factoryAddresses).not.toHaveLength(0);
+      });
+
+      it('should relay createSigner on an official SafeWebAuthnSignerFactory', async () => {
+        const chain = chainBuilder().with('chainId', chainId).build();
+        // The createSigner branch doesn't consult the Safe version, so any
+        // string suffices. Avoid SAFE_VERSIONS[chainId] which is keyed off the
+        // suite's randomly-sampled supportedChainIds and may not contain our
+        // hardcoded factory chains.
+        const version = faker.system.semver();
+        const to = getAddress(faker.helpers.arrayElement(factoryAddresses));
+        const data = createSignerEncoder().encode();
+        const taskId = faker.string.uuid();
+        networkService.get.mockImplementation(({ url }) => {
+          switch (url) {
+            case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+              return Promise.resolve({ data: rawify(chain), status: 200 });
+            default:
+              return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        });
+        networkService.post.mockImplementation(({ url }) => {
+          switch (url) {
+            case `${relayUrl}/rpc`:
+              return Promise.resolve({
+                data: rawify({ jsonrpc: '2.0', result: taskId, id: 1 }),
+                status: 200,
+              });
+            default:
+              return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        });
+
+        await request(app.getHttpServer())
+          .post(`/v1/chains/${chainId}/relay`)
+          .send({ version, to, data })
+          .expect(201)
+          .expect({ taskId });
+      });
+
+      it('should return 422 for createSigner on an unofficial SafeWebAuthnSignerFactory', async () => {
+        const chain = chainBuilder().with('chainId', chainId).build();
+        // The createSigner branch doesn't consult the Safe version, so any
+        // string suffices. Avoid SAFE_VERSIONS[chainId] which is keyed off the
+        // suite's randomly-sampled supportedChainIds and may not contain our
+        // hardcoded factory chains.
+        const version = faker.system.semver();
+        // Unofficial factory address
+        const to = getAddress(faker.finance.ethereumAddress());
+        const data = createSignerEncoder().encode();
+        networkService.get.mockImplementation(({ url }) => {
+          switch (url) {
+            case `${safeConfigUrl}/api/v1/chains/${chainId}`:
+              return Promise.resolve({ data: rawify(chain), status: 200 });
+            default:
+              return Promise.reject(`No matching rule for url: ${url}`);
+          }
+        });
+
+        await request(app.getHttpServer())
+          .post(`/v1/chains/${chainId}/relay`)
+          .send({ version, to, data })
+          .expect(422)
+          .expect({
+            message: 'Unofficial SafeWebAuthnSignerFactory contract.',
+            statusCode: 422,
+          });
+      });
+    },
+  );
 });

--- a/src/modules/relay/routes/relay.controller.ts
+++ b/src/modules/relay/routes/relay.controller.ts
@@ -29,6 +29,7 @@ import { InvalidTransferExceptionFilter } from '@/modules/relay/domain/exception
 import { UnofficialMasterCopyExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-master-copy.exception-filter';
 import { UnofficialMultiSendExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-multisend.error';
 import { UnofficialProxyFactoryExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-proxy-factory.exception-filter';
+import { UnofficialSignerFactoryExceptionFilter } from '@/modules/relay/domain/exception-filters/unofficial-signer-factory.exception-filter';
 import { RelayDtoSchema } from '@/modules/relay/routes/entities/schemas/relay.dto.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { HexSchema } from '@/validation/entities/schemas/hex.schema';
@@ -82,6 +83,7 @@ export class RelayController {
     UnofficialMasterCopyExceptionFilter,
     UnofficialMultiSendExceptionFilter,
     UnofficialProxyFactoryExceptionFilter,
+    UnofficialSignerFactoryExceptionFilter,
   )
   async relay(
     @Param('chainId') chainId: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,7 +2807,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@safe-global/safe-modules-deployments@npm:^3.0.1":
+"@safe-global/safe-modules-deployments@npm:3.0.1":
   version: 3.0.1
   resolution: "@safe-global/safe-modules-deployments@npm:3.0.1"
   checksum: 10/cb4ab566c3dd7e1b91c2cd3fa8df68132a3acfe15ff3c10485a8d1450a8f69be3ef47f8163860ff16880d8d44b7cb46bd07820f2d173cc622a7bf988a6379039
@@ -9747,7 +9747,7 @@ __metadata:
     "@nestjs/testing": "npm:11.1.17"
     "@nestjs/typeorm": "npm:11.0.0"
     "@safe-global/safe-deployments": "npm:1.37.51"
-    "@safe-global/safe-modules-deployments": "npm:^3.0.1"
+    "@safe-global/safe-modules-deployments": "npm:3.0.1"
     "@smithy/util-stream": "npm:4.5.5"
     "@types/amqplib": "npm:0"
     "@types/cookie-parser": "npm:1.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,6 +2807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@safe-global/safe-modules-deployments@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@safe-global/safe-modules-deployments@npm:3.0.1"
+  checksum: 10/cb4ab566c3dd7e1b91c2cd3fa8df68132a3acfe15ff3c10485a8d1450a8f69be3ef47f8163860ff16880d8d44b7cb46bd07820f2d173cc622a7bf988a6379039
+  languageName: node
+  linkType: hard
+
 "@scarf/scarf@npm:=1.4.0":
   version: 1.4.0
   resolution: "@scarf/scarf@npm:1.4.0"
@@ -9740,6 +9747,7 @@ __metadata:
     "@nestjs/testing": "npm:11.1.17"
     "@nestjs/typeorm": "npm:11.0.0"
     "@safe-global/safe-deployments": "npm:1.37.51"
+    "@safe-global/safe-modules-deployments": "npm:^3.0.1"
     "@smithy/util-stream": "npm:4.5.5"
     "@types/amqplib": "npm:0"
     "@types/cookie-parser": "npm:1.4.8"


### PR DESCRIPTION
## Summary

[WA-2112](https://linear.app/safe-global/issue/WA-2112/cgw-allow-gas-relay-sponsorship-for)

The relay endpoint currently rejects `SafeWebAuthnSignerFactory.createSigner` with `InvalidTransferError`, so passkey signer deployment can't be gas-sponsored — a blocker for the device-bound signing onboarding flow. This PR accepts `createSigner` calls to the official factory and rate-limits them per-passkey.

## Changes

- Add `@safe-global/safe-modules-deployments` as a dependency, pinned to factory **v0.2.1** via `SUPPORTED_SIGNER_FACTORY_VERSION`. Wrap it in `src/domain/common/utils/deployments.ts` (mirrors the existing `safe-deployments` wrapper) and extend the ESLint `no-restricted-imports` rule so only the wrapper may import it.
- New `SignerFactoryDecoder` extending `AbiDecoder`, registered in `RelayDecodersModule`. ABI is loaded from the package at runtime (single source of truth) and projected onto a `parseAbi`-derived type for typed selector helpers.
- `LimitAddressesMapper.getLimitAddresses` gets a new branch that matches the `createSigner` selector, validates `to` is the official v0.2.1 factory for the chain, decodes `(x, y, verifiers)`, and returns `keccak256(abi.encode(x, y, verifiers))` truncated to 20 bytes as the rate-limit key.

### Why a hash-derived key, not the factory address

The factory address is the same constant for every user on a chain. Returning it as the rate-limit key would make every passkey deployment globally share a single daily quota — trivial to grief, hostile to legitimate spikes. Hashing the `createSigner` args gives each unique passkey its own quota.

### Tests

6 new unit tests in `limit-addresses.mapper.spec.ts` cover happy path, determinism, distinctness, anti-regression on factory-keying, unofficial-factory rejection, and malformed-args rejection. Full suite (1144 tests) passes; lint and type-check clean.