### PR TITLE
fix: log portfolio endpoint errors

### DIFF
--- a/src/domain/common/entities/log-type.entity.ts
+++ b/src/domain/common/entities/log-type.entity.ts
@@ -30,6 +30,7 @@ export enum LogType {
   NotificationSent = 'NOTIFICATION_SENT',
   NotificationEventProcessed = 'NOTIFICATION_EVENT_PROCESSED',
   NotificationDeliveryQueued = 'NOTIFICATION_DELIVERY_QUEUED',
+  PortfolioRequestError = 'PORTFOLIO_REQUEST_ERROR',
   RateLimit = 'RATE_LIMIT',
   TxRelayEligibility = 'TX_RELAY_ELIGIBILITY',
   TransactionPropose = 'TRANSACTION_PROPOSE',

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import type { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { DataSourceError } from '@/domain/errors/data-source.error';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { ZerionPortfolioApi } from '@/modules/portfolio/datasources/zerion-portfolio-api.service';
+import type { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import type { ICacheService } from '@/datasources/cache/cache.service.interface';
+import { LogType } from '@/domain/common/entities/log-type.entity';
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+
+describe('ZerionPortfolioApi', () => {
+  let service: ZerionPortfolioApi;
+  let fakeConfigurationService: FakeConfigurationService;
+
+  const zerionApiKey = faker.string.sample();
+  const zerionBaseUri = faker.internet.url({ appendSlash: false });
+  const supportedFiatCodes = ['USD', 'EUR'];
+
+  const mockNetworkService = jest.mocked({
+    get: jest.fn(),
+    post: jest.fn(),
+    postForm: jest.fn(),
+    delete: jest.fn(),
+  } as jest.MockedObjectDeep<INetworkService>);
+
+  const mockHttpErrorFactory = jest.mocked({
+    from: jest.fn(),
+  } as jest.MockedObjectDeep<HttpErrorFactory>);
+
+  const mockLoggingService = jest.mocked({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as jest.MockedObjectDeep<ILoggingService>);
+
+  const mockCacheService = jest.mocked({
+    hGet: jest.fn(),
+    hSet: jest.fn(),
+    deleteByKey: jest.fn(),
+  } as jest.MockedObjectDeep<ICacheService>);
+
+  const mockChainMappingService = jest.mocked({
+    getNetworkFromChainId: jest.fn(),
+    getChainIdFromNetwork: jest.fn(),
+  } as jest.MockedObjectDeep<ZerionChainMappingService>);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fakeConfigurationService = new FakeConfigurationService();
+    fakeConfigurationService.set(
+      'balances.providers.zerion.apiKey',
+      zerionApiKey,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.baseUri',
+      zerionBaseUri,
+    );
+    fakeConfigurationService.set(
+      'balances.providers.zerion.currencies',
+      supportedFiatCodes,
+    );
+
+    service = new ZerionPortfolioApi(
+      mockNetworkService,
+      fakeConfigurationService as IConfigurationService,
+      mockHttpErrorFactory,
+      mockLoggingService,
+      mockCacheService,
+      mockChainMappingService,
+    );
+  });
+
+  describe('getPortfolio', () => {
+    it.each([true, false])(
+      'should log portfolio request failures with trusted=%s',
+      async (trusted) => {
+        const address = getAddress(faker.finance.ethereumAddress());
+        const fiatCode = 'USD';
+        const sourceError = new NetworkResponseError(
+          new URL(`${zerionBaseUri}/v1/wallets/${address}/positions`),
+          new Response(null, { status: 401, statusText: 'Unauthorized' }),
+          {
+            errors: [
+              {
+                code: 'unauthorized',
+                title: 'Unauthorized',
+                detail: 'Invalid Zerion API key',
+              },
+            ],
+          },
+        );
+        const dataSourceError = new DataSourceError('Unauthorized', 401);
+        mockNetworkService.get.mockRejectedValue(sourceError);
+        mockHttpErrorFactory.from.mockReturnValue(dataSourceError);
+
+        await expect(
+          service.getPortfolio({
+            address,
+            fiatCode,
+            trusted,
+            isTestnet: false,
+            sync: true,
+          }),
+        ).rejects.toBe(dataSourceError);
+
+        expect(mockLoggingService.error).toHaveBeenCalledWith({
+          type: LogType.PortfolioRequestError,
+          source: 'ZerionPortfolioApi',
+          event: 'Portfolio request failed',
+          safeAddress: address,
+          fiatCode,
+          trusted,
+          sync: true,
+          isTestnet: false,
+          request_status: 401,
+          detail: 'Invalid Zerion API key',
+        });
+        expect(
+          JSON.stringify(mockLoggingService.error.mock.calls[0][0]),
+        ).not.toContain(zerionApiKey);
+        expect(
+          JSON.stringify(mockLoggingService.error.mock.calls[0][0]),
+        ).not.toContain('Authorization');
+      },
+    );
+  });
+});

--- a/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
+++ b/src/modules/portfolio/datasources/zerion-portfolio-api.service.ts
@@ -1,5 +1,6 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
-import { groupBy } from 'lodash';
+import { get, groupBy } from 'lodash';
 import type { Address } from 'viem';
 import { getAddress, isAddress } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -22,6 +23,7 @@ import type { ZerionBalance } from '@/modules/balances/datasources/entities/zeri
 import { ZerionBalancesSchema } from '@/modules/balances/datasources/entities/zerion-balance.entity';
 import { ZodError } from 'zod';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { LogType } from '@/domain/common/entities/log-type.entity';
 import {
   CacheService,
   ICacheService,
@@ -32,6 +34,8 @@ import {
   normalizeZerionBalances,
 } from '@/modules/balances/datasources/zerion-api.helpers';
 import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import { asError } from '@/logging/utils';
 
 /**
  * Zerion portfolio API integration.
@@ -140,11 +144,45 @@ export class ZerionPortfolioApi implements IPortfolioApi {
 
       return normalizeZerionBalances(response.data);
     } catch (error) {
+      this._logPortfolioRequestError({ ...args, error });
+
       if (error instanceof ZodError) {
         throw error;
       }
       throw this.httpErrorFactory.from(error);
     }
+  }
+
+  private _logPortfolioRequestError(args: {
+    address: Address;
+    fiatCode: string;
+    trusted?: boolean;
+    isTestnet?: boolean;
+    sync?: boolean;
+    error: unknown;
+  }): void {
+    this.loggingService.error({
+      type: LogType.PortfolioRequestError,
+      source: 'ZerionPortfolioApi',
+      event: 'Portfolio request failed',
+      safeAddress: args.address,
+      fiatCode: args.fiatCode,
+      trusted: Boolean(args.trusted),
+      sync: Boolean(args.sync),
+      isTestnet: Boolean(args.isTestnet),
+      request_status:
+        args.error instanceof NetworkResponseError
+          ? args.error.response.status
+          : undefined,
+      detail:
+        args.error instanceof NetworkResponseError
+          ? String(
+              get(args.error.data, 'errors[0].detail') ??
+                get(args.error.data, 'errors[0].title') ??
+                args.error.response.statusText,
+            )
+          : asError(args.error).message,
+    });
   }
 
   /**

--- a/src/modules/portfolio/domain/portfolio.repository.spec.ts
+++ b/src/modules/portfolio/domain/portfolio.repository.spec.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import { PortfolioRepository } from '@/modules/portfolio/domain/portfolio.repository';
 import type { IPortfolioApi } from '@/modules/portfolio/interfaces/portfolio-api.interface';
 import type { ICacheService } from '@/datasources/cache/cache.service.interface';
@@ -87,7 +88,8 @@ describe('PortfolioRepository', () => {
         expect(mockPortfolioApi.getPortfolio).toHaveBeenCalledWith({
           address,
           fiatCode,
-          chainIds: undefined,
+          isTestnet: undefined,
+          sync: undefined,
           trusted: undefined,
         });
 
@@ -120,7 +122,7 @@ describe('PortfolioRepository', () => {
         expect(mockPortfolioApi.getPortfolio).toHaveBeenCalledWith({
           address,
           fiatCode,
-          chainIds: undefined,
+          isTestnet: undefined,
           trusted: undefined,
           sync: true,
         });


### PR DESCRIPTION
## Summary

Resolves: [WA-2104](https://linear.app/safe-global/issue/WA-2104/log-portfolio-endpoint-errors-to-datadog)

Logs Zerion portfolio endpoint failures as structured Datadog errors before they are mapped to `DataSourceError`, so upstream 4xx failures such as invalid Zerion credentials are visible with portfolio request context.

## Changes

- Add `PORTFOLIO_REQUEST_ERROR` log type.
- Log portfolio request failures in `ZerionPortfolioApi` with Safe address, fiat code, request flags, upstream status, and Zerion error detail.
- Add focused coverage for trusted and untrusted portfolio request failures.

## Tests

- `yarn eslint src/domain/common/entities/log-type.entity.ts src/modules/portfolio/domain/portfolio.repository.spec.ts src/modules/portfolio/datasources/zerion-portfolio-api.service.ts src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts`
- `yarn test src/modules/portfolio/datasources/zerion-portfolio-api.service.spec.ts src/modules/portfolio/domain/portfolio.repository.spec.ts --runInBand --watchman=false`
