### PR TITLE
chore: register HN allowlist outreach 11 for Tempo Safes

### DIFF
--- a/migrations/deprecated/00022_targeted_messaging_add_outreach_11/index.sql
+++ b/migrations/deprecated/00022_targeted_messaging_add_outreach_11/index.sql
@@ -1,0 +1,21 @@
+-- SPDX-License-Identifier: FSL-1.1-MIT
+
+INSERT INTO outreaches (
+    source_id,
+    name,
+    start_date,
+    end_date,
+    type,
+    team_name,
+    source_file,
+    source_file_checksum
+) VALUES (
+    11,
+    'Hypernative Allowlist (update 29.04.26)',
+    '1970-01-01 00:00:00.000',
+    '1970-01-01 00:00:00.000',
+    '',
+    'Wallet',
+    'targeted_feature_hypernative_allowlist_campaign_29-04-26.json',
+    '1d20da86493ffa8479fcabb5bac90654d3b8256f50ec78c28075d190ba5a649e'
+);


### PR DESCRIPTION
## Summary
[WA-2120](https://linear.app/safe-global/issue/WA-2120/map-tempo-safes-to-hypernative-no-guards)

## Changes

Adds migration 00022 inserting outreach source_id 11 referencing `targeted_feature_hypernative_allowlist_campaign_29-04-26.json`, which extends the prior allowlist (outreach 10) with two Tempo-mapped Safes on Ethereum and Tempo (chainId 4217).