### PR TITLE
feat(auth): verify Auth0 ID tokens via JWKS

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -150,9 +150,15 @@
     "required": false
   },
   {
-    "name": "AUTH0_SIGNING_SECRET",
-    "description": "Signing secret used to verify Auth0 tokens when the tenant is configured with symmetric signing",
-    "defaultValue": null,
+    "name": "AUTH0_JWKS_CACHE_MAX_AGE_MILLISECONDS",
+    "description": "Maximum time to cache Auth0 JWKS before refreshing",
+    "defaultValue": 3600000,
+    "required": false
+  },
+  {
+    "name": "AUTH0_JWKS_COOLDOWN_MILLISECONDS",
+    "description": "Minimum cooldown between Auth0 JWKS refresh attempts",
+    "defaultValue": 30000,
     "required": false
   },
   {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cache-manager": "6.4.1",
     "cookie-parser": "1.4.7",
     "csv-stringify": "^6.7.0",
+    "jose": "6.2.2",
     "jsonwebtoken": "9.0.3",
     "lodash": "4.17.23",
     "nestjs-cls": "6.2.0",
@@ -124,7 +125,7 @@
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!@faker-js).+"
+      "node_modules/(?!(?:@faker-js|jose)/).+"
     ],
     "roots": [
       "./src",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -36,8 +36,9 @@ export default (): ReturnType<typeof configuration> => ({
       clientSecret: faker.string.uuid(),
       redirectUri: faker.internet.url(),
       audience: faker.internet.url({ appendSlash: false }),
-      signingSecret: faker.string.alphanumeric(32),
       scope: 'openid email',
+      jwksCacheMaxAgeMs: faker.number.int({ min: 60_000, max: 3_600_000 }),
+      jwksCooldownMs: faker.number.int({ min: 1_000, max: 60_000 }),
     },
     rateLimit: {
       max: faker.number.int({ min: 100, max: 200 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -58,8 +58,14 @@ export default () => ({
       clientSecret: process.env.AUTH0_CLIENT_SECRET,
       redirectUri: process.env.AUTH0_REDIRECT_URI,
       audience: process.env.AUTH0_API_AUDIENCE,
-      signingSecret: process.env.AUTH0_SIGNING_SECRET,
       scope: process.env.AUTH0_SCOPE || 'openid',
+      jwksCacheMaxAgeMs: parseInt(
+        process.env.AUTH0_JWKS_CACHE_MAX_AGE_MILLISECONDS ??
+          `${60 * 60 * 1_000}`, // 1 hour
+      ),
+      jwksCooldownMs: parseInt(
+        process.env.AUTH0_JWKS_COOLDOWN_MILLISECONDS ?? `${30_000}`, // 30 seconds
+      ),
     },
     rateLimit: {
       max: parseInt(process.env.AUTH_RATE_LIMIT_MAX ?? `${5}`),

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -52,8 +52,13 @@ export const RootConfigurationSchema = z
     AUTH0_CLIENT_ID: z.string().optional(),
     AUTH0_CLIENT_SECRET: z.string().optional(),
     AUTH0_REDIRECT_URI: z.url().optional(),
-    AUTH0_SIGNING_SECRET: z.string().optional(),
     AUTH0_SCOPE: z.string().optional(),
+    AUTH0_JWKS_CACHE_MAX_AGE_MILLISECONDS: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional(),
+    AUTH0_JWKS_COOLDOWN_MILLISECONDS: z.coerce.number().int().min(1).optional(),
     AUTH_STATE_TTL_MILLISECONDS: z.coerce.number().int().min(1).optional(),
     AWS_ACCESS_KEY_ID: z.string().optional(),
     AWS_KMS_ENCRYPTION_KEY_ID: z.string().optional(),

--- a/src/datasources/jwt/jwt.constants.ts
+++ b/src/datasources/jwt/jwt.constants.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
-export const JWT_HS_ALGORITHM = 'HS256';
-// Keep this untyped: Auth0 ID-token verification uses jose, while tests use jsonwebtoken.
-export const JWT_RS_ALGORITHM = 'RS256';
+export const JWT_HS_ALGORITHM = 'HS256' as const;
+// Keep this library-agnostic: Auth0 ID-token verification uses jose, while tests use jsonwebtoken.
+export const JWT_RS_ALGORITHM = 'RS256' as const;

--- a/src/datasources/jwt/jwt.constants.ts
+++ b/src/datasources/jwt/jwt.constants.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import type { Algorithm } from 'jsonwebtoken';
 
-export const JWT_ALGORITHM: Algorithm = 'HS256';
+export const JWT_HS_ALGORITHM = 'HS256';
+// Keep this untyped: Auth0 ID-token verification uses jose, while tests use jsonwebtoken.
+export const JWT_RS_ALGORITHM = 'RS256';

--- a/src/datasources/jwt/jwt.service.ts
+++ b/src/datasources/jwt/jwt.service.ts
@@ -4,7 +4,7 @@ import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { Algorithm, JwtPayload } from 'jsonwebtoken';
-import { JWT_ALGORITHM } from '@/datasources/jwt/jwt.constants';
+import { JWT_HS_ALGORITHM } from '@/datasources/jwt/jwt.constants';
 
 @Injectable()
 export class JwtService implements IJwtService {
@@ -39,7 +39,7 @@ export class JwtService implements IJwtService {
       },
       {
         secretOrPrivateKey: options?.secretOrPrivateKey ?? this.secret,
-        algorithm: options?.algorithm ?? JWT_ALGORITHM,
+        algorithm: options?.algorithm ?? JWT_HS_ALGORITHM,
       },
     );
   }
@@ -57,7 +57,7 @@ export class JwtService implements IJwtService {
       issuer: options?.issuer ?? this.issuer,
       audience: options?.audience ?? this.issuer,
       secretOrPrivateKey: options?.secretOrPrivateKey ?? this.secret,
-      algorithms: options?.algorithms ?? [JWT_ALGORITHM],
+      algorithms: options?.algorithms ?? [JWT_HS_ALGORITHM],
     });
   }
 
@@ -74,7 +74,7 @@ export class JwtService implements IJwtService {
       issuer: options?.issuer ?? this.issuer,
       audience: options?.audience ?? this.issuer,
       secretOrPrivateKey: options?.secretOrPrivateKey ?? this.secret,
-      algorithms: options?.algorithms ?? [JWT_ALGORITHM],
+      algorithms: options?.algorithms ?? [JWT_HS_ALGORITHM],
     });
   }
 

--- a/src/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper.ts
+++ b/src/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper.ts
@@ -71,11 +71,15 @@ export function signAuth0Jwt(args: {
   kid: string;
   privateKey: string;
   payload: object;
+  noTimestamp?: boolean;
 }): string {
   return jwt.sign(args.payload, args.privateKey, {
     algorithm: JWT_RS_ALGORITHM,
     issuer: args.issuer,
     audience: args.audience,
+    ...(args.noTimestamp === undefined
+      ? {}
+      : { noTimestamp: args.noTimestamp }),
     header: { kid: args.kid, alg: JWT_RS_ALGORITHM },
   });
 }

--- a/src/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper.ts
+++ b/src/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { generateKeyPairSync } from 'node:crypto';
+import { JWT_RS_ALGORITHM } from '@/datasources/jwt/jwt.constants';
+import { faker } from '@faker-js/faker';
+import jwt from 'jsonwebtoken';
+
+export type Auth0JwksFixture = {
+  privateKey: string;
+  publicJwk: JsonWebKey;
+  kid: string;
+};
+
+export function getFetchUrl(input: Parameters<typeof fetch>[0]): string {
+  return input instanceof Request ? input.url : input.toString();
+}
+
+export function getAuth0JwksFixture(): Auth0JwksFixture {
+  const keyPair = generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+  return {
+    privateKey: keyPair.privateKey
+      .export({ format: 'pem', type: 'pkcs8' })
+      .toString(),
+    publicJwk: keyPair.publicKey.export({ format: 'jwk' }),
+    kid: faker.string.alphanumeric(12),
+  };
+}
+
+export function createAuth0JwksResponse(
+  publicJwk: JsonWebKey,
+  kid: string,
+): Response {
+  return new Response(
+    JSON.stringify({
+      keys: [
+        {
+          ...publicJwk,
+          kid,
+          alg: JWT_RS_ALGORITHM,
+          use: 'sig',
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
+export function mockAuth0Jwks(args: {
+  fetchMock: jest.SpiedFunction<typeof fetch>;
+  issuer: string;
+  publicJwk: JsonWebKey;
+  kid: string;
+}): void {
+  args.fetchMock.mockImplementation((input) => {
+    const url = getFetchUrl(input);
+
+    if (url === `${args.issuer}.well-known/jwks.json`) {
+      return Promise.resolve(createAuth0JwksResponse(args.publicJwk, args.kid));
+    }
+
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+}
+
+export function signAuth0Jwt(args: {
+  issuer: string;
+  audience: string;
+  kid: string;
+  privateKey: string;
+  payload: object;
+}): string {
+  return jwt.sign(args.payload, args.privateKey, {
+    algorithm: JWT_RS_ALGORITHM,
+    issuer: args.issuer,
+    audience: args.audience,
+    header: { kid: args.kid, alg: JWT_RS_ALGORITHM },
+  });
+}

--- a/src/modules/auth/oidc/auth0/auth0.constants.ts
+++ b/src/modules/auth/oidc/auth0/auth0.constants.ts
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+export const AUTH0_JWKS_PATH = '/.well-known/jwks.json';

--- a/src/modules/auth/oidc/auth0/auth0.module.ts
+++ b/src/modules/auth/oidc/auth0/auth0.module.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@/datasources/jwt/jwt.module';
 import { NetworkModule } from '@/datasources/network/network.module';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { IAuth0Api } from '@/modules/auth/oidc/auth0/datasources/auth0-api.interface';
@@ -10,7 +9,7 @@ import { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.reposit
 import { Auth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository';
 
 @Module({
-  imports: [NetworkModule, JwtModule],
+  imports: [NetworkModule],
   providers: [
     HttpErrorFactory,
     {

--- a/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
-import { Auth0TokenVerifier } from '@/modules/auth/oidc/auth0/domain/auth0-token.verifier';
-import type { IJwtService } from '@/datasources/jwt/jwt.service.interface';
 import type { ILoggingService } from '@/logging/logging.interface';
+import {
+  createAuth0JwksResponse,
+  getAuth0JwksFixture,
+  getFetchUrl,
+  signAuth0Jwt,
+} from '@/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper';
+import { Auth0TokenVerifier } from '@/modules/auth/oidc/auth0/domain/auth0-token.verifier';
 import { faker } from '@faker-js/faker';
 import { UnauthorizedException } from '@nestjs/common';
-import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
-
-const jwtServiceMock = {
-  decode: jest.fn(),
-} as jest.MockedObjectDeep<IJwtService>;
+import jwt from 'jsonwebtoken';
 
 const loggingServiceMock = {
   debug: jest.fn(),
@@ -18,117 +19,183 @@ const loggingServiceMock = {
 describe('Auth0TokenVerifier', () => {
   let target: Auth0TokenVerifier;
   let issuer: string;
-  let audience: string;
-  let signingSecret: string;
+  let clientId: string;
+  let fetchMock: jest.SpiedFunction<typeof fetch>;
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     const domain = faker.internet.domainName();
     issuer = `https://${domain}/`;
-    audience = faker.string.alphanumeric();
-    signingSecret = faker.string.alphanumeric(32);
+    clientId = faker.string.uuid();
 
     const fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('auth.auth0.domain', domain);
-    fakeConfigurationService.set('auth.auth0.audience', audience);
-    fakeConfigurationService.set('auth.auth0.signingSecret', signingSecret);
+    fakeConfigurationService.set('auth.auth0.clientId', clientId);
+    fakeConfigurationService.set('auth.auth0.jwksCacheMaxAgeMs', 60 * 60_000);
+    fakeConfigurationService.set('auth.auth0.jwksCooldownMs', 30_000);
+    fetchMock = jest.spyOn(global, 'fetch');
 
     target = new Auth0TokenVerifier(
-      jwtServiceMock,
       fakeConfigurationService,
       loggingServiceMock,
     );
   });
 
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
   describe('verifyAndDecode', () => {
-    it('should decode and parse the token with correct options', () => {
-      const accessToken = faker.string.alphanumeric();
-      const now = Math.floor(Date.now() / 1_000);
-      const decoded = {
-        sub: faker.string.uuid(),
-        iat: now,
-        nbf: now,
-        exp: now + 3600,
-      };
-      jwtServiceMock.decode.mockReturnValue(decoded);
-
-      const result = target.verifyAndDecode(accessToken);
-
-      expect(result.sub).toBe(decoded.sub);
-      expect(result.iat).toEqual(new Date(now * 1_000));
-      expect(result.nbf).toEqual(new Date(now * 1_000));
-      expect(result.exp).toEqual(new Date((now + 3600) * 1_000));
-      expect(jwtServiceMock.decode).toHaveBeenCalledTimes(1);
-      expect(jwtServiceMock.decode).toHaveBeenCalledWith(accessToken, {
+    it('should verify the JWT with the Auth0 JWKS public key', async () => {
+      const email = faker.internet.email().toLowerCase();
+      const sub = faker.string.uuid();
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
         issuer,
-        audience,
-        secretOrPrivateKey: signingSecret,
-        algorithms: ['HS256'],
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: {
+          sub,
+          email,
+          email_verified: true,
+        },
       });
-    });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
 
-    it('should parse a token without optional claims', () => {
-      const accessToken = faker.string.alphanumeric();
-      const decoded = { sub: faker.string.numeric() };
-      jwtServiceMock.decode.mockReturnValue(decoded);
+      const result = await target.verifyAndDecode(token);
 
-      const result = target.verifyAndDecode(accessToken);
-
-      expect(result.sub).toBe(decoded.sub);
-      expect(result.iat).toBeUndefined();
-      expect(result.nbf).toBeUndefined();
-      expect(result.exp).toBeUndefined();
-    });
-
-    it('should throw if sub is missing', () => {
-      const accessToken = faker.string.alphanumeric();
-      jwtServiceMock.decode.mockReturnValue({});
-
-      expect(() => target.verifyAndDecode(accessToken)).toThrow();
-    });
-
-    it('should throw UnauthorizedException for JsonWebTokenError', () => {
-      const accessToken = faker.string.alphanumeric();
-      const message =
-        'jwt audience invalid. expected: https://secret.example.com/';
-      jwtServiceMock.decode.mockImplementation(() => {
-        throw new JsonWebTokenError(message);
-      });
-
-      expect(() => target.verifyAndDecode(accessToken)).toThrow(
-        new UnauthorizedException('Invalid access token'),
+      expect(result).toEqual(
+        expect.objectContaining({
+          aud: clientId,
+          email,
+          email_verified: true,
+          iss: issuer,
+          sub,
+        }),
       );
-      expect(loggingServiceMock.debug).toHaveBeenCalledTimes(1);
+      expect(getFetchUrl(fetchMock.mock.calls[0][0])).toBe(
+        `${issuer}.well-known/jwks.json`,
+      );
+    });
+
+    it('should cache the remote JWKS', async () => {
+      const sub = faker.string.uuid();
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const sign = (): string =>
+        signAuth0Jwt({
+          issuer,
+          audience: clientId,
+          kid,
+          privateKey,
+          payload: { sub },
+        });
+
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      await target.verifyAndDecode(sign());
+      await target.verifyAndDecode(sign());
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow email_verified without an email claim', async () => {
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: {
+          sub: faker.string.uuid(),
+          email_verified: true,
+        },
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      const result = await target.verifyAndDecode(token);
+
+      expect(result.email).toBeUndefined();
+      expect(result.email_verified).toBe(true);
+    });
+
+    it('should throw when the JWT has an invalid email claim', async () => {
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: {
+          sub: faker.string.uuid(),
+          email: faker.word.noun(),
+          email_verified: true,
+        },
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid JWT'),
+      );
       expect(loggingServiceMock.debug).toHaveBeenCalledWith(
-        `Auth0: JWT verification failed: ${message}`,
+        expect.stringContaining('Auth0: JWT verification failed:'),
       );
     });
 
-    it('should throw UnauthorizedException for TokenExpiredError', () => {
-      const accessToken = faker.string.alphanumeric();
-      const message = 'jwt expired';
-      jwtServiceMock.decode.mockImplementation(() => {
-        throw new TokenExpiredError(message, new Date());
+    it('should throw when the signing key cannot be found in the JWKS', async () => {
+      const { privateKey, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: { sub: faker.string.uuid() },
       });
 
-      expect(() => target.verifyAndDecode(accessToken)).toThrow(
-        new UnauthorizedException('Invalid access token'),
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ keys: [] }), { status: 200 }),
       );
-      expect(loggingServiceMock.debug).toHaveBeenCalledTimes(1);
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid JWT'),
+      );
+    });
+
+    it('should throw when the JWT uses an unexpected algorithm', async () => {
+      const token = jwt.sign({ sub: faker.string.uuid() }, 'secret', {
+        algorithm: 'HS256',
+        header: { kid: faker.string.alphanumeric(12), alg: 'HS256' },
+        issuer,
+        audience: clientId,
+      });
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid JWT'),
+      );
+    });
+
+    it('should throw when JWT verification fails', async () => {
+      const trustedKeyPair = getAuth0JwksFixture();
+      const untrustedKeyPair = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid: trustedKeyPair.kid,
+        privateKey: untrustedKeyPair.privateKey,
+        payload: { sub: faker.string.uuid() },
+      });
+
+      fetchMock.mockResolvedValueOnce(
+        createAuth0JwksResponse(trustedKeyPair.publicJwk, trustedKeyPair.kid),
+      );
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid JWT'),
+      );
       expect(loggingServiceMock.debug).toHaveBeenCalledWith(
-        `Auth0: JWT verification failed: ${message}`,
+        expect.stringContaining('Auth0: JWT verification failed:'),
       );
-    });
-
-    it('should propagate non-JWT errors from jwtService.decode', () => {
-      const accessToken = faker.string.alphanumeric();
-      const error = new Error('unexpected error');
-      jwtServiceMock.decode.mockImplementation(() => {
-        throw error;
-      });
-
-      expect(() => target.verifyAndDecode(accessToken)).toThrow(error);
     });
   });
 });

--- a/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
+import { toSecondsTimestamp } from '@/domain/common/utils/time';
 import type { ILoggingService } from '@/logging/logging.interface';
 import {
   createAuth0JwksResponse,
@@ -8,6 +9,7 @@ import {
   signAuth0Jwt,
 } from '@/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper';
 import { Auth0TokenVerifier } from '@/modules/auth/oidc/auth0/domain/auth0-token.verifier';
+import { Auth0TokenSchema } from '@/modules/auth/oidc/auth0/domain/entities/auth0-token.entity';
 import { faker } from '@faker-js/faker';
 import { UnauthorizedException } from '@nestjs/common';
 import jwt from 'jsonwebtoken';
@@ -47,9 +49,13 @@ describe('Auth0TokenVerifier', () => {
   });
 
   describe('verifyAndDecode', () => {
-    it('should verify the JWT with the Auth0 JWKS public key', async () => {
+    it('should verify the ID token with the Auth0 JWKS public key', async () => {
       const email = faker.internet.email().toLowerCase();
       const sub = faker.string.uuid();
+      const issuedAt = toSecondsTimestamp(faker.date.recent());
+      const notBefore = toSecondsTimestamp(faker.date.recent());
+      const expiresAt = toSecondsTimestamp(faker.date.future());
+      const jwtId = faker.string.uuid();
       const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
       const token = signAuth0Jwt({
         issuer,
@@ -60,21 +66,27 @@ describe('Auth0TokenVerifier', () => {
           sub,
           email,
           email_verified: true,
+          iat: issuedAt,
+          nbf: notBefore,
+          exp: expiresAt,
+          jti: jwtId,
         },
       });
       fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
 
       const result = await target.verifyAndDecode(token);
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          aud: clientId,
-          email,
-          email_verified: true,
-          iss: issuer,
-          sub,
-        }),
-      );
+      expect(result).toEqual({
+        aud: clientId,
+        email,
+        email_verified: true,
+        exp: new Date(expiresAt * 1_000),
+        iat: new Date(issuedAt * 1_000),
+        iss: issuer,
+        jti: jwtId,
+        nbf: new Date(notBefore * 1_000),
+        sub,
+      });
       expect(getFetchUrl(fetchMock.mock.calls[0][0])).toBe(
         `${issuer}.well-known/jwks.json`,
       );
@@ -100,7 +112,7 @@ describe('Auth0TokenVerifier', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should allow email_verified without an email claim', async () => {
+    it('should throw when email_verified is true without an email claim', async () => {
       const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
       const token = signAuth0Jwt({
         issuer,
@@ -114,13 +126,15 @@ describe('Auth0TokenVerifier', () => {
       });
       fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
 
-      const result = await target.verifyAndDecode(token);
-
-      expect(result.email).toBeUndefined();
-      expect(result.email_verified).toBe(true);
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid ID token'),
+      );
+      expect(loggingServiceMock.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Auth0: ID token verification failed:'),
+      );
     });
 
-    it('should throw when the JWT has an invalid email claim', async () => {
+    it('should throw when the ID token has an invalid email claim', async () => {
       const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
       const token = signAuth0Jwt({
         issuer,
@@ -136,10 +150,10 @@ describe('Auth0TokenVerifier', () => {
       fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
 
       await expect(target.verifyAndDecode(token)).rejects.toThrow(
-        new UnauthorizedException('Invalid JWT'),
+        new UnauthorizedException('Invalid ID token'),
       );
       expect(loggingServiceMock.debug).toHaveBeenCalledWith(
-        expect.stringContaining('Auth0: JWT verification failed:'),
+        expect.stringContaining('Auth0: ID token verification failed:'),
       );
     });
 
@@ -158,11 +172,11 @@ describe('Auth0TokenVerifier', () => {
       );
 
       await expect(target.verifyAndDecode(token)).rejects.toThrow(
-        new UnauthorizedException('Invalid JWT'),
+        new UnauthorizedException('Invalid ID token'),
       );
     });
 
-    it('should throw when the JWT uses an unexpected algorithm', async () => {
+    it('should throw when the ID token uses an unexpected algorithm', async () => {
       const token = jwt.sign({ sub: faker.string.uuid() }, 'secret', {
         algorithm: 'HS256',
         header: { kid: faker.string.alphanumeric(12), alg: 'HS256' },
@@ -171,11 +185,103 @@ describe('Auth0TokenVerifier', () => {
       });
 
       await expect(target.verifyAndDecode(token)).rejects.toThrow(
-        new UnauthorizedException('Invalid JWT'),
+        new UnauthorizedException('Invalid ID token'),
       );
     });
 
-    it('should throw when JWT verification fails', async () => {
+    it('should throw when the ID token issuer does not match Auth0 config', async () => {
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer: faker.internet.url(),
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: { sub: faker.string.uuid() },
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid ID token'),
+      );
+    });
+
+    it('should throw when the ID token audience does not match Auth0 config', async () => {
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: faker.string.uuid(),
+        kid,
+        privateKey,
+        payload: { sub: faker.string.uuid() },
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid ID token'),
+      );
+    });
+
+    it('should throw when the ID token is expired', async () => {
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: {
+          sub: faker.string.uuid(),
+          exp: toSecondsTimestamp(faker.date.past()),
+        },
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid ID token'),
+      );
+    });
+
+    it('should throw when the ID token has no subject claim', async () => {
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: {},
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      await expect(target.verifyAndDecode(token)).rejects.toThrow(
+        new UnauthorizedException('Invalid ID token'),
+      );
+    });
+
+    it('should rethrow unexpected verification errors', async () => {
+      const error = new Error('unexpected parse failure');
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: { sub: faker.string.uuid() },
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+      const parseSpy = jest
+        .spyOn(Auth0TokenSchema, 'parse')
+        .mockImplementationOnce(() => {
+          throw error;
+        });
+
+      try {
+        await expect(target.verifyAndDecode(token)).rejects.toThrow(error);
+        expect(loggingServiceMock.debug).not.toHaveBeenCalled();
+      } finally {
+        parseSpy.mockRestore();
+      }
+    });
+
+    it('should throw when ID token verification fails', async () => {
       const trustedKeyPair = getAuth0JwksFixture();
       const untrustedKeyPair = getAuth0JwksFixture();
       const token = signAuth0Jwt({
@@ -191,10 +297,10 @@ describe('Auth0TokenVerifier', () => {
       );
 
       await expect(target.verifyAndDecode(token)).rejects.toThrow(
-        new UnauthorizedException('Invalid JWT'),
+        new UnauthorizedException('Invalid ID token'),
       );
       expect(loggingServiceMock.debug).toHaveBeenCalledWith(
-        expect.stringContaining('Auth0: JWT verification failed:'),
+        expect.stringContaining('Auth0: ID token verification failed:'),
       );
     });
   });

--- a/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.spec.ts
@@ -49,7 +49,7 @@ describe('Auth0TokenVerifier', () => {
   });
 
   describe('verifyAndDecode', () => {
-    it('should verify the ID token with the Auth0 JWKS public key', async () => {
+    it('should decode and parse the ID token with correct options', async () => {
       const email = faker.internet.email().toLowerCase();
       const sub = faker.string.uuid();
       const issuedAt = toSecondsTimestamp(faker.date.recent());
@@ -112,7 +112,28 @@ describe('Auth0TokenVerifier', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw when email_verified is true without an email claim', async () => {
+    it('should parse an ID token without optional claims', async () => {
+      const sub = faker.string.uuid();
+      const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
+      const token = signAuth0Jwt({
+        issuer,
+        audience: clientId,
+        kid,
+        privateKey,
+        payload: { sub },
+        noTimestamp: true,
+      });
+      fetchMock.mockResolvedValueOnce(createAuth0JwksResponse(publicJwk, kid));
+
+      const result = await target.verifyAndDecode(token);
+
+      expect(result.sub).toBe(sub);
+      expect(result.iat).toBeUndefined();
+      expect(result.nbf).toBeUndefined();
+      expect(result.exp).toBeUndefined();
+    });
+
+    it('should throw when the ID token has email_verified true without an email claim', async () => {
       const { privateKey, publicJwk, kid } = getAuth0JwksFixture();
       const token = signAuth0Jwt({
         issuer,

--- a/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.ts
@@ -45,24 +45,24 @@ export class Auth0TokenVerifier {
   /**
    * Verifies an Auth0 JWT against the tenant JWKS and returns validated token claims.
    *
-   * The audience is the Auth0 application client ID, not the API audience used
-   * for access tokens.
+   * @param idToken - The raw ID token string to verify.
+   * @returns The decoded and validated {@link Auth0Token} claims.
+   * @throws {UnauthorizedException} If the ID token is invalid, expired, or fails verification.
    */
-  public async verifyAndDecode(jwt: string): Promise<Auth0Token> {
+  public async verifyAndDecode(idToken: string): Promise<Auth0Token> {
     try {
-      const { payload } = await jwtVerify(jwt, this.jwks, {
+      const { payload } = await jwtVerify(idToken, this.jwks, {
         issuer: this.issuer,
         audience: this.audience,
         algorithms: [JWT_RS_ALGORITHM],
       });
-      const token = Auth0TokenSchema.parse(payload);
-      return token;
+      return Auth0TokenSchema.parse(payload);
     } catch (error) {
       if (error instanceof errors.JOSEError || error instanceof z.ZodError) {
         this.loggingService.debug(
-          `Auth0: JWT verification failed: ${error.message}`,
+          `Auth0: ID token verification failed: ${error.message}`,
         );
-        throw new UnauthorizedException('Invalid JWT');
+        throw new UnauthorizedException('Invalid ID token');
       }
 
       throw error;

--- a/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0-token.verifier.ts
@@ -1,22 +1,26 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { IConfigurationService } from '@/config/configuration.service.interface';
-import { JWT_ALGORITHM } from '@/datasources/jwt/jwt.constants';
-import { IJwtService } from '@/datasources/jwt/jwt.service.interface';
+import { JWT_RS_ALGORITHM } from '@/datasources/jwt/jwt.constants';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
+import { AUTH0_JWKS_PATH } from '@/modules/auth/oidc/auth0/auth0.constants';
 import type { Auth0Token } from '@/modules/auth/oidc/auth0/domain/entities/auth0-token.entity';
 import { Auth0TokenSchema } from '@/modules/auth/oidc/auth0/domain/entities/auth0-token.entity';
 import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
-import { JsonWebTokenError } from 'jsonwebtoken';
+import {
+  createRemoteJWKSet,
+  errors,
+  type JWTVerifyGetKey,
+  jwtVerify,
+} from 'jose';
+import { z } from 'zod';
 
 @Injectable()
 export class Auth0TokenVerifier {
   private readonly issuer: string;
   private readonly audience: string;
-  private readonly signingSecret: string;
+  private readonly jwks: JWTVerifyGetKey;
 
   constructor(
-    @Inject(IJwtService)
-    private readonly jwtService: IJwtService,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
     @Inject(LoggingService)
@@ -26,29 +30,41 @@ export class Auth0TokenVerifier {
       this.configurationService.getOrThrow<string>('auth.auth0.domain');
     this.issuer = `https://${domain}/`;
     this.audience = this.configurationService.getOrThrow<string>(
-      'auth.auth0.audience',
+      'auth.auth0.clientId',
     );
-    this.signingSecret = this.configurationService.getOrThrow<string>(
-      'auth.auth0.signingSecret',
-    );
+    this.jwks = createRemoteJWKSet(new URL(AUTH0_JWKS_PATH, this.issuer), {
+      cacheMaxAge: this.configurationService.getOrThrow<number>(
+        'auth.auth0.jwksCacheMaxAgeMs',
+      ),
+      cooldownDuration: this.configurationService.getOrThrow<number>(
+        'auth.auth0.jwksCooldownMs',
+      ),
+    });
   }
 
-  verifyAndDecode(accessToken: string): Auth0Token {
+  /**
+   * Verifies an Auth0 JWT against the tenant JWKS and returns validated token claims.
+   *
+   * The audience is the Auth0 application client ID, not the API audience used
+   * for access tokens.
+   */
+  public async verifyAndDecode(jwt: string): Promise<Auth0Token> {
     try {
-      const decoded = this.jwtService.decode<{ sub: string }>(accessToken, {
+      const { payload } = await jwtVerify(jwt, this.jwks, {
         issuer: this.issuer,
         audience: this.audience,
-        secretOrPrivateKey: this.signingSecret,
-        algorithms: [JWT_ALGORITHM],
+        algorithms: [JWT_RS_ALGORITHM],
       });
-      return Auth0TokenSchema.parse(decoded);
+      const token = Auth0TokenSchema.parse(payload);
+      return token;
     } catch (error) {
-      if (error instanceof JsonWebTokenError) {
+      if (error instanceof errors.JOSEError || error instanceof z.ZodError) {
         this.loggingService.debug(
           `Auth0: JWT verification failed: ${error.message}`,
         );
-        throw new UnauthorizedException('Invalid access token');
+        throw new UnauthorizedException('Invalid JWT');
       }
+
       throw error;
     }
   }

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
@@ -54,7 +54,7 @@ describe('Auth0Repository', () => {
   });
 
   describe('authenticateWithAuthorizationCode', () => {
-    it('should exchange the code and use claims from the verified token', async () => {
+    it('should exchange the authorization code and return verified token claims', async () => {
       const code = faker.string.alphanumeric(32);
       const token = faker.string.alphanumeric(64);
       const decodedToken = {

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
@@ -54,9 +54,41 @@ describe('Auth0Repository', () => {
   });
 
   describe('authenticateWithAuthorizationCode', () => {
-    it('should exchange the code and verify the returned access token', async () => {
+    it('should exchange the code and use claims from the verified token', async () => {
       const code = faker.string.alphanumeric(32);
-      const accessToken = faker.string.alphanumeric(64);
+      const token = faker.string.alphanumeric(64);
+      const decodedToken = {
+        sub: `auth0|${faker.string.uuid()}`,
+        iat: faker.date.past(),
+        nbf: faker.date.recent(),
+        exp: faker.date.future(),
+        email: faker.internet.email().toLowerCase(),
+        email_verified: true,
+      };
+
+      auth0ApiMock.exchangeAuthorizationCode.mockResolvedValue(
+        rawify({
+          access_token: faker.string.alphanumeric(64),
+          refresh_token: faker.string.alphanumeric(64),
+          id_token: token,
+          token_type: 'Bearer',
+          expires_in: 3600,
+        }),
+      );
+      auth0TokenVerifierMock.verifyAndDecode.mockResolvedValue(decodedToken);
+
+      const result = await target.authenticateWithAuthorizationCode(code);
+
+      expect(result).toEqual(decodedToken);
+      expect(auth0ApiMock.exchangeAuthorizationCode).toHaveBeenCalledWith(code);
+      expect(auth0TokenVerifierMock.verifyAndDecode).toHaveBeenCalledWith(
+        token,
+      );
+    });
+
+    it('should keep authentication working when the token has no email claims', async () => {
+      const code = faker.string.alphanumeric(32);
+      const token = faker.string.alphanumeric(64);
       const decodedToken = {
         sub: `auth0|${faker.string.uuid()}`,
         iat: faker.date.past(),
@@ -66,21 +98,20 @@ describe('Auth0Repository', () => {
 
       auth0ApiMock.exchangeAuthorizationCode.mockResolvedValue(
         rawify({
-          access_token: accessToken,
+          access_token: faker.string.alphanumeric(64),
           refresh_token: faker.string.alphanumeric(64),
-          id_token: faker.string.alphanumeric(64),
+          id_token: token,
           token_type: 'Bearer',
           expires_in: 3600,
         }),
       );
-      auth0TokenVerifierMock.verifyAndDecode.mockReturnValue(decodedToken);
+      auth0TokenVerifierMock.verifyAndDecode.mockResolvedValue(decodedToken);
 
       const result = await target.authenticateWithAuthorizationCode(code);
 
       expect(result).toEqual(decodedToken);
-      expect(auth0ApiMock.exchangeAuthorizationCode).toHaveBeenCalledWith(code);
       expect(auth0TokenVerifierMock.verifyAndDecode).toHaveBeenCalledWith(
-        accessToken,
+        token,
       );
     });
 
@@ -98,7 +129,7 @@ describe('Auth0Repository', () => {
 
     it('should propagate token verifier errors', async () => {
       const code = faker.string.alphanumeric(32);
-      const error = new Error('invalid access token');
+      const error = new Error('invalid token');
 
       auth0ApiMock.exchangeAuthorizationCode.mockResolvedValue(
         rawify({
@@ -106,11 +137,10 @@ describe('Auth0Repository', () => {
           refresh_token: faker.string.alphanumeric(64),
           id_token: faker.string.alphanumeric(64),
           token_type: 'Bearer',
+          expires_in: 3600,
         }),
       );
-      auth0TokenVerifierMock.verifyAndDecode.mockImplementation(() => {
-        throw error;
-      });
+      auth0TokenVerifierMock.verifyAndDecode.mockRejectedValue(error);
 
       await expect(
         target.authenticateWithAuthorizationCode(code),
@@ -122,9 +152,11 @@ describe('Auth0Repository', () => {
 
       auth0ApiMock.exchangeAuthorizationCode.mockResolvedValue(
         rawify({
-          access_token: '',
-          id_token: faker.string.alphanumeric(64),
+          access_token: faker.string.alphanumeric(64),
+          refresh_token: faker.string.alphanumeric(64),
+          id_token: '',
           token_type: 'Bearer',
+          expires_in: 3600,
         }),
       );
 

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.ts
@@ -22,7 +22,7 @@ export class Auth0Repository implements IAuth0Repository {
     code: string,
   ): Promise<Auth0Token> {
     const response = await this.auth0Api.exchangeAuthorizationCode(code);
-    const { access_token } = Auth0TokenResponseSchema.parse(response);
-    return this.auth0TokenVerifier.verifyAndDecode(access_token);
+    const { id_token } = Auth0TokenResponseSchema.parse(response);
+    return this.auth0TokenVerifier.verifyAndDecode(id_token);
   }
 }

--- a/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
+++ b/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
@@ -2,8 +2,12 @@
 import { JwtClaimsSchema } from '@/datasources/jwt/jwt-claims.entity';
 import { z } from 'zod';
 
+// Auth0 ID token claims:
+// https://auth0.com/docs/tokens/references/id-token-structure
 export const Auth0TokenSchema = JwtClaimsSchema.extend({
   sub: z.string().min(1),
+  email: z.email().optional(),
+  email_verified: z.boolean().optional(),
 });
 
 export type Auth0Token = z.infer<typeof Auth0TokenSchema>;

--- a/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
+++ b/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
@@ -8,6 +8,14 @@ export const Auth0TokenSchema = JwtClaimsSchema.extend({
   sub: z.string().min(1),
   email: z.email().optional(),
   email_verified: z.boolean().optional(),
+}).superRefine((token, ctx) => {
+  if (token.email_verified === true && token.email === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'email is required when email_verified is true',
+      path: ['email'],
+    });
+  }
 });
 
 export type Auth0Token = z.infer<typeof Auth0TokenSchema>;

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -10,6 +10,12 @@ import { faker } from '@faker-js/faker';
 import { getSecondsUntil } from '@/domain/common/utils/time';
 import type { Server } from 'net';
 import { sign } from 'jsonwebtoken';
+import {
+  type Auth0JwksFixture,
+  getAuth0JwksFixture,
+  mockAuth0Jwks,
+  signAuth0Jwt,
+} from '@/modules/auth/oidc/auth0/__tests__/auth0-jwks.helper';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { UsersModule } from '@/modules/users/users.module';
 import { TestUsersModule } from '@/modules/users/__tests__/test.users.module';
@@ -25,6 +31,7 @@ describe('OidcAuthController', () => {
   let app: INestApplication<Server>;
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let jwtService: IJwtService;
+  let fetchMock: jest.SpiedFunction<typeof fetch> | undefined;
 
   let maxValidityPeriodInMs: number;
   let stateTtlMs: number;
@@ -34,9 +41,9 @@ describe('OidcAuthController', () => {
     clientSecret: string;
     redirectUri: string;
     audience: string;
-    signingSecret: string;
     scope: string;
   };
+  let auth0JwksFixture: Auth0JwksFixture;
   let postLoginRedirectUri: string;
 
   function signAuth0Token(claims: {
@@ -45,11 +52,12 @@ describe('OidcAuthController', () => {
     iat?: number;
     nbf?: number;
   }): string {
-    return sign(claims, auth0Config.signingSecret, {
-      algorithm: 'HS256',
+    return signAuth0Jwt({
       issuer: `https://${auth0Config.domain}/`,
-      audience: auth0Config.audience,
-      noTimestamp: true,
+      audience: auth0Config.clientId,
+      kid: auth0JwksFixture.kid,
+      privateKey: auth0JwksFixture.privateKey,
+      payload: claims,
     });
   }
 
@@ -71,6 +79,9 @@ describe('OidcAuthController', () => {
 
     networkService = moduleFixture.get(NetworkService);
     jwtService = moduleFixture.get(IJwtService);
+    fetchMock?.mockRestore();
+    const mockedFetch = jest.spyOn(global, 'fetch');
+    fetchMock = mockedFetch;
 
     const configService: IConfigurationService = moduleFixture.get(
       IConfigurationService,
@@ -88,14 +99,18 @@ describe('OidcAuthController', () => {
       clientSecret: configService.getOrThrow<string>('auth.auth0.clientSecret'),
       redirectUri: configService.getOrThrow<string>('auth.auth0.redirectUri'),
       audience: configService.getOrThrow<string>('auth.auth0.audience'),
-      signingSecret: configService.getOrThrow<string>(
-        'auth.auth0.signingSecret',
-      ),
       scope: configService.getOrThrow<string>('auth.auth0.scope'),
     };
+    auth0JwksFixture = getAuth0JwksFixture();
 
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
+    mockAuth0Jwks({
+      fetchMock: mockedFetch,
+      issuer: `https://${auth0Config.domain}/`,
+      publicJwk: auth0JwksFixture.publicJwk,
+      kid: auth0JwksFixture.kid,
+    });
   }
 
   describe('default configuration', () => {
@@ -121,6 +136,7 @@ describe('OidcAuthController', () => {
 
     afterEach(async () => {
       jest.useRealTimers();
+      fetchMock?.mockRestore();
       await app?.close();
     });
 
@@ -329,8 +345,8 @@ describe('OidcAuthController', () => {
         networkService.postForm.mockResolvedValueOnce({
           status: 200,
           data: rawify({
-            access_token: auth0Token,
-            id_token: 'auth0-id-token',
+            access_token: faker.string.alphanumeric(64),
+            id_token: auth0Token,
             token_type: 'Bearer',
             scope: faker.lorem.words(),
           }),
@@ -408,9 +424,9 @@ describe('OidcAuthController', () => {
         networkService.postForm.mockResolvedValueOnce({
           status: 200,
           data: rawify({
-            access_token: invalidToken,
+            access_token: faker.string.alphanumeric(64),
             refresh_token: 'auth0-refresh-token',
-            id_token: 'auth0-id-token',
+            id_token: invalidToken,
             token_type: 'Bearer',
           }),
         });
@@ -517,8 +533,8 @@ describe('OidcAuthController', () => {
         networkService.postForm.mockResolvedValueOnce({
           status: 200,
           data: rawify({
-            access_token: auth0Token,
-            id_token: 'auth0-id-token',
+            access_token: faker.string.alphanumeric(64),
+            id_token: auth0Token,
             token_type: 'Bearer',
           }),
         });
@@ -568,8 +584,8 @@ describe('OidcAuthController', () => {
         networkService.postForm.mockResolvedValueOnce({
           status: 200,
           data: rawify({
-            access_token: auth0Token,
-            id_token: 'auth0-id-token',
+            access_token: faker.string.alphanumeric(64),
+            id_token: auth0Token,
             token_type: 'Bearer',
             scope: faker.lorem.words(),
           }),
@@ -666,6 +682,7 @@ describe('OidcAuthController', () => {
     });
 
     afterEach(async () => {
+      fetchMock?.mockRestore();
       await app?.close();
     });
 
@@ -720,6 +737,7 @@ describe('OidcAuthController', () => {
 
       afterEach(async () => {
         jest.useRealTimers();
+        fetchMock?.mockRestore();
         await app?.close();
       });
 
@@ -746,6 +764,7 @@ describe('OidcAuthController', () => {
     describe('production environment', () => {
       afterEach(async () => {
         jest.useRealTimers();
+        fetchMock?.mockRestore();
         await app?.close();
       });
 

--- a/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.controller.integration.spec.ts
@@ -31,7 +31,7 @@ describe('OidcAuthController', () => {
   let app: INestApplication<Server>;
   let networkService: jest.MockedObjectDeep<INetworkService>;
   let jwtService: IJwtService;
-  let fetchMock: jest.SpiedFunction<typeof fetch> | undefined;
+  let fetchMock: jest.SpiedFunction<typeof fetch>;
 
   let maxValidityPeriodInMs: number;
   let stateTtlMs: number;
@@ -45,6 +45,14 @@ describe('OidcAuthController', () => {
   };
   let auth0JwksFixture: Auth0JwksFixture;
   let postLoginRedirectUri: string;
+
+  beforeEach(() => {
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
 
   function signAuth0Token(claims: {
     sub: string;
@@ -79,9 +87,6 @@ describe('OidcAuthController', () => {
 
     networkService = moduleFixture.get(NetworkService);
     jwtService = moduleFixture.get(IJwtService);
-    fetchMock?.mockRestore();
-    const mockedFetch = jest.spyOn(global, 'fetch');
-    fetchMock = mockedFetch;
 
     const configService: IConfigurationService = moduleFixture.get(
       IConfigurationService,
@@ -106,7 +111,7 @@ describe('OidcAuthController', () => {
     app = await new TestAppProvider().provide(moduleFixture);
     await app.init();
     mockAuth0Jwks({
-      fetchMock: mockedFetch,
+      fetchMock,
       issuer: `https://${auth0Config.domain}/`,
       publicJwk: auth0JwksFixture.publicJwk,
       kid: auth0JwksFixture.kid,
@@ -136,7 +141,6 @@ describe('OidcAuthController', () => {
 
     afterEach(async () => {
       jest.useRealTimers();
-      fetchMock?.mockRestore();
       await app?.close();
     });
 
@@ -682,7 +686,6 @@ describe('OidcAuthController', () => {
     });
 
     afterEach(async () => {
-      fetchMock?.mockRestore();
       await app?.close();
     });
 
@@ -737,7 +740,6 @@ describe('OidcAuthController', () => {
 
       afterEach(async () => {
         jest.useRealTimers();
-        fetchMock?.mockRestore();
         await app?.close();
       });
 
@@ -764,7 +766,6 @@ describe('OidcAuthController', () => {
     describe('production environment', () => {
       afterEach(async () => {
         jest.useRealTimers();
-        fetchMock?.mockRestore();
         await app?.close();
       });
 

--- a/test/jest-all.json
+++ b/test/jest-all.json
@@ -9,7 +9,7 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "transformIgnorePatterns": ["node_modules/(?!@faker-js).+"],
+  "transformIgnorePatterns": ["node_modules/(?!(?:@faker-js|jose)/).+"],
   "coverageDirectory": "./coverage",
   "moduleNameMapper": {
     "^@/abis/(.*)$": "<rootDir>/abis/$1",

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -9,7 +9,7 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "transformIgnorePatterns": ["node_modules/(?!@faker-js).+"],
+  "transformIgnorePatterns": ["node_modules/(?!(?:@faker-js|jose)/).+"],
   "coverageDirectory": "./coverage",
   "moduleNameMapper": {
     "^@/abis/(.*)$": "<rootDir>/abis/$1",

--- a/test/jest-integration.json
+++ b/test/jest-integration.json
@@ -9,7 +9,7 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "transformIgnorePatterns": ["node_modules/(?!@faker-js).+"],
+  "transformIgnorePatterns": ["node_modules/(?!(?:@faker-js|jose)/).+"],
   "coverageDirectory": "./coverage",
   "moduleNameMapper": {
     "^@/abis/(.*)$": "<rootDir>/abis/$1",

--- a/test/jest-unit.json
+++ b/test/jest-unit.json
@@ -11,7 +11,7 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "transformIgnorePatterns": ["node_modules/(?!@faker-js).+"],
+  "transformIgnorePatterns": ["node_modules/(?!(?:@faker-js|jose)/).+"],
   "collectCoverageFrom": ["**/*.(t|j)s"],
   "coverageDirectory": "./coverage",
   "coveragePathIgnorePatterns": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7941,6 +7941,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:6.2.2":
+  version: 6.2.2
+  resolution: "jose@npm:6.2.2"
+  checksum: 10/fd66f24916d2507dbde0ca77ede86377e7d7eae42c7f94db0dfd014b0c6ce5041365dc8e757a44e54cd7606ea5e9c757aa544b51e55cb8a736e83320db1b8258
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -9762,6 +9769,7 @@ __metadata:
     eslint-config-prettier: "npm:10.1.8"
     husky: "npm:9.1.7"
     jest: "npm:29.7.0"
+    jose: "npm:6.2.2"
     jsonwebtoken: "npm:9.0.3"
     lodash: "npm:4.17.23"
     nestjs-cls: "npm:6.2.0"


### PR DESCRIPTION
Resolves: https://linear.app/safe-global/issue/WA-2181/cgw-verify-auth0-id-tokens-via-jwks

This PR implements the Auth0 JWT verification prerequisite for email identity support. It switches CGW OIDC authentication from Auth0 access-token verification with a shared signing secret to Auth0 ID-token verification via JWKS, so verified ID-token claims can be consumed safely by follow-up work.

Summary

- verify Auth0 ID tokens with `jose` and the tenant JWKS endpoint
- validate ID-token claims with the Auth0 token schema, including optional email claims
- use the Auth0 application client ID as the ID-token audience
- remove `AUTH0_SIGNING_SECRET` usage from the Auth0 verification path
- add configurable JWKS cache/cooldown values
- keep `AUTH0_SCOPE` default at minimal `openid`
- add focused tests for JWKS verification, caching, invalid claims, wrong algorithms, and missing email claims

Notes

- This PR does not persist or expose email yet. That is intentionally split into the follow-up PR.
- `AUTH0_SCOPE` must be configured per environment to request email claims when the email feature is enabled.