### PR TITLE
feat(spaces): support email invites

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1404,6 +1404,18 @@
     "required": false
   },
   {
+    "name": "SPACES_RESEND_INVITE_RATE_LIMIT_MAX",
+    "description": "Maximum resend invite requests per time window",
+    "defaultValue": 50,
+    "required": false
+  },
+  {
+    "name": "SPACES_RESEND_INVITE_RATE_LIMIT_WINDOW_SECONDS",
+    "description": "Time window for resend invite rate limiting",
+    "defaultValue": 600,
+    "required": false
+  },
+  {
     "name": "SPACES_MAX_SAFES_PER_SPACE",
     "description": "Maximum number of Safes per Space",
     "defaultValue": 10,

--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1398,6 +1398,12 @@
     "required": false
   },
   {
+    "name": "SPACES_INVITE_EXPIRY_SECONDS",
+    "description": "Time until a Space invite expires, in seconds",
+    "defaultValue": 604800,
+    "required": false
+  },
+  {
     "name": "SPACES_MAX_SAFES_PER_SPACE",
     "description": "Maximum number of Safes per Space",
     "defaultValue": 10,

--- a/migrations/1777000000000-add-member-invite-expires-at.ts
+++ b/migrations/1777000000000-add-member-invite-expires-at.ts
@@ -11,6 +11,7 @@ export class AddMemberInviteExpiresAt1777000000000
       `ALTER TABLE "members" ADD COLUMN "invite_expires_at" timestamp with time zone`,
     );
     await queryRunner.query(
+      // MemberStatus enum values at migration time: 0 = INVITED, 2 = DECLINED.
       `UPDATE "members" SET "invite_expires_at" = "created_at" + interval '7 days' WHERE "status" IN (0, 2)`,
     );
   }

--- a/migrations/1777000000000-add-member-invite-expires-at.ts
+++ b/migrations/1777000000000-add-member-invite-expires-at.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMemberInviteExpiresAt1777000000000
+  implements MigrationInterface
+{
+  name = 'AddMemberInviteExpiresAt1777000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "members" ADD COLUMN "invite_expires_at" timestamp with time zone`,
+    );
+    await queryRunner.query(
+      `UPDATE "members" SET "invite_expires_at" = "created_at" + interval '7 days' WHERE "status" IN (0, 2)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "members" DROP COLUMN "invite_expires_at"`,
+    );
+  }
+}

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -442,6 +442,10 @@ export default (): ReturnType<typeof configuration> => ({
         max: faker.number.int({ min: 100, max: 200 }),
         windowSeconds: faker.number.int({ min: 100, max: 200 }),
       },
+      resendInvite: {
+        max: faker.number.int({ min: 100, max: 200 }),
+        windowSeconds: faker.number.int({ min: 100, max: 200 }),
+      },
     },
   },
   staking: {

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -432,6 +432,7 @@ export default (): ReturnType<typeof configuration> => ({
     maxSafesPerSpace: faker.number.int({ min: 5, max: 10 }),
     maxSpaceCreationsPerUser: faker.number.int({ min: 100, max: 200 }),
     maxInvites: faker.number.int({ min: 5, max: 10 }),
+    inviteExpirySeconds: faker.number.int({ min: 100, max: 200 }),
     rateLimit: {
       creation: {
         max: faker.number.int({ min: 100, max: 200 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -755,6 +755,10 @@ export default () => ({
       10,
     ),
     maxInvites: Number.parseInt(process.env.SPACES_MAX_INVITES ?? `${50}`, 10),
+    inviteExpirySeconds: Number.parseInt(
+      process.env.SPACES_INVITE_EXPIRY_SECONDS ?? `${7 * 24 * 60 * 60}`,
+      10,
+    ),
     rateLimit: {
       creation: {
         max: Number.parseInt(process.env.SPACES_RATE_LIMIT_MAX ?? `${10}`, 10),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -777,6 +777,17 @@ export default () => ({
           10,
         ),
       },
+      resendInvite: {
+        max: Number.parseInt(
+          process.env.SPACES_RESEND_INVITE_RATE_LIMIT_MAX ?? `${50}`,
+          10,
+        ),
+        windowSeconds: Number.parseInt(
+          process.env.SPACES_RESEND_INVITE_RATE_LIMIT_WINDOW_SECONDS ??
+            `${600}`,
+          10,
+        ),
+      },
     },
   },
   staking: {

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -61,6 +61,7 @@ export const RootConfigurationSchema = z
       .optional(),
     AUTH0_JWKS_COOLDOWN_MILLISECONDS: z.coerce.number().int().min(1).optional(),
     AUTH_STATE_TTL_MILLISECONDS: z.coerce.number().int().min(1).optional(),
+    SPACES_INVITE_EXPIRY_SECONDS: z.coerce.number().int().min(1).optional(),
     AWS_ACCESS_KEY_ID: z.string().optional(),
     AWS_KMS_ENCRYPTION_KEY_ID: z.string().optional(),
     AWS_SECRET_ACCESS_KEY: z.string().optional(),

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -235,6 +235,7 @@ describe('SpacesRepository', () => {
         name: expect.any(String),
         alias: null,
         invitedBy: null,
+        inviteExpiresAt: null,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
         user: {
@@ -327,6 +328,7 @@ describe('SpacesRepository', () => {
         name: `${spaceName} creator`,
         alias: null,
         invitedBy: null,
+        inviteExpiresAt: null,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
         user: {

--- a/src/modules/spaces/routes/entities/__tests__/resend-invite.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/resend-invite.dto.entity.spec.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { ResendInviteDtoSchema } from '@/modules/spaces/routes/entities/resend-invite.dto.entity';
+
+describe('ResendInviteDtoSchema', () => {
+  it('should accept an address-only payload', () => {
+    const result = ResendInviteDtoSchema.safeParse({
+      address: getAddress(faker.finance.ethereumAddress()),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should accept an email-only payload', () => {
+    const result = ResendInviteDtoSchema.safeParse({
+      email: faker.internet.email().toLowerCase(),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject a payload that has both address and email', () => {
+    const result = ResendInviteDtoSchema.safeParse({
+      address: getAddress(faker.finance.ethereumAddress()),
+      email: faker.internet.email().toLowerCase(),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an empty payload', () => {
+    const result = ResendInviteDtoSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a non-address string in the address branch', () => {
+    const result = ResendInviteDtoSchema.safeParse({
+      address: 'not-an-address',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a malformed email', () => {
+    const result = ResendInviteDtoSchema.safeParse({ email: 'not-an-email' });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an email longer than 255 characters', () => {
+    const localPart = 'a'.repeat(250);
+    const result = ResendInviteDtoSchema.safeParse({
+      email: `${localPart}@example.com`,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/modules/spaces/routes/entities/get-space.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/get-space.dto.entity.ts
@@ -31,6 +31,9 @@ class SpaceMemberDto {
   })
   public status!: Member['status'];
 
+  @ApiProperty({ type: Date, nullable: true })
+  public inviteExpiresAt!: Member['inviteExpiresAt'];
+
   @ApiProperty({ type: UserDto })
   public user!: Partial<UserDto>;
 }

--- a/src/modules/spaces/routes/entities/invitation.entity.ts
+++ b/src/modules/spaces/routes/entities/invitation.entity.ts
@@ -10,8 +10,8 @@ import {
 import type { User } from '@/modules/users/domain/entities/user.entity';
 
 export class Invitation {
-  @ApiProperty({ type: Number })
-  userId!: User['id'];
+  @ApiPropertyOptional({ type: Number })
+  userId?: User['id'];
 
   @ApiProperty({ type: String })
   name!: Member['name'];

--- a/src/modules/spaces/routes/entities/invitation.entity.ts
+++ b/src/modules/spaces/routes/entities/invitation.entity.ts
@@ -27,4 +27,7 @@ export class Invitation {
 
   @ApiPropertyOptional({ type: String, nullable: true })
   invitedBy!: Member['invitedBy'];
+
+  @ApiProperty({ type: Date })
+  inviteExpiresAt!: Member['inviteExpiresAt'];
 }

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -11,23 +11,15 @@ import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { MemberRole } from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
-const InviteUserSchema = z
-  .object({
-    address: AddressSchema.optional(),
-    email: z.email().max(255).optional(),
-    role: z.enum(getStringEnumKeys(MemberRole)),
-    name: NameSchema,
-  })
-  .superRefine((value, ctx) => {
-    const identifiers = [value.address, value.email].filter(Boolean);
+const SharedInviteFields = {
+  role: z.enum(getStringEnumKeys(MemberRole)),
+  name: NameSchema,
+};
 
-    if (identifiers.length !== 1) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Exactly one of address or email is required.',
-      });
-    }
-  });
+const InviteUserSchema = z.union([
+  z.object({ address: AddressSchema, ...SharedInviteFields }).strict(),
+  z.object({ email: z.email().max(255), ...SharedInviteFields }).strict(),
+]);
 
 const InviteUserDtoSchema = z.array(InviteUserSchema).min(1);
 
@@ -55,7 +47,7 @@ export class InviteUserDto {
   public readonly role!: keyof typeof MemberRole;
 }
 
-export class InviteUsersDto implements z.infer<typeof InviteUsersDtoSchema> {
+export class InviteUsersDto {
   @ApiProperty({
     type: InviteUserDto,
     isArray: true,

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -28,10 +28,16 @@ export const InviteUsersDtoSchema = z.object({
 });
 
 export class InviteUserDto {
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description:
+      'Wallet address to invite. Provide either address or email, but not both.',
+  })
   public readonly address?: Address;
 
-  @ApiPropertyOptional()
+  @ApiPropertyOptional({
+    description:
+      'Email address to invite. Provide either email or address, but not both.',
+  })
   public readonly email?: string;
 
   @ApiProperty({

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -1,32 +1,47 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
 import {
   NAME_MAX_LENGTH,
   NAME_MIN_LENGTH,
+  NameSchema,
 } from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { MemberRole } from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
-const InviteUserDtoSchema = z
-  .array(
-    z.object({
-      address: AddressSchema,
-      role: z.enum(getStringEnumKeys(MemberRole)),
-      name: z.string().max(255),
-    }),
-  )
-  .min(1);
+const InviteUserSchema = z
+  .object({
+    address: AddressSchema.optional(),
+    email: z.email().max(255).optional(),
+    role: z.enum(getStringEnumKeys(MemberRole)),
+    name: NameSchema,
+  })
+  .superRefine((value, ctx) => {
+    const identifiers = [value.address, value.email].filter(Boolean);
+
+    if (identifiers.length !== 1) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Exactly one of address or email is required.',
+        path: ['address'],
+      });
+    }
+  });
+
+const InviteUserDtoSchema = z.array(InviteUserSchema).min(1);
 
 export const InviteUsersDtoSchema = z.object({
   users: InviteUserDtoSchema,
 });
 
 export class InviteUserDto {
-  @ApiProperty()
-  public readonly address!: Address;
+  @ApiPropertyOptional()
+  public readonly address?: Address;
+
+  @ApiPropertyOptional()
+  public readonly email?: string;
 
   @ApiProperty({
     type: String,

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -25,7 +25,6 @@ const InviteUserSchema = z
       ctx.addIssue({
         code: 'custom',
         message: 'Exactly one of address or email is required.',
-        path: ['address'],
       });
     }
   });

--- a/src/modules/spaces/routes/entities/members.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/members.dto.entity.ts
@@ -48,6 +48,9 @@ export class MemberDto {
   @ApiProperty()
   updatedAt!: Date;
 
+  @ApiProperty({ type: Date, nullable: true })
+  inviteExpiresAt!: DomainMember['inviteExpiresAt'];
+
   @ApiProperty({ type: MemberUser })
   user!: MemberUser;
 }

--- a/src/modules/spaces/routes/entities/resend-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/resend-invite.dto.entity.ts
@@ -4,23 +4,12 @@ import type { Address } from 'viem';
 import { z } from 'zod';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
-export const ResendInviteDtoSchema = z
-  .object({
-    address: AddressSchema.optional(),
-    email: z.email().max(255).optional(),
-  })
-  .superRefine((value, ctx) => {
-    const identifiers = [value.address, value.email].filter(Boolean);
+export const ResendInviteDtoSchema = z.union([
+  z.object({ address: AddressSchema }).strict(),
+  z.object({ email: z.email().max(255) }).strict(),
+]);
 
-    if (identifiers.length !== 1) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Exactly one of address or email is required.',
-      });
-    }
-  });
-
-export class ResendInviteDto implements z.infer<typeof ResendInviteDtoSchema> {
+export class ResendInviteDto {
   @ApiPropertyOptional()
   public readonly address?: Address;
 

--- a/src/modules/spaces/routes/entities/resend-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/resend-invite.dto.entity.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import type { Address } from 'viem';
+import { z } from 'zod';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+
+export const ResendInviteDtoSchema = z
+  .object({
+    address: AddressSchema.optional(),
+    email: z.email().max(255).optional(),
+  })
+  .superRefine((value, ctx) => {
+    const identifiers = [value.address, value.email].filter(Boolean);
+
+    if (identifiers.length !== 1) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Exactly one of address or email is required.',
+      });
+    }
+  });
+
+export class ResendInviteDto implements z.infer<typeof ResendInviteDtoSchema> {
+  @ApiPropertyOptional()
+  public readonly address?: Address;
+
+  @ApiPropertyOptional()
+  public readonly email?: string;
+}

--- a/src/modules/spaces/routes/guards/spaces-resend-invite-rate-limit.guard.ts
+++ b/src/modules/spaces/routes/guards/spaces-resend-invite-rate-limit.guard.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import {
+  CacheService,
+  type ICacheService,
+} from '@/datasources/cache/cache.service.interface';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import { RateLimitGuard } from '@/routes/common/guards/rate-limit.guard';
+
+@Injectable()
+export class SpacesResendInviteRateLimitGuard extends RateLimitGuard {
+  constructor(
+    @Inject(IConfigurationService)
+    readonly configurationService: IConfigurationService,
+    @Inject(CacheService) cacheService: ICacheService,
+    @Inject(LoggingService) loggingService: ILoggingService,
+  ) {
+    const rateLimits = {
+      max: configurationService.getOrThrow<number>(
+        'spaces.rateLimit.resendInvite.max',
+      ),
+      windowSeconds: configurationService.getOrThrow<number>(
+        'spaces.rateLimit.resendInvite.windowSeconds',
+      ),
+    };
+    super(cacheService, loggingService, rateLimits);
+  }
+}

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -642,7 +642,7 @@ describe('MembersController', () => {
     });
   });
 
-  describe('POST /v1/spaces/:spaceId/members/:userId/resend', () => {
+  describe('POST /v1/spaces/:spaceId/members/resend', () => {
     it('should resend an invitation', async () => {
       const adminAuthPayloadDto = siweAuthPayloadDtoBuilder().build();
       const adminAccessToken = jwtService.sign(adminAuthPayloadDto);
@@ -684,8 +684,9 @@ describe('MembersController', () => {
         .expect(201);
 
       await request(app.getHttpServer())
-        .post(`/v1/spaces/${spaceId}/members/${userId}/resend`)
+        .post(`/v1/spaces/${spaceId}/members/resend`)
         .set('Cookie', [`access_token=${adminAccessToken}`])
+        .send({ address: inviteeAuthPayloadDto.signer_address })
         .expect(201)
         .expect({});
 

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -127,6 +127,7 @@ describe('MembersController', () => {
               role: 'ADMIN',
               status: 'INVITED',
               invitedBy: authPayloadDto.signer_address,
+              inviteExpiresAt: expect.any(String),
             },
             {
               userId: expect.any(Number),
@@ -135,6 +136,54 @@ describe('MembersController', () => {
               role: 'MEMBER',
               status: 'INVITED',
               invitedBy: authPayloadDto.signer_address,
+              inviteExpiresAt: expect.any(String),
+            },
+          ]),
+        );
+    });
+
+    it('should invite users by email', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const spaceName = nameBuilder();
+      const invitedEmail = faker.internet.email().toLowerCase();
+      const invitedName = faker.person.firstName();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(201);
+
+      const createSpaceResponse = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: spaceName })
+        .expect(201);
+      const spaceId = createSpaceResponse.body.id;
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/invite`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              email: invitedEmail,
+              name: invitedName,
+            },
+          ],
+        })
+        .expect(201)
+        .expect(({ body }) =>
+          expect(body).toEqual([
+            {
+              userId: expect.any(Number),
+              spaceId,
+              name: invitedName,
+              role: 'MEMBER',
+              status: 'INVITED',
+              invitedBy: authPayloadDto.signer_address,
+              inviteExpiresAt: expect.any(String),
             },
           ]),
         );
@@ -587,9 +636,74 @@ describe('MembersController', () => {
         })
         .expect(409)
         .expect({
-          message: `${memberAddress} is already in this space or has a pending invite.`,
+          message: 'User is already in this space or has a pending invite.',
           error: 'Conflict',
           statusCode: 409,
+        });
+    });
+  });
+
+  describe('POST /v1/spaces/:spaceId/members/:userId/resend', () => {
+    it('should resend an invitation', async () => {
+      const adminAuthPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const adminAccessToken = jwtService.sign(adminAuthPayloadDto);
+      const inviteeAuthPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const inviteeAccessToken = jwtService.sign(inviteeAuthPayloadDto);
+      const spaceName = nameBuilder();
+      const memberName = nameBuilder();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${adminAccessToken}`])
+        .expect(201);
+
+      const createSpaceResponse = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${adminAccessToken}`])
+        .send({ name: spaceName })
+        .expect(201);
+      const spaceId = createSpaceResponse.body.id;
+
+      const inviteUsersResponse = await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/invite`)
+        .set('Cookie', [`access_token=${adminAccessToken}`])
+        .send({
+          users: [
+            {
+              role: 'MEMBER',
+              address: inviteeAuthPayloadDto.signer_address,
+              name: memberName,
+            },
+          ],
+        })
+        .expect(201);
+      const userId = inviteUsersResponse.body[0].userId;
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/decline`)
+        .set('Cookie', [`access_token=${inviteeAccessToken}`])
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/${userId}/resend`)
+        .set('Cookie', [`access_token=${adminAccessToken}`])
+        .expect(201)
+        .expect({});
+
+      await request(app.getHttpServer())
+        .get(`/v1/spaces/${spaceId}/members`)
+        .set('Cookie', [`access_token=${adminAccessToken}`])
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.members).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                status: 'INVITED',
+                inviteExpiresAt: expect.any(String),
+                user: expect.objectContaining({ id: userId }),
+              }),
+            ]),
+          );
         });
     });
   });

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -177,7 +177,6 @@ describe('MembersController', () => {
         .expect(({ body }) =>
           expect(body).toEqual([
             {
-              userId: expect.any(Number),
               spaceId,
               name: invitedName,
               role: 'MEMBER',

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -72,7 +72,7 @@ export class MembersController {
   })
   @ApiBody({
     type: InviteUsersDto,
-    description: 'List of wallet addresses to invite to the space',
+    description: 'List of wallet addresses or email addresses to invite',
   })
   @ApiOkResponse({
     description: 'Users invited successfully',
@@ -185,6 +185,52 @@ export class MembersController {
     return await this.membersService.declineInvite({
       authPayload,
       spaceId,
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Resend space invitation',
+    description:
+      'Resends an invitation and resets its expiration. Only space admins can resend invitations.',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'number',
+    description: 'Space ID containing the invitation',
+    example: 1,
+  })
+  @ApiParam({
+    name: 'userId',
+    type: 'number',
+    description: 'User ID of the invited member',
+    example: 123,
+  })
+  @ApiOkResponse({
+    description: 'Invitation resent successfully',
+  })
+  @ApiForbiddenResponse({
+    description:
+      'Access forbidden - user is not authorized to resend invitations',
+  })
+  @ApiNotFoundResponse({
+    description: 'User, space, or invitation not found',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User is not active or not an admin of this space',
+  })
+  @Post('/:spaceId/members/:userId/resend')
+  @UseGuards(AuthGuard)
+  public async resendInvite(
+    @Auth() authPayload: AuthPayload,
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: number,
+    @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    userId: number,
+  ): Promise<void> {
+    return await this.membersService.resendInvite({
+      authPayload,
+      spaceId,
+      userId,
     });
   }
 

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -77,7 +77,8 @@ export class MembersController {
   })
   @ApiBody({
     type: InviteUsersDto,
-    description: 'List of wallet addresses or email addresses to invite',
+    description:
+      'List of wallet addresses or email addresses to invite to the space',
   })
   @ApiOkResponse({
     description: 'Users invited successfully',

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -41,6 +41,10 @@ import {
   MembersDto,
 } from '@/modules/spaces/routes/entities/members.dto.entity';
 import {
+  ResendInviteDto,
+  ResendInviteDtoSchema,
+} from '@/modules/spaces/routes/entities/resend-invite.dto.entity';
+import {
   type UpdateMemberAliasDto,
   UpdateMemberAliasDtoSchema,
 } from '@/modules/spaces/routes/entities/update-member-name.dto.entity';
@@ -48,6 +52,7 @@ import {
   UpdateRoleDto,
   UpdateRoleDtoSchema,
 } from '@/modules/spaces/routes/entities/update-role.dto.entity';
+import { SpacesResendInviteRateLimitGuard } from '@/modules/spaces/routes/guards/spaces-resend-invite-rate-limit.guard';
 import { MembersService } from '@/modules/spaces/routes/members.service';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
@@ -199,11 +204,9 @@ export class MembersController {
     description: 'Space ID containing the invitation',
     example: 1,
   })
-  @ApiParam({
-    name: 'userId',
-    type: 'number',
-    description: 'User ID of the invited member',
-    example: 123,
+  @ApiBody({
+    type: ResendInviteDto,
+    description: 'Wallet address or email address of the invited member',
   })
   @ApiOkResponse({
     description: 'Invitation resent successfully',
@@ -218,19 +221,19 @@ export class MembersController {
   @ApiUnauthorizedResponse({
     description: 'User is not active or not an admin of this space',
   })
-  @Post('/:spaceId/members/:userId/resend')
-  @UseGuards(AuthGuard)
+  @Post('/:spaceId/members/resend')
+  @UseGuards(AuthGuard, SpacesResendInviteRateLimitGuard)
   public async resendInvite(
     @Auth() authPayload: AuthPayload,
     @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     spaceId: number,
-    @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
-    userId: number,
+    @Body(new ValidationPipe(ResendInviteDtoSchema))
+    resendInviteDto: ResendInviteDto,
   ): Promise<void> {
     return await this.membersService.resendInvite({
       authPayload,
       spaceId,
-      userId,
+      resendInviteDto,
     });
   }
 

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -402,7 +402,7 @@ describe('MembersService', () => {
       );
     });
 
-    it('returns the stored email for invited self memberships', async () => {
+    it('redacts email for invited self memberships', async () => {
       const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
       const email = faker.internet.email().toLowerCase();
       const member = memberBuilder()
@@ -426,7 +426,7 @@ describe('MembersService', () => {
           status: 'INVITED',
           user: expect.objectContaining({
             id: member.user.id,
-            email,
+            email: null,
           }),
         }),
       );

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -10,29 +10,21 @@ import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity'
 import { MembersService } from '@/modules/spaces/routes/members.service';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import { userBuilder } from '@/modules/users/datasources/entities/__tests__/users.entity.db.builder';
-import { type IMembersRepository as IMembersRepositoryInterface } from '@/modules/users/domain/members.repository.interface';
+import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 
-const MAX_INVITES = 10;
-const INVITE_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
-const INVITE_CREATED_AT = new Date('2026-04-24T00:00:00.000Z');
+const MAX_INVITES = faker.number.int({ min: 5, max: 10 });
+const INVITE_EXPIRY_SECONDS = faker.number.int({ min: 100, max: 200 });
+const INVITE_CREATED_AT = faker.date.anytime();
 const EXPECTED_INVITE_EXPIRES_AT = new Date(
   INVITE_CREATED_AT.getTime() + INVITE_EXPIRY_SECONDS * 1_000,
 );
 
-type MembersRepositoryMock = Pick<
-  jest.Mocked<IMembersRepositoryInterface>,
-  | 'inviteUsers'
-  | 'resendInvite'
-  | 'findAuthorizedMembersOrFail'
-  | 'findSelfMembershipOrFail'
->;
-
-const membersRepositoryMock: MembersRepositoryMock = {
+const membersRepositoryMock = {
   inviteUsers: jest.fn(),
   resendInvite: jest.fn(),
   findAuthorizedMembersOrFail: jest.fn(),
   findSelfMembershipOrFail: jest.fn(),
-};
+} as jest.MockedObjectDeep<IMembersRepository>;
 
 const configurationServiceMock: jest.Mocked<IConfigurationService> = {
   get: jest.fn(),
@@ -55,73 +47,74 @@ describe('MembersService', () => {
     jest.resetAllMocks();
     mockConfiguration();
     service = new MembersService(
-      membersRepositoryMock as MembersRepositoryMock &
-        IMembersRepositoryInterface,
+      membersRepositoryMock,
       configurationServiceMock,
     );
   });
 
   describe('inviteUser', () => {
-    it('sets the configured invite expiration', async () => {
+    beforeEach(() => {
       jest.useFakeTimers().setSystemTime(INVITE_CREATED_AT);
-      try {
-        const authPayload = new AuthPayload(
-          oidcAuthPayloadDtoBuilder().build(),
-        );
-        const spaceId = faker.number.int({ min: 1 });
-        const users = [
-          {
-            email: faker.internet.email().toLowerCase(),
-            name: faker.person.firstName(),
-            role: 'MEMBER' as const,
-          },
-        ];
+    });
 
-        membersRepositoryMock.inviteUsers.mockResolvedValue([]);
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
-        await service.inviteUser({
-          authPayload,
-          spaceId,
-          inviteUsersDto: { users },
-        });
+    it('sets the configured invite expiration', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const users = [
+        {
+          email: faker.internet.email().toLowerCase(),
+          name: faker.person.firstName(),
+          role: 'MEMBER' as const,
+        },
+      ];
 
-        expect(membersRepositoryMock.inviteUsers).toHaveBeenCalledWith({
-          authPayload,
-          spaceId,
-          users,
-          inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
-        });
-      } finally {
-        jest.useRealTimers();
-      }
+      membersRepositoryMock.inviteUsers.mockResolvedValue([]);
+
+      await service.inviteUser({
+        authPayload,
+        spaceId,
+        inviteUsersDto: { users },
+      });
+
+      expect(membersRepositoryMock.inviteUsers).toHaveBeenCalledWith({
+        authPayload,
+        spaceId,
+        users,
+        inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
+      });
     });
   });
 
   describe('resendInvite', () => {
-    it('resets the configured invite expiration', async () => {
+    beforeEach(() => {
       jest.useFakeTimers().setSystemTime(INVITE_CREATED_AT);
-      try {
-        const authPayload = new AuthPayload(
-          oidcAuthPayloadDtoBuilder().build(),
-        );
-        const spaceId = faker.number.int({ min: 1 });
-        const email = faker.internet.email().toLowerCase();
+    });
 
-        await service.resendInvite({
-          authPayload,
-          spaceId,
-          resendInviteDto: { email },
-        });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
-        expect(membersRepositoryMock.resendInvite).toHaveBeenCalledWith({
-          authPayload,
-          spaceId,
-          email,
-          inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
-        });
-      } finally {
-        jest.useRealTimers();
-      }
+    it('resets the configured invite expiration', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const email = faker.internet.email().toLowerCase();
+
+      await service.resendInvite({
+        authPayload,
+        spaceId,
+        resendInviteDto: { email },
+      });
+
+      expect(membersRepositoryMock.resendInvite).toHaveBeenCalledWith({
+        authPayload,
+        spaceId,
+        email,
+        inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
+      });
     });
   });
 

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -2,64 +2,466 @@
 
 import { faker } from '@faker-js/faker';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
-import { oidcAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import {
+  oidcAuthPayloadDtoBuilder,
+  siweAuthPayloadDtoBuilder,
+} from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { MembersService } from '@/modules/spaces/routes/members.service';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import { userBuilder } from '@/modules/users/datasources/entities/__tests__/users.entity.db.builder';
-import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
+import { type IMembersRepository as IMembersRepositoryInterface } from '@/modules/users/domain/members.repository.interface';
 
 const MAX_INVITES = 10;
+const INVITE_EXPIRY_SECONDS = 7 * 24 * 60 * 60;
+const INVITE_CREATED_AT = new Date('2026-04-24T00:00:00.000Z');
+const EXPECTED_INVITE_EXPIRES_AT = new Date(
+  INVITE_CREATED_AT.getTime() + INVITE_EXPIRY_SECONDS * 1_000,
+);
 
-const membersRepositoryMock = {
-  findAuthorizedMembersOrFail: jest.fn(),
+type MembersRepositoryMock = Pick<
+  jest.Mocked<IMembersRepositoryInterface>,
+  | 'inviteUsers'
+  | 'resendInvite'
+  | 'findAuthorizedMembersOrFail'
+  | 'findSelfMembershipOrFail'
+>;
+
+const membersRepositoryMock: MembersRepositoryMock = {
   inviteUsers: jest.fn(),
-} as jest.MockedObjectDeep<IMembersRepository>;
+  resendInvite: jest.fn(),
+  findAuthorizedMembersOrFail: jest.fn(),
+  findSelfMembershipOrFail: jest.fn(),
+};
 
-const configurationServiceMock = {
+const configurationServiceMock: jest.Mocked<IConfigurationService> = {
+  get: jest.fn(),
   getOrThrow: jest.fn(),
-} as jest.MockedObjectDeep<IConfigurationService>;
+};
+
+function mockConfiguration(): void {
+  configurationServiceMock.get.mockReturnValue(undefined);
+  configurationServiceMock.getOrThrow.mockImplementation((key: string) => {
+    if (key === 'spaces.maxInvites') return MAX_INVITES;
+    if (key === 'spaces.inviteExpirySeconds') return INVITE_EXPIRY_SECONDS;
+    throw new Error(`Unexpected configuration key: ${key}`);
+  });
+}
 
 describe('MembersService', () => {
   let service: MembersService;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    configurationServiceMock.getOrThrow.mockReturnValue(MAX_INVITES);
+    mockConfiguration();
     service = new MembersService(
-      membersRepositoryMock,
+      membersRepositoryMock as MembersRepositoryMock &
+        IMembersRepositoryInterface,
       configurationServiceMock,
     );
   });
 
+  describe('inviteUser', () => {
+    it('sets the configured invite expiration', async () => {
+      jest.useFakeTimers().setSystemTime(INVITE_CREATED_AT);
+      try {
+        const authPayload = new AuthPayload(
+          oidcAuthPayloadDtoBuilder().build(),
+        );
+        const spaceId = faker.number.int({ min: 1 });
+        const users = [
+          {
+            email: faker.internet.email().toLowerCase(),
+            name: faker.person.firstName(),
+            role: 'MEMBER' as const,
+          },
+        ];
+
+        membersRepositoryMock.inviteUsers.mockResolvedValue([]);
+
+        await service.inviteUser({
+          authPayload,
+          spaceId,
+          inviteUsersDto: { users },
+        });
+
+        expect(membersRepositoryMock.inviteUsers).toHaveBeenCalledWith({
+          authPayload,
+          spaceId,
+          users,
+          inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('resendInvite', () => {
+    it('resets the configured invite expiration', async () => {
+      jest.useFakeTimers().setSystemTime(INVITE_CREATED_AT);
+      try {
+        const authPayload = new AuthPayload(
+          oidcAuthPayloadDtoBuilder().build(),
+        );
+        const spaceId = faker.number.int({ min: 1 });
+        const userId = faker.number.int({ min: 1 });
+
+        await service.resendInvite({ authPayload, spaceId, userId });
+
+        expect(membersRepositoryMock.resendInvite).toHaveBeenCalledWith({
+          authPayload,
+          spaceId,
+          userId,
+          inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
   describe('get', () => {
-    it('should hide stored email for invited members', async () => {
+    it('returns pending invites with email for active admins', async () => {
+      const adminUserId = faker.number.int({ min: 1 });
+      const authPayload = new AuthPayload(
+        siweAuthPayloadDtoBuilder().with('sub', String(adminUserId)).build(),
+      );
+      const activeEmail = faker.internet.email().toLowerCase();
+      const invitedEmail = faker.internet.email().toLowerCase();
+      const activeMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('id', adminUserId)
+            .with('email', activeEmail)
+            .with('status', 'ACTIVE')
+            .build(),
+        )
+        .with('status', 'ACTIVE')
+        .with('role', 'ADMIN')
+        .build();
+      const invitedMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('email', invitedEmail)
+            .with('status', 'PENDING')
+            .build(),
+        )
+        .with('status', 'INVITED')
+        .build();
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        activeMember,
+        invitedMember,
+      ]);
+
+      await expect(
+        service.get({
+          authPayload,
+          spaceId: faker.number.int(),
+        }),
+      ).resolves.toEqual({
+        members: [
+          expect.objectContaining({
+            id: activeMember.id,
+            status: 'ACTIVE',
+            user: expect.objectContaining({
+              id: activeMember.user.id,
+              email: activeEmail,
+            }),
+          }),
+          expect.objectContaining({
+            id: invitedMember.id,
+            status: 'INVITED',
+            user: expect.objectContaining({
+              id: invitedMember.user.id,
+              email: invitedEmail,
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('hides pending invites from non-admin members', async () => {
+      const memberUserId = faker.number.int({ min: 1 });
+      const authPayload = new AuthPayload(
+        siweAuthPayloadDtoBuilder().with('sub', String(memberUserId)).build(),
+      );
+      const activeEmail = faker.internet.email().toLowerCase();
+      const activeMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('id', memberUserId)
+            .with('email', activeEmail)
+            .with('status', 'ACTIVE')
+            .build(),
+        )
+        .with('status', 'ACTIVE')
+        .with('role', 'MEMBER')
+        .build();
+      const invitedMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('email', faker.internet.email().toLowerCase())
+            .with('status', 'PENDING')
+            .build(),
+        )
+        .with('status', 'INVITED')
+        .build();
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        activeMember,
+        invitedMember,
+      ]);
+
+      await expect(
+        service.get({
+          authPayload,
+          spaceId: faker.number.int(),
+        }),
+      ).resolves.toEqual({
+        members: [
+          expect.objectContaining({
+            id: activeMember.id,
+            status: 'ACTIVE',
+            user: expect.objectContaining({
+              id: activeMember.user.id,
+              email: activeEmail,
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('returns invitee email to active admins', async () => {
+      const adminUserId = faker.number.int({ min: 1 });
+      const invitedEmail = faker.internet.email().toLowerCase();
+      const authPayload = new AuthPayload(
+        siweAuthPayloadDtoBuilder().with('sub', String(adminUserId)).build(),
+      );
+      const adminMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('id', adminUserId)
+            .with('status', 'ACTIVE')
+            .build(),
+        )
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      const invitedMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('email', invitedEmail)
+            .with('status', 'PENDING')
+            .build(),
+        )
+        .with('status', 'INVITED')
+        .build();
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        adminMember,
+        invitedMember,
+      ]);
+
+      await expect(
+        service.get({ authPayload, spaceId: faker.number.int() }),
+      ).resolves.toEqual({
+        members: expect.arrayContaining([
+          expect.objectContaining({
+            id: invitedMember.id,
+            user: expect.objectContaining({ email: invitedEmail }),
+          }),
+        ]),
+      });
+    });
+
+    it('does not return invitee email to non-admin members', async () => {
+      const memberUserId = faker.number.int({ min: 1 });
+      const invitedEmail = faker.internet.email().toLowerCase();
+      const authPayload = new AuthPayload(
+        siweAuthPayloadDtoBuilder().with('sub', String(memberUserId)).build(),
+      );
+      const activeMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('id', memberUserId)
+            .with('status', 'ACTIVE')
+            .build(),
+        )
+        .with('role', 'MEMBER')
+        .with('status', 'ACTIVE')
+        .build();
+      const invitedMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('email', invitedEmail)
+            .with('status', 'PENDING')
+            .build(),
+        )
+        .with('status', 'INVITED')
+        .build();
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        activeMember,
+        invitedMember,
+      ]);
+
+      const result = await service.get({
+        authPayload,
+        spaceId: faker.number.int(),
+      });
+
+      expect(result.members).toEqual([
+        expect.objectContaining({ id: activeMember.id }),
+      ]);
+      expect(result.members).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: invitedMember.id,
+            user: expect.objectContaining({ email: invitedEmail }),
+          }),
+        ]),
+      );
+    });
+
+    it('preserves null email for active members without a stored email', async () => {
+      const userId = faker.number.int({ min: 1 });
+      const authPayload = new AuthPayload(
+        siweAuthPayloadDtoBuilder().with('sub', String(userId)).build(),
+      );
+      const activeMember = memberBuilder()
+        .with(
+          'user',
+          userBuilder()
+            .with('id', userId)
+            .with('email', null)
+            .with('status', 'ACTIVE')
+            .build(),
+        )
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        activeMember,
+      ]);
+
+      await expect(
+        service.get({
+          authPayload,
+          spaceId: faker.number.int(),
+        }),
+      ).resolves.toEqual({
+        members: [
+          expect.objectContaining({
+            id: activeMember.id,
+            status: 'ACTIVE',
+            user: expect.objectContaining({
+              id: activeMember.user.id,
+              email: null,
+            }),
+          }),
+        ],
+      });
+    });
+  });
+
+  describe('getSelfMembership', () => {
+    it('returns the stored email for active memberships', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
       const email = faker.internet.email().toLowerCase();
       const member = memberBuilder()
-        .with('status', 'INVITED')
+        .with(
+          'user',
+          userBuilder().with('email', email).with('status', 'ACTIVE').build(),
+        )
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findSelfMembershipOrFail.mockResolvedValue(member);
+
+      await expect(
+        service.getSelfMembership({
+          authPayload,
+          spaceId: faker.number.int(),
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          id: member.id,
+          status: 'ACTIVE',
+          user: expect.objectContaining({
+            id: member.user.id,
+            email,
+          }),
+        }),
+      );
+    });
+
+    it('returns the stored email for invited self memberships', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const email = faker.internet.email().toLowerCase();
+      const member = memberBuilder()
         .with(
           'user',
           userBuilder().with('email', email).with('status', 'PENDING').build(),
         )
+        .with('status', 'INVITED')
         .build();
+
+      membersRepositoryMock.findSelfMembershipOrFail.mockResolvedValue(member);
+
+      await expect(
+        service.getSelfMembership({
+          authPayload,
+          spaceId: faker.number.int(),
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          id: member.id,
+          status: 'INVITED',
+          user: expect.objectContaining({
+            id: member.user.id,
+            email,
+          }),
+        }),
+      );
+    });
+
+    it('preserves null for active memberships without a stored email', async () => {
       const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
-      const spaceId = faker.number.int({ min: 1 });
+      const member = memberBuilder()
+        .with(
+          'user',
+          userBuilder().with('email', null).with('status', 'ACTIVE').build(),
+        )
+        .with('status', 'ACTIVE')
+        .build();
 
-      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
-        member,
-      ]);
+      membersRepositoryMock.findSelfMembershipOrFail.mockResolvedValue(member);
 
-      await expect(service.get({ authPayload, spaceId })).resolves.toEqual({
-        members: [
-          {
-            ...member,
-            user: {
-              ...member.user,
-              email: null,
-            },
-          },
-        ],
-      });
+      await expect(
+        service.getSelfMembership({
+          authPayload,
+          spaceId: faker.number.int(),
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          id: member.id,
+          status: 'ACTIVE',
+          user: expect.objectContaining({
+            id: member.user.id,
+            email: null,
+          }),
+        }),
+      );
     });
   });
 });

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -105,14 +105,18 @@ describe('MembersService', () => {
           oidcAuthPayloadDtoBuilder().build(),
         );
         const spaceId = faker.number.int({ min: 1 });
-        const userId = faker.number.int({ min: 1 });
+        const email = faker.internet.email().toLowerCase();
 
-        await service.resendInvite({ authPayload, spaceId, userId });
+        await service.resendInvite({
+          authPayload,
+          spaceId,
+          resendInviteDto: { email },
+        });
 
         expect(membersRepositoryMock.resendInvite).toHaveBeenCalledWith({
           authPayload,
           spaceId,
-          userId,
+          email,
           inviteExpiresAt: EXPECTED_INVITE_EXPIRES_AT,
         });
       } finally {

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -11,6 +11,7 @@ import type {
   MemberDto,
   MembersDto,
 } from '@/modules/spaces/routes/entities/members.dto.entity';
+import type { ResendInviteDto } from '@/modules/spaces/routes/entities/resend-invite.dto.entity';
 import type { UpdateMemberAliasDto } from '@/modules/spaces/routes/entities/update-member-name.dto.entity';
 import type { UpdateRoleDto } from '@/modules/spaces/routes/entities/update-role.dto.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
@@ -53,12 +54,13 @@ export class MembersService {
   public async resendInvite(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    userId: User['id'];
+    resendInviteDto: ResendInviteDto;
   }): Promise<void> {
     return await this.membersRepository.resendInvite({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
-      userId: args.userId,
+      address: args.resendInviteDto.address,
+      email: args.resendInviteDto.email,
       inviteExpiresAt: this.getInviteExpiresAt(),
     });
   }
@@ -115,10 +117,13 @@ export class MembersService {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<MemberDto> {
-    return await this.membersRepository.findSelfMembershipOrFail({
+    const member = await this.membersRepository.findSelfMembershipOrFail({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
+
+    // Self-view can expose the caller's own invited email.
+    return member;
   }
 
   public async updateRole(args: {

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -2,6 +2,7 @@
 import { ConflictException, Inject } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { AcceptInviteDto } from '@/modules/spaces/routes/entities/accept-invite.dto.entity';
 import type { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
@@ -12,11 +13,13 @@ import type {
 } from '@/modules/spaces/routes/entities/members.dto.entity';
 import type { UpdateMemberAliasDto } from '@/modules/spaces/routes/entities/update-member-name.dto.entity';
 import type { UpdateRoleDto } from '@/modules/spaces/routes/entities/update-role.dto.entity';
+import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 
 export class MembersService {
   private readonly maxInvites: number;
+  private readonly inviteExpirySeconds: number;
 
   public constructor(
     @Inject(IMembersRepository)
@@ -26,6 +29,9 @@ export class MembersService {
   ) {
     this.maxInvites =
       this.configurationService.getOrThrow<number>('spaces.maxInvites');
+    this.inviteExpirySeconds = this.configurationService.getOrThrow<number>(
+      'spaces.inviteExpirySeconds',
+    );
   }
 
   public async inviteUser(args: {
@@ -39,7 +45,21 @@ export class MembersService {
     return await this.membersRepository.inviteUsers({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
+      inviteExpiresAt: this.getInviteExpiresAt(),
       users: args.inviteUsersDto.users,
+    });
+  }
+
+  public async resendInvite(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+    userId: User['id'];
+  }): Promise<void> {
+    return await this.membersRepository.resendInvite({
+      authPayload: args.authPayload,
+      spaceId: args.spaceId,
+      userId: args.userId,
+      inviteExpiresAt: this.getInviteExpiresAt(),
     });
   }
 
@@ -69,20 +89,25 @@ export class MembersService {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<MembersDto> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+    const members = await this.membersRepository.findAuthorizedMembersOrFail({
+      authPayload: args.authPayload,
+      spaceId: args.spaceId,
+    });
+    const isAdmin = members.some((member) => {
+      return (
+        member.user.id === userId &&
+        member.status === 'ACTIVE' &&
+        member.role === 'ADMIN'
+      );
+    });
+
     return {
-      members: (
-        await this.membersRepository.findAuthorizedMembersOrFail({
-          authPayload: args.authPayload,
-          spaceId: args.spaceId,
-        })
-      ).map((member) => ({
-        ...member,
-        user: {
-          ...member.user,
-          // Only expose email once the member accepted the invite.
-          email: member.status === 'ACTIVE' ? member.user.email : null,
-        },
-      })),
+      members: members
+        .filter((member) => isAdmin || member.status === 'ACTIVE')
+        .map((member) =>
+          this.toMemberDto(member, { includeInvitedEmail: isAdmin }),
+        ),
     };
   }
 
@@ -142,5 +167,25 @@ export class MembersService {
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
+  }
+
+  private toMemberDto(
+    member: Member,
+    options: { includeInvitedEmail?: boolean } = {},
+  ): MemberDto {
+    return {
+      ...member,
+      user: {
+        ...member.user,
+        email:
+          member.status === 'ACTIVE' || options.includeInvitedEmail === true
+            ? member.user.email
+            : null,
+      },
+    };
+  }
+
+  private getInviteExpiresAt(): Date {
+    return new Date(Date.now() + this.inviteExpirySeconds * 1_000);
   }
 }

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -59,8 +59,9 @@ export class MembersService {
     return await this.membersRepository.resendInvite({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
-      address: args.resendInviteDto.address,
-      email: args.resendInviteDto.email,
+      ...(args.resendInviteDto.email
+        ? { email: args.resendInviteDto.email }
+        : { address: args.resendInviteDto.address }),
       inviteExpiresAt: this.getInviteExpiresAt(),
     });
   }
@@ -122,8 +123,7 @@ export class MembersService {
       spaceId: args.spaceId,
     });
 
-    // Self-view can expose the caller's own invited email.
-    return member;
+    return this.toMemberDto(member);
   }
 
   public async updateRole(args: {

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ConflictException, Inject } from '@nestjs/common';
+import { BadRequestException, ConflictException, Inject } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
@@ -56,14 +56,27 @@ export class MembersService {
     spaceId: Space['id'];
     resendInviteDto: ResendInviteDto;
   }): Promise<void> {
-    return await this.membersRepository.resendInvite({
-      authPayload: args.authPayload,
-      spaceId: args.spaceId,
-      ...(args.resendInviteDto.email
-        ? { email: args.resendInviteDto.email }
-        : { address: args.resendInviteDto.address }),
-      inviteExpiresAt: this.getInviteExpiresAt(),
-    });
+    if (args.resendInviteDto.email) {
+      return await this.membersRepository.resendInvite({
+        authPayload: args.authPayload,
+        spaceId: args.spaceId,
+        email: args.resendInviteDto.email,
+        inviteExpiresAt: this.getInviteExpiresAt(),
+      });
+    }
+
+    if (args.resendInviteDto.address) {
+      return await this.membersRepository.resendInvite({
+        authPayload: args.authPayload,
+        spaceId: args.spaceId,
+        address: args.resendInviteDto.address,
+        inviteExpiresAt: this.getInviteExpiresAt(),
+      });
+    }
+
+    throw new BadRequestException(
+      'Exactly one of address or email is required.',
+    );
   }
 
   public async acceptInvite(args: {

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { BadRequestException, ConflictException, Inject } from '@nestjs/common';
+import { ConflictException, Inject } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
@@ -73,10 +73,6 @@ export class MembersService {
         inviteExpiresAt: this.getInviteExpiresAt(),
       });
     }
-
-    throw new BadRequestException(
-      'Exactly one of address or email is required.',
-    );
   }
 
   public async acceptInvite(args: {

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -89,6 +89,10 @@ describe('SpacesService', () => {
           safeCount: 3,
         },
       ]);
+      expect(membersRepositoryMock.find).toHaveBeenCalledWith({
+        where: { user: { id: userId }, status: expect.anything() },
+        relations: ['space'],
+      });
     });
 
     it.each([

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -276,7 +276,9 @@ describe('SpacesService', () => {
         .build();
 
       membersRepositoryMock.find.mockResolvedValue([member]);
-      spacesRepositoryMock.find.mockResolvedValue([space]);
+      spacesRepositoryMock.find.mockResolvedValue([
+        spaceBuilder().with('id', space.id).with('members', [member]).build(),
+      ]);
 
       const result = await service.getActiveOrInvitedSpace(
         space.id,
@@ -299,7 +301,9 @@ describe('SpacesService', () => {
         .build();
 
       membersRepositoryMock.find.mockResolvedValue([member]);
-      spacesRepositoryMock.find.mockResolvedValue([space]);
+      spacesRepositoryMock.find.mockResolvedValue([
+        spaceBuilder().with('id', space.id).with('members', [member]).build(),
+      ]);
 
       await expect(
         service.getActiveOrInvitedSpace(999999, authPayload),

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -145,6 +145,57 @@ describe('SpacesService', () => {
       expect(result[0].safeCount).toBe(0);
     });
 
+    it('should hide invited members from non-admins', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const userId = Number(authPayload.sub);
+      const space = spaceBuilder().build();
+      const callerMember = memberBuilder()
+        .with('user', userBuilder().with('id', userId).build())
+        .with('space', space)
+        .with('role', 'MEMBER')
+        .with('status', 'ACTIVE')
+        .build();
+      const activeMember = memberBuilder().with('status', 'ACTIVE').build();
+      const invitedMember = memberBuilder().with('status', 'INVITED').build();
+
+      membersRepositoryMock.find.mockResolvedValue([callerMember]);
+      spacesRepositoryMock.find.mockResolvedValue([
+        spaceBuilder()
+          .with('id', space.id)
+          .with('members', [callerMember, activeMember, invitedMember])
+          .build(),
+      ]);
+
+      const result = await service.getActiveOrInvitedSpaces(authPayload);
+
+      expect(result[0].members).toEqual([callerMember, activeMember]);
+    });
+
+    it('should show invited members to active admins', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const userId = Number(authPayload.sub);
+      const space = spaceBuilder().build();
+      const adminMember = memberBuilder()
+        .with('user', userBuilder().with('id', userId).build())
+        .with('space', space)
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      const invitedMember = memberBuilder().with('status', 'INVITED').build();
+
+      membersRepositoryMock.find.mockResolvedValue([adminMember]);
+      spacesRepositoryMock.find.mockResolvedValue([
+        spaceBuilder()
+          .with('id', space.id)
+          .with('members', [adminMember, invitedMember])
+          .build(),
+      ]);
+
+      const result = await service.getActiveOrInvitedSpaces(authPayload);
+
+      expect(result[0].members).toEqual([adminMember, invitedMember]);
+    });
+
     it.each([
       ['SIWE', siweAuthPayloadDtoBuilder] as const,
       ['OIDC', oidcAuthPayloadDtoBuilder] as const,

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -71,9 +71,26 @@ export class SpacesService {
     return spaces.map((space) => ({
       id: space.id,
       name: space.name,
-      members: space.members,
+      members: this.getVisibleMembersForUser(space.members ?? [], userId),
       safeCount: space.safes?.length ?? 0,
     }));
+  }
+
+  private getVisibleMembersForUser(
+    members: Space['members'],
+    userId: number,
+  ): Space['members'] {
+    const isActiveAdmin = members.some((member) => {
+      return (
+        member.user.id === userId &&
+        member.status === 'ACTIVE' &&
+        member.role === 'ADMIN'
+      );
+    });
+
+    return members.filter((member) => {
+      return isActiveAdmin || member.status === 'ACTIVE';
+    });
   }
 
   public async getActiveOrInvitedSpace(

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -71,7 +71,7 @@ export class SpacesService {
     return spaces.map((space) => ({
       id: space.id,
       name: space.name,
-      members: this.getVisibleMembersForUser(space.members ?? [], userId),
+      members: this.getVisibleMembersForUser(space.members, userId),
       safeCount: space.safes?.length ?? 0,
     }));
   }

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -68,14 +68,12 @@ export class SpacesService {
       relations: { members: { user: true }, safes: true },
     });
 
-    return spaces.map((space) => {
-      return {
-        id: space.id,
-        name: space.name,
-        members: space.members,
-        safeCount: space.safes?.length ?? 0,
-      };
-    });
+    return spaces.map((space) => ({
+      id: space.id,
+      name: space.name,
+      members: space.members,
+      safeCount: space.safes?.length ?? 0,
+    }));
   }
 
   public async getActiveOrInvitedSpace(

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -60,6 +60,7 @@ export class SpacesService {
           name: true,
           invitedBy: true,
           status: true,
+          inviteExpiresAt: true,
           user: { id: true },
         },
         safes: { id: true },
@@ -67,12 +68,14 @@ export class SpacesService {
       relations: { members: { user: true }, safes: true },
     });
 
-    return spaces.map((space) => ({
-      id: space.id,
-      name: space.name,
-      members: space.members,
-      safeCount: space.safes?.length ?? 0,
-    }));
+    return spaces.map((space) => {
+      return {
+        id: space.id,
+        name: space.name,
+        members: space.members,
+        safeCount: space.safes?.length ?? 0,
+      };
+    });
   }
 
   public async getActiveOrInvitedSpace(

--- a/src/modules/users/__tests__/test.users.module.ts
+++ b/src/modules/users/__tests__/test.users.module.ts
@@ -17,10 +17,10 @@ import { IUsersRepository } from '@/modules/users/domain/users.repository.interf
         deleteWalletFromUser: jest.fn(),
         findByWalletAddressOrFail: jest.fn(),
         findByWalletAddress: jest.fn(),
+        findOrCreateInviteeByEmail: jest.fn(),
         // Plain functions (not jest.fn) so they survive jest.resetAllMocks()
         // in tests that call getAccessToken → findOrCreate*.
         findOrCreateByWalletAddress: (): Promise<number> => Promise.resolve(1),
-        findOrCreateInviteeByEmail: (): Promise<number> => Promise.resolve(1),
         findOrCreateByExtUserIdWithEmail: (): Promise<number> =>
           Promise.resolve(1),
         findEmailById: jest.fn().mockResolvedValue(undefined),

--- a/src/modules/users/__tests__/test.users.module.ts
+++ b/src/modules/users/__tests__/test.users.module.ts
@@ -20,6 +20,7 @@ import { IUsersRepository } from '@/modules/users/domain/users.repository.interf
         // Plain functions (not jest.fn) so they survive jest.resetAllMocks()
         // in tests that call getAccessToken → findOrCreate*.
         findOrCreateByWalletAddress: (): Promise<number> => Promise.resolve(1),
+        findOrCreateInviteeByEmail: jest.fn().mockResolvedValue(1),
         findOrCreateByExtUserIdWithEmail: (): Promise<number> =>
           Promise.resolve(1),
         findEmailById: jest.fn().mockResolvedValue(undefined),

--- a/src/modules/users/__tests__/test.users.module.ts
+++ b/src/modules/users/__tests__/test.users.module.ts
@@ -20,7 +20,7 @@ import { IUsersRepository } from '@/modules/users/domain/users.repository.interf
         // Plain functions (not jest.fn) so they survive jest.resetAllMocks()
         // in tests that call getAccessToken → findOrCreate*.
         findOrCreateByWalletAddress: (): Promise<number> => Promise.resolve(1),
-        findOrCreateInviteeByEmail: jest.fn().mockResolvedValue(1),
+        findOrCreateInviteeByEmail: (): Promise<number> => Promise.resolve(1),
         findOrCreateByExtUserIdWithEmail: (): Promise<number> =>
           Promise.resolve(1),
         findEmailById: jest.fn().mockResolvedValue(undefined),
@@ -37,6 +37,7 @@ import { IUsersRepository } from '@/modules/users/domain/users.repository.interf
         findOrFail: jest.fn(),
         find: jest.fn(),
         inviteUsers: jest.fn(),
+        resendInvite: jest.fn(),
         acceptInvite: jest.fn(),
         declineInvite: jest.fn(),
         findAuthorizedMembersOrFail: jest.fn(),

--- a/src/modules/users/datasources/entities/__tests__/member.entity.db.builder.ts
+++ b/src/modules/users/datasources/entities/__tests__/member.entity.db.builder.ts
@@ -19,6 +19,7 @@ export function memberBuilder(): IBuilder<Member> {
     .with('role', 'ADMIN')
     .with('status', 'ACTIVE')
     .with('invitedBy', getAddress(faker.finance.ethereumAddress()))
+    .with('inviteExpiresAt', null)
     .with('createdAt', new Date())
     .with('updatedAt', new Date());
 }

--- a/src/modules/users/datasources/entities/member.entity.db.ts
+++ b/src/modules/users/datasources/entities/member.entity.db.ts
@@ -88,6 +88,13 @@ export class Member implements DomainMember {
   invitedBy!: Address | null;
 
   @Column({
+    name: 'invite_expires_at',
+    type: 'timestamp with time zone',
+    nullable: true,
+  })
+  inviteExpiresAt!: Date | null;
+
+  @Column({
     name: 'created_at',
     type: 'timestamp with time zone',
     default: () => 'CURRENT_TIMESTAMP',

--- a/src/modules/users/domain/entities/invitation.entity.ts
+++ b/src/modules/users/domain/entities/invitation.entity.ts
@@ -4,20 +4,9 @@ import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 
-type InvitationIdentifier = {
-  address?: Address;
-  email?: string;
-};
-
-export type AddressInvitationIdentifier = InvitationIdentifier &
-  Required<Pick<InvitationIdentifier, 'address'>> & {
-    email?: never;
-  };
-
-export type EmailInvitationIdentifier = InvitationIdentifier &
-  Required<Pick<InvitationIdentifier, 'email'>> & {
-    address?: never;
-  };
+export type InvitationIdentifier =
+  | { address: Address; email?: never }
+  | { email: string; address?: never };
 
 export type Invitation = {
   userId?: User['id'];

--- a/src/modules/users/domain/entities/invitation.entity.ts
+++ b/src/modules/users/domain/entities/invitation.entity.ts
@@ -10,10 +10,14 @@ type InvitationIdentifier = {
 };
 
 export type AddressInvitationIdentifier = InvitationIdentifier &
-  Required<Pick<InvitationIdentifier, 'address'>>;
+  Required<Pick<InvitationIdentifier, 'address'>> & {
+    email?: never;
+  };
 
 export type EmailInvitationIdentifier = InvitationIdentifier &
-  Required<Pick<InvitationIdentifier, 'email'>>;
+  Required<Pick<InvitationIdentifier, 'email'>> & {
+    address?: never;
+  };
 
 export type Invitation = {
   userId?: User['id'];

--- a/src/modules/users/domain/entities/invitation.entity.ts
+++ b/src/modules/users/domain/entities/invitation.entity.ts
@@ -4,7 +4,7 @@ import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 
 export type Invitation = {
-  userId: User['id'];
+  userId?: User['id'];
   spaceId: Space['id'];
   role: Member['role'];
   name: Member['name'];

--- a/src/modules/users/domain/entities/invitation.entity.ts
+++ b/src/modules/users/domain/entities/invitation.entity.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
@@ -9,4 +10,5 @@ export type Invitation = {
   name: Member['name'];
   status: Member['status'];
   invitedBy: Member['invitedBy'];
+  inviteExpiresAt: Member['inviteExpiresAt'];
 };

--- a/src/modules/users/domain/entities/invitation.entity.ts
+++ b/src/modules/users/domain/entities/invitation.entity.ts
@@ -1,7 +1,19 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import type { Address } from 'viem';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
+
+type InvitationIdentifier = {
+  address?: Address;
+  email?: string;
+};
+
+export type AddressInvitationIdentifier = InvitationIdentifier &
+  Required<Pick<InvitationIdentifier, 'address'>>;
+
+export type EmailInvitationIdentifier = InvitationIdentifier &
+  Required<Pick<InvitationIdentifier, 'email'>>;
 
 export type Invitation = {
   userId?: User['id'];

--- a/src/modules/users/domain/entities/member.entity.ts
+++ b/src/modules/users/domain/entities/member.entity.ts
@@ -31,6 +31,7 @@ export const MemberSchema: z.ZodType<
     role: keyof typeof MemberRole;
     status: keyof typeof MemberStatus;
     invitedBy: Address | null;
+    inviteExpiresAt: Date | null;
   }
 > = RowSchema.extend({
   user: z.lazy(() => UserSchema),
@@ -40,6 +41,7 @@ export const MemberSchema: z.ZodType<
   role: z.enum(getStringEnumKeys(MemberRole)),
   status: z.enum(getStringEnumKeys(MemberStatus)),
   invitedBy: AddressSchema.nullable() as z.ZodType<Address | null>,
+  inviteExpiresAt: z.date().nullable(),
 });
 
 export type Member = z.infer<typeof MemberSchema>;

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -670,7 +670,6 @@ describe('MembersRepository', () => {
 
       expect(invitation).toEqual([
         {
-          userId: expect.any(Number),
           spaceId,
           name: invitedName,
           role: 'MEMBER',
@@ -682,11 +681,10 @@ describe('MembersRepository', () => {
 
       await expect(
         dbUserRepo.findOneOrFail({
-          where: { id: invitation[0].userId },
+          where: { email: invitedEmail },
         }),
       ).resolves.toEqual(
         expect.objectContaining({
-          id: invitation[0].userId,
           email: invitedEmail,
           extUserId: null,
           status: 'PENDING',
@@ -704,11 +702,10 @@ describe('MembersRepository', () => {
         authPayload,
         authPayloadDto,
       } = await createSiweUser();
-      const existingUser = await dbUserRepo.insert({
+      await dbUserRepo.insert({
         status: 'ACTIVE',
         email: invitedEmail,
       });
-      const existingUserId = existingUser.identifiers[0].id as number;
       const space = await dbSpacesRepository.insert({
         name: spaceName,
         status: 'ACTIVE',
@@ -738,7 +735,6 @@ describe('MembersRepository', () => {
 
       expect(invitation).toEqual([
         {
-          userId: existingUserId,
           spaceId,
           name: invitedName,
           role: 'MEMBER',

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -36,6 +36,8 @@ import { UsersRepository } from '@/modules/users/domain/users.repository';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
 
+const INVITE_EXPIRES_AT = new Date('2026-05-01T00:00:00.000Z');
+
 const mockLoggingService = {
   debug: jest.fn(),
   error: jest.fn(),
@@ -286,6 +288,7 @@ describe('MembersRepository', () => {
         role: memberRole,
         status: memberStatus,
         invitedBy: memberInvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
     });
@@ -338,6 +341,7 @@ describe('MembersRepository', () => {
         role: memberRole,
         status: memberStatus,
         invitedBy: memberInvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
     });
@@ -410,6 +414,7 @@ describe('MembersRepository', () => {
           role: memberRole1,
           status: memberStatus1,
           invitedBy: member1InvitedBy,
+          inviteExpiresAt: null,
           updatedAt: expect.any(Date),
         },
         {
@@ -420,6 +425,7 @@ describe('MembersRepository', () => {
           role: memberRole2,
           status: memberStatus2,
           invitedBy: member2InvitedBy,
+          inviteExpiresAt: null,
           updatedAt: expect.any(Date),
         },
       ]);
@@ -491,6 +497,7 @@ describe('MembersRepository', () => {
           role: memberRole1,
           status: memberStatus1,
           invitedBy: member1InvitedBy,
+          inviteExpiresAt: null,
           updatedAt: expect.any(Date),
         },
         {
@@ -501,6 +508,7 @@ describe('MembersRepository', () => {
           role: memberRole2,
           status: member2Status,
           invitedBy: member2InvitedBy,
+          inviteExpiresAt: null,
           updatedAt: expect.any(Date),
         },
       ]);
@@ -554,6 +562,7 @@ describe('MembersRepository', () => {
       const member = await membersRepository.inviteUsers({
         authPayload,
         spaceId,
+        inviteExpiresAt: INVITE_EXPIRES_AT,
         users,
       });
 
@@ -566,6 +575,7 @@ describe('MembersRepository', () => {
             role: user.role,
             status: 'INVITED',
             invitedBy: authPayloadDto.signer_address,
+            inviteExpiresAt: INVITE_EXPIRES_AT,
           };
         }),
       );
@@ -602,6 +612,7 @@ describe('MembersRepository', () => {
       const member = await membersRepository.inviteUsers({
         authPayload,
         spaceId,
+        inviteExpiresAt: INVITE_EXPIRES_AT,
         users,
       });
 
@@ -614,9 +625,133 @@ describe('MembersRepository', () => {
             role: user.role,
             status: 'INVITED',
             invitedBy: null,
+            inviteExpiresAt: INVITE_EXPIRES_AT,
           };
         }),
       );
+    });
+
+    it('should invite an email by creating a pending stub user', async () => {
+      const spaceName = nameBuilder();
+      const adminName = nameBuilder();
+      const invitedEmail = faker.internet.email().toLowerCase();
+      const invitedName = faker.person.firstName();
+      const {
+        user: owner,
+        authPayload,
+        authPayloadDto,
+      } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: owner,
+        space: space.generatedMaps[0],
+        name: adminName,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      const invitation = await membersRepository.inviteUsers({
+        authPayload,
+        spaceId,
+        inviteExpiresAt: INVITE_EXPIRES_AT,
+        users: [
+          {
+            email: invitedEmail,
+            role: 'MEMBER',
+            name: invitedName,
+          },
+        ],
+      });
+
+      expect(invitation).toEqual([
+        {
+          userId: expect.any(Number),
+          spaceId,
+          name: invitedName,
+          role: 'MEMBER',
+          status: 'INVITED',
+          invitedBy: authPayloadDto.signer_address,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
+        },
+      ]);
+
+      await expect(
+        dbUserRepo.findOneOrFail({
+          where: { id: invitation[0].userId },
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          id: invitation[0].userId,
+          email: invitedEmail,
+          extUserId: null,
+          status: 'PENDING',
+        }),
+      );
+    });
+
+    it('should reuse an existing email-matched user for email invites', async () => {
+      const spaceName = nameBuilder();
+      const adminName = nameBuilder();
+      const invitedEmail = faker.internet.email().toLowerCase();
+      const invitedName = faker.person.firstName();
+      const {
+        user: owner,
+        authPayload,
+        authPayloadDto,
+      } = await createSiweUser();
+      const existingUser = await dbUserRepo.insert({
+        status: 'ACTIVE',
+        email: invitedEmail,
+      });
+      const existingUserId = existingUser.identifiers[0].id as number;
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: owner,
+        space: space.generatedMaps[0],
+        name: adminName,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      const invitation = await membersRepository.inviteUsers({
+        authPayload,
+        spaceId,
+        inviteExpiresAt: INVITE_EXPIRES_AT,
+        users: [
+          {
+            email: invitedEmail,
+            role: 'MEMBER',
+            name: invitedName,
+          },
+        ],
+      });
+
+      expect(invitation).toEqual([
+        {
+          userId: existingUserId,
+          spaceId,
+          name: invitedName,
+          role: 'MEMBER',
+          status: 'INVITED',
+          invitedBy: authPayloadDto.signer_address,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
+        },
+      ]);
+      await expect(
+        dbUserRepo.find({
+          where: { email: invitedEmail },
+        }),
+      ).resolves.toHaveLength(1);
     });
 
     it('should not create PENDING users for existing ones', async () => {
@@ -650,6 +785,7 @@ describe('MembersRepository', () => {
       await membersRepository.inviteUsers({
         authPayload,
         spaceId,
+        inviteExpiresAt: INVITE_EXPIRES_AT,
         users: [
           {
             address: memberWallet,
@@ -699,6 +835,7 @@ describe('MembersRepository', () => {
         membersRepository.inviteUsers({
           authPayload: new AuthPayload(),
           spaceId,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
           users,
         }),
       ).rejects.toThrow('Not authenticated');
@@ -736,6 +873,7 @@ describe('MembersRepository', () => {
         membersRepository.inviteUsers({
           authPayload,
           spaceId,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
           users,
         }),
       ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
@@ -773,6 +911,7 @@ describe('MembersRepository', () => {
         membersRepository.inviteUsers({
           authPayload,
           spaceId,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
           users,
         }),
       ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
@@ -815,6 +954,7 @@ describe('MembersRepository', () => {
         membersRepository.inviteUsers({
           authPayload,
           spaceId: targetSpaceId,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
           users,
         }),
       ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
@@ -836,6 +976,7 @@ describe('MembersRepository', () => {
         membersRepository.inviteUsers({
           authPayload,
           spaceId,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
           users,
         }),
       ).rejects.toThrow('Space not found.');
@@ -878,6 +1019,7 @@ describe('MembersRepository', () => {
         membersRepository.inviteUsers({
           authPayload: invitedAdminAuthPayload,
           spaceId,
+          inviteExpiresAt: INVITE_EXPIRES_AT,
           users,
         }),
       ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
@@ -944,6 +1086,7 @@ describe('MembersRepository', () => {
         role: memberRole,
         status: 'ACTIVE',
         invitedBy: memberInvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
       await expect(
@@ -1083,6 +1226,7 @@ describe('MembersRepository', () => {
         role: memberRole,
         status: 'ACTIVE',
         invitedBy: memberInvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
       await expect(
@@ -1097,6 +1241,59 @@ describe('MembersRepository', () => {
         status: 'ACTIVE', // No longer PENDING
         updatedAt: expect.any(Date),
       });
+    });
+
+    it('should not accept an expired invite', async () => {
+      const memberInvitedBy = getAddress(faker.finance.ethereumAddress());
+      const spaceName = nameBuilder();
+      const adminName = nameBuilder();
+      const memberName = nameBuilder();
+      const { user: admin } = await createSiweUser();
+      const { user, authPayload } = await createSiweUser({
+        status: 'PENDING',
+      });
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: admin,
+        space: space.generatedMaps[0],
+        name: adminName,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: memberInvitedBy,
+      });
+      const member = await dbMembersRepository.insert({
+        user,
+        space: space.generatedMaps[0],
+        name: memberName,
+        role: 'MEMBER',
+        status: 'INVITED',
+        invitedBy: memberInvitedBy,
+        inviteExpiresAt: new Date(Date.now() - 1_000),
+      });
+      const memberId = member.identifiers[0].id as Member['id'];
+
+      await expect(
+        membersRepository.acceptInvite({
+          authPayload,
+          spaceId,
+          payload: { name: nameBuilder() },
+        }),
+      ).rejects.toThrow('Invite has expired.');
+
+      await expect(
+        dbMembersRepository.findOneOrFail({
+          where: { id: memberId },
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          status: 'INVITED',
+          name: memberName,
+        }),
+      );
     });
 
     it('should not accept the invite if the user was not invited', async () => {
@@ -1333,6 +1530,7 @@ describe('MembersRepository', () => {
         role: memberRole,
         status: 'DECLINED',
         invitedBy: memberInvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
       await expect(
@@ -1605,6 +1803,7 @@ describe('MembersRepository', () => {
           role: memberRole,
           status: 'ACTIVE',
           invitedBy: memberInvitedBy,
+          inviteExpiresAt: null,
           updatedAt: expect.any(Date),
           user: {
             createdAt: expect.any(Date),
@@ -2010,6 +2209,7 @@ describe('MembersRepository', () => {
         role: 'ADMIN',
         status: 'ACTIVE',
         invitedBy: expect.any(String),
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
         space: expect.objectContaining({ id: spaceId }),
       });
@@ -2030,6 +2230,7 @@ describe('MembersRepository', () => {
         role: 'MEMBER',
         status: 'ACTIVE',
         invitedBy: expect.any(String),
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
         space: expect.objectContaining({ id: space2Id }),
       });
@@ -2399,6 +2600,7 @@ describe('MembersRepository', () => {
         role: 'MEMBER',
         status: 'ACTIVE',
         invitedBy: member2InvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
     });
@@ -2770,6 +2972,7 @@ describe('MembersRepository', () => {
         role: 'MEMBER',
         status: 'ACTIVE',
         invitedBy: signerMember2InvitedBy,
+        inviteExpiresAt: null,
         updatedAt: expect.any(Date),
       });
     });

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -36,7 +36,7 @@ import { UsersRepository } from '@/modules/users/domain/users.repository';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
 
-const INVITE_EXPIRES_AT = new Date('2026-05-01T00:00:00.000Z');
+const INVITE_EXPIRES_AT = faker.date.future();
 
 const mockLoggingService = {
   debug: jest.fn(),

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -35,8 +35,10 @@ export interface IMembersRepository {
   inviteUsers(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
+    inviteExpiresAt: Member['inviteExpiresAt'];
     users: Array<{
-      address: Address;
+      address?: Address;
+      email?: string;
       role: Member['role'];
       name: Member['name'];
     }>;
@@ -46,6 +48,13 @@ export interface IMembersRepository {
     authPayload: AuthPayload;
     spaceId: Space['id'];
     payload: Pick<Member, 'name'>;
+  }): Promise<void>;
+
+  resendInvite(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+    userId: User['id'];
+    inviteExpiresAt: Member['inviteExpiresAt'];
   }): Promise<void>;
 
   declineInvite(args: {

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -9,7 +9,11 @@ import type { Address } from 'viem';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
-import type { Invitation } from '@/modules/users/domain/entities/invitation.entity';
+import type {
+  AddressInvitationIdentifier,
+  EmailInvitationIdentifier,
+  Invitation,
+} from '@/modules/users/domain/entities/invitation.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 
@@ -50,13 +54,13 @@ export interface IMembersRepository {
     payload: Pick<Member, 'name'>;
   }): Promise<void>;
 
-  resendInvite(args: {
-    authPayload: AuthPayload;
-    spaceId: Space['id'];
-    address?: Address;
-    email?: string;
-    inviteExpiresAt: Member['inviteExpiresAt'];
-  }): Promise<void>;
+  resendInvite(
+    args: {
+      authPayload: AuthPayload;
+      spaceId: Space['id'];
+      inviteExpiresAt: Member['inviteExpiresAt'];
+    } & (AddressInvitationIdentifier | EmailInvitationIdentifier),
+  ): Promise<void>;
 
   declineInvite(args: {
     authPayload: AuthPayload;

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -10,8 +10,7 @@ import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.en
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import type {
-  AddressInvitationIdentifier,
-  EmailInvitationIdentifier,
+  InvitationIdentifier,
   Invitation,
 } from '@/modules/users/domain/entities/invitation.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
@@ -59,7 +58,7 @@ export interface IMembersRepository {
       authPayload: AuthPayload;
       spaceId: Space['id'];
       inviteExpiresAt: Member['inviteExpiresAt'];
-    } & (AddressInvitationIdentifier | EmailInvitationIdentifier),
+    } & InvitationIdentifier,
   ): Promise<void>;
 
   declineInvite(args: {

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -53,7 +53,8 @@ export interface IMembersRepository {
   resendInvite(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    userId: User['id'];
+    address?: Address;
+    email?: string;
     inviteExpiresAt: Member['inviteExpiresAt'];
   }): Promise<void>;
 

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { spaceBuilder } from '@/modules/spaces/domain/entities/__tests__/space.entity.db.builder';
+import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
+import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
+import { MemberStatus } from '@/modules/users/domain/entities/member.entity';
+import { MembersRepository } from '@/modules/users/domain/members.repository';
+import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import type { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
+
+const INVITE_EXPIRES_AT = new Date('2026-05-01T00:00:00.000Z');
+
+describe('MembersRepository', () => {
+  const usersRepositoryMock = {
+    findOrCreateInviteeByEmail: jest.fn(),
+    create: jest.fn(),
+    updateStatus: jest.fn(),
+  } as unknown as jest.MockedObjectDeep<IUsersRepository>;
+
+  const spacesRepositoryMock = {
+    findOneOrFail: jest.fn(),
+  } as unknown as jest.MockedObjectDeep<ISpacesRepository>;
+
+  const walletsRepositoryMock = {
+    find: jest.fn(),
+    create: jest.fn(),
+  } as unknown as jest.MockedObjectDeep<IWalletsRepository>;
+
+  let membersOrmRepository: {
+    createQueryBuilder: jest.Mock;
+    find: jest.Mock;
+    findOne: jest.Mock;
+    update: jest.Mock;
+  };
+  let queryBuilder: {
+    update: jest.Mock;
+    set: jest.Mock;
+    where: jest.Mock;
+    andWhere: jest.Mock;
+    execute: jest.Mock;
+  };
+  let entityManager: { insert: jest.Mock };
+  let postgresDatabaseService: jest.MockedObjectDeep<PostgresDatabaseService>;
+  let target: MembersRepository;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    queryBuilder = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      execute: jest.fn(),
+    };
+    membersOrmRepository = {
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      update: jest.fn(),
+    };
+    entityManager = {
+      insert: jest.fn(),
+    };
+    postgresDatabaseService = {
+      getRepository: jest.fn().mockResolvedValue(membersOrmRepository),
+      transaction: jest
+        .fn()
+        .mockImplementation(
+          async (
+            callback: (manager: typeof entityManager) => Promise<unknown>,
+          ) => {
+            return await callback(entityManager);
+          },
+        ),
+    } as unknown as jest.MockedObjectDeep<PostgresDatabaseService>;
+
+    target = new MembersRepository(
+      postgresDatabaseService,
+      usersRepositoryMock,
+      spacesRepositoryMock,
+      walletsRepositoryMock,
+    );
+  });
+
+  it('should invite email users via stub-user lookup and skip wallet lookup', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const spaceId = faker.number.int({ min: 1 });
+    const email = faker.internet.email().toLowerCase();
+    const name = faker.person.firstName();
+    const inviteeUserId = faker.number.int({ min: 1 });
+    const space = { id: spaceId } as unknown as Space;
+
+    spacesRepositoryMock.findOneOrFail.mockResolvedValue(space);
+    membersOrmRepository.findOne.mockResolvedValue({
+      id: faker.number.int({ min: 1 }),
+    });
+    usersRepositoryMock.findOrCreateInviteeByEmail.mockResolvedValue(
+      inviteeUserId,
+    );
+
+    const result = await target.inviteUsers({
+      authPayload,
+      spaceId,
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+      users: [{ email, name, role: 'MEMBER' }],
+    });
+
+    expect(walletsRepositoryMock.find).not.toHaveBeenCalled();
+    expect(usersRepositoryMock.findOrCreateInviteeByEmail).toHaveBeenCalledWith(
+      email,
+      entityManager,
+    );
+    expect(entityManager.insert).toHaveBeenCalledWith(expect.any(Function), {
+      user: { id: inviteeUserId },
+      space,
+      name,
+      role: 'MEMBER',
+      status: 'INVITED',
+      invitedBy: authPayloadDto.signer_address,
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+    });
+    expect(result).toEqual([
+      {
+        userId: inviteeUserId,
+        spaceId,
+        name,
+        role: 'MEMBER',
+        status: 'INVITED',
+        invitedBy: authPayloadDto.signer_address,
+        inviteExpiresAt: INVITE_EXPIRES_AT,
+      },
+    ]);
+  });
+
+  it('should reuse wallet lookup for address invites', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const spaceId = faker.number.int({ min: 1 });
+    const address = getAddress(faker.finance.ethereumAddress());
+    const inviteeUserId = faker.number.int({ min: 1 });
+    const space = { id: spaceId } as unknown as Space;
+
+    spacesRepositoryMock.findOneOrFail.mockResolvedValue(space);
+    membersOrmRepository.findOne.mockResolvedValue({
+      id: faker.number.int({ min: 1 }),
+    });
+    walletsRepositoryMock.find.mockResolvedValue([
+      { address, user: { id: inviteeUserId } },
+    ] as Array<Wallet>);
+
+    await target.inviteUsers({
+      authPayload,
+      spaceId,
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+      users: [{ address, name: faker.person.firstName(), role: 'ADMIN' }],
+    });
+
+    expect(
+      usersRepositoryMock.findOrCreateInviteeByEmail,
+    ).not.toHaveBeenCalled();
+    expect(walletsRepositoryMock.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relations: { user: true },
+      }),
+    );
+  });
+
+  it('should resend invitations by resetting status and expiration', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const spaceId = faker.number.int({ min: 1 });
+    const userId = faker.number.int({ min: 1 });
+
+    membersOrmRepository.find.mockResolvedValue([
+      {
+        user: { id: Number(authPayloadDto.sub) },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      },
+    ]);
+    queryBuilder.execute.mockResolvedValue({ affected: 1 });
+
+    await target.resendInvite({
+      authPayload,
+      spaceId,
+      userId,
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+    });
+
+    expect(queryBuilder.set).toHaveBeenCalledWith({
+      status: 'INVITED',
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+    });
+    expect(queryBuilder.where).toHaveBeenCalledWith('user_id = :userId', {
+      userId,
+    });
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('space_id = :spaceId', {
+      spaceId,
+    });
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'status IN (:...statuses)',
+      { statuses: [MemberStatus.INVITED, MemberStatus.DECLINED] },
+    );
+  });
+
+  it('should reject expired invites', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const inviteExpiresAt = new Date('2026-04-30T00:00:00.000Z');
+
+    jest.useFakeTimers().setSystemTime(new Date('2026-05-01T00:00:00.000Z'));
+    try {
+      spacesRepositoryMock.findOneOrFail.mockResolvedValue(
+        spaceBuilder()
+          .with('members', [
+            memberBuilder().with('inviteExpiresAt', inviteExpiresAt).build(),
+          ])
+          .build(),
+      );
+
+      await expect(
+        target.acceptInvite({
+          authPayload,
+          spaceId: faker.number.int({ min: 1 }),
+          payload: { name: faker.person.firstName() },
+        }),
+      ).rejects.toThrow('Invite has expired.');
+
+      expect(postgresDatabaseService.transaction).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -130,7 +130,6 @@ describe('MembersRepository', () => {
     });
     expect(result).toEqual([
       {
-        userId: inviteeUserId,
         spaceId,
         name,
         role: 'MEMBER',

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -291,6 +291,54 @@ describe('MembersRepository', () => {
     );
   });
 
+  it('should reject resend when caller is not an active admin', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const otherAdminUserId = Number(authPayloadDto.sub) + 1;
+
+    membersOrmRepository.find.mockResolvedValue([
+      {
+        user: { id: otherAdminUserId },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      },
+    ]);
+
+    await expect(
+      target.resendInvite({
+        authPayload,
+        spaceId: faker.number.int({ min: 1 }),
+        address: getAddress(faker.finance.ethereumAddress()),
+        inviteExpiresAt: INVITE_EXPIRES_AT,
+      }),
+    ).rejects.toThrow('User is not an active admin.');
+
+    expect(queryBuilder.execute).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundException when no invitation row matches the resend target', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+
+    membersOrmRepository.find.mockResolvedValue([
+      {
+        user: { id: Number(authPayloadDto.sub) },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      },
+    ]);
+    queryBuilder.execute.mockResolvedValue({ affected: 0 });
+
+    await expect(
+      target.resendInvite({
+        authPayload,
+        spaceId: faker.number.int({ min: 1 }),
+        address: getAddress(faker.finance.ethereumAddress()),
+        inviteExpiresAt: INVITE_EXPIRES_AT,
+      }),
+    ).rejects.toThrow('Invitation not found.');
+  });
+
   it('should reject expired invites', async () => {
     const authPayloadDto = siweAuthPayloadDtoBuilder().build();
     const authPayload = new AuthPayload(authPayloadDto);

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -91,6 +91,10 @@ describe('MembersRepository', () => {
     );
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should invite email users via stub-user lookup and skip wallet lookup', async () => {
     const authPayloadDto = siweAuthPayloadDtoBuilder().build();
     const authPayload = new AuthPayload(authPayloadDto);
@@ -293,26 +297,22 @@ describe('MembersRepository', () => {
     const inviteExpiresAt = new Date('2026-04-30T00:00:00.000Z');
 
     jest.useFakeTimers().setSystemTime(new Date('2026-05-01T00:00:00.000Z'));
-    try {
-      spacesRepositoryMock.findOneOrFail.mockResolvedValue(
-        spaceBuilder()
-          .with('members', [
-            memberBuilder().with('inviteExpiresAt', inviteExpiresAt).build(),
-          ])
-          .build(),
-      );
+    spacesRepositoryMock.findOneOrFail.mockResolvedValue(
+      spaceBuilder()
+        .with('members', [
+          memberBuilder().with('inviteExpiresAt', inviteExpiresAt).build(),
+        ])
+        .build(),
+    );
 
-      await expect(
-        target.acceptInvite({
-          authPayload,
-          spaceId: faker.number.int({ min: 1 }),
-          payload: { name: faker.person.firstName() },
-        }),
-      ).rejects.toThrow('Invite has expired.');
+    await expect(
+      target.acceptInvite({
+        authPayload,
+        spaceId: faker.number.int({ min: 1 }),
+        payload: { name: faker.person.firstName() },
+      }),
+    ).rejects.toThrow('Invite has expired.');
 
-      expect(postgresDatabaseService.transaction).not.toHaveBeenCalled();
-    } finally {
-      jest.useRealTimers();
-    }
+    expect(postgresDatabaseService.transaction).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -173,11 +173,11 @@ describe('MembersRepository', () => {
     );
   });
 
-  it('should resend invitations by resetting status and expiration', async () => {
+  it('should resend email invitations by resetting status and expiration', async () => {
     const authPayloadDto = siweAuthPayloadDtoBuilder().build();
     const authPayload = new AuthPayload(authPayloadDto);
     const spaceId = faker.number.int({ min: 1 });
-    const userId = faker.number.int({ min: 1 });
+    const email = faker.internet.email().toLowerCase();
 
     membersOrmRepository.find.mockResolvedValue([
       {
@@ -191,7 +191,7 @@ describe('MembersRepository', () => {
     await target.resendInvite({
       authPayload,
       spaceId,
-      userId,
+      email,
       inviteExpiresAt: INVITE_EXPIRES_AT,
     });
 
@@ -199,15 +199,55 @@ describe('MembersRepository', () => {
       status: 'INVITED',
       inviteExpiresAt: INVITE_EXPIRES_AT,
     });
-    expect(queryBuilder.where).toHaveBeenCalledWith('user_id = :userId', {
-      userId,
-    });
-    expect(queryBuilder.andWhere).toHaveBeenCalledWith('space_id = :spaceId', {
+    expect(queryBuilder.where).toHaveBeenCalledWith('space_id = :spaceId', {
       spaceId,
     });
     expect(queryBuilder.andWhere).toHaveBeenCalledWith(
       'status IN (:...statuses)',
       { statuses: [MemberStatus.INVITED, MemberStatus.DECLINED] },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'user_id IN (SELECT id FROM users WHERE email = :email)',
+      { email },
+    );
+  });
+
+  it('should resend address invitations by resetting status and expiration', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const spaceId = faker.number.int({ min: 1 });
+    const address = getAddress(faker.finance.ethereumAddress());
+
+    membersOrmRepository.find.mockResolvedValue([
+      {
+        user: { id: Number(authPayloadDto.sub) },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+      },
+    ]);
+    queryBuilder.execute.mockResolvedValue({ affected: 1 });
+
+    await target.resendInvite({
+      authPayload,
+      spaceId,
+      address,
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+    });
+
+    expect(queryBuilder.set).toHaveBeenCalledWith({
+      status: 'INVITED',
+      inviteExpiresAt: INVITE_EXPIRES_AT,
+    });
+    expect(queryBuilder.where).toHaveBeenCalledWith('space_id = :spaceId', {
+      spaceId,
+    });
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'status IN (:...statuses)',
+      { statuses: [MemberStatus.INVITED, MemberStatus.DECLINED] },
+    );
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'user_id IN (SELECT user_id FROM wallets WHERE address = :address)',
+      { address },
     );
   });
 

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -15,7 +15,7 @@ import type { IUsersRepository } from '@/modules/users/domain/users.repository.i
 import type { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
 
-const INVITE_EXPIRES_AT = new Date('2026-05-01T00:00:00.000Z');
+const INVITE_EXPIRES_AT = faker.date.future();
 
 describe('MembersRepository', () => {
   const usersRepositoryMock = {
@@ -46,7 +46,7 @@ describe('MembersRepository', () => {
     andWhere: jest.Mock;
     execute: jest.Mock;
   };
-  let entityManager: { insert: jest.Mock };
+  let entityManager: { insert: jest.Mock; update: jest.Mock };
   let postgresDatabaseService: jest.MockedObjectDeep<PostgresDatabaseService>;
   let target: MembersRepository;
 
@@ -68,6 +68,7 @@ describe('MembersRepository', () => {
     };
     entityManager = {
       insert: jest.fn(),
+      update: jest.fn(),
     };
     postgresDatabaseService = {
       getRepository: jest.fn().mockResolvedValue(membersOrmRepository),
@@ -170,6 +171,41 @@ describe('MembersRepository', () => {
       expect.objectContaining({
         relations: { user: true },
       }),
+    );
+  });
+
+  it('should clear invite expiration when declining an invite', async () => {
+    const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+    const authPayload = new AuthPayload(authPayloadDto);
+    const spaceId = faker.number.int({ min: 1 });
+    const memberId = faker.number.int({ min: 1 });
+
+    spacesRepositoryMock.findOneOrFail.mockResolvedValue({
+      members: [{ id: memberId }],
+    } as unknown as Space);
+
+    await target.declineInvite({
+      authPayload,
+      spaceId,
+    });
+
+    expect(spacesRepositoryMock.findOneOrFail).toHaveBeenCalledWith({
+      where: {
+        id: spaceId,
+        members: {
+          user: { id: Number(authPayloadDto.sub) },
+          status: 'INVITED',
+        },
+      },
+      relations: { members: { user: true } },
+    });
+    expect(entityManager.update).toHaveBeenCalledWith(
+      expect.any(Function),
+      memberId,
+      {
+        status: 'DECLINED',
+        inviteExpiresAt: null,
+      },
     );
   });
 

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -167,7 +167,7 @@ export class MembersRepository implements IMembersRepository {
           throw err;
         }
 
-        invitations.push({
+        const invitation: Invitation = {
           userId: userIdToInvite,
           spaceId: space.id,
           name: userToInvite.name,
@@ -175,7 +175,12 @@ export class MembersRepository implements IMembersRepository {
           status: 'INVITED',
           invitedBy,
           inviteExpiresAt: args.inviteExpiresAt,
-        });
+        };
+        if (userToInvite.email) {
+          // Avoid exposing internal user IDs for email-based invite probes.
+          invitation.userId = undefined;
+        }
+        invitations.push(invitation);
       }
     });
 

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -292,6 +292,7 @@ export class MembersRepository implements IMembersRepository {
     await this.postgresDatabaseService.transaction(async (entityManager) => {
       await entityManager.update(DbMember, member.id, {
         status: 'DECLINED',
+        inviteExpiresAt: null,
       });
     });
   }

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -319,19 +319,15 @@ export class MembersRepository implements IMembersRepository {
         statuses: [MemberStatus.INVITED, MemberStatus.DECLINED],
       });
 
-    if (args.email) {
+    if (args.email !== undefined) {
       queryBuilder.andWhere(
         'user_id IN (SELECT id FROM users WHERE email = :email)',
         { email: args.email.trim().toLowerCase() },
       );
-    } else if (args.address) {
+    } else {
       queryBuilder.andWhere(
         'user_id IN (SELECT user_id FROM wallets WHERE address = :address)',
         { address: getAddress(args.address) },
-      );
-    } else {
-      throw new BadRequestException(
-        'Exactly one of address or email is required.',
       );
     }
 

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -2,6 +2,7 @@
 import {
   ConflictException,
   ForbiddenException,
+  GoneException,
   Inject,
   Injectable,
   NotFoundException,
@@ -23,7 +24,10 @@ import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import type { Invitation } from '@/modules/users/domain/entities/invitation.entity';
-import type { Member } from '@/modules/users/domain/entities/member.entity';
+import {
+  type Member,
+  MemberStatus,
+} from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
@@ -91,9 +95,11 @@ export class MembersRepository implements IMembersRepository {
   public async inviteUsers(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
+    inviteExpiresAt: Member['inviteExpiresAt'];
     users: Array<{
       name: Member['name'];
-      address: Address;
+      address?: Address;
+      email?: string;
       role: Member['role'];
     }>;
   }): Promise<Array<Invitation>> {
@@ -116,11 +122,16 @@ export class MembersRepository implements IMembersRepository {
       throw new ForbiddenException('User is not an active admin.');
     }
 
-    const invitedAddresses = args.users.map((user) => user.address);
-    const invitedWallets = await this.walletsRepository.find({
-      where: { address: In(invitedAddresses) },
-      relations: { user: true },
-    });
+    const invitedAddresses = args.users.flatMap((user) =>
+      user.address ? [user.address] : [],
+    );
+    const invitedWallets =
+      invitedAddresses.length > 0
+        ? await this.walletsRepository.find({
+            where: { address: In(invitedAddresses) },
+            relations: { user: true },
+          })
+        : [];
     const invitations: Array<Invitation> = [];
 
     // TODO: Until OIDC invite flow is set up, OIDC admins have no wallet
@@ -131,16 +142,11 @@ export class MembersRepository implements IMembersRepository {
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
       for (const userToInvite of args.users) {
-        // Find existing User via Wallet or create new User and Wallet.
-        const wallet = invitedWallets.find((wallet) => {
-          return isAddressEqual(wallet.address, userToInvite.address);
+        const userIdToInvite = await this.getUserIdToInvite({
+          entityManager,
+          userToInvite,
+          invitedWallets,
         });
-        const userIdToInvite = wallet
-          ? wallet.user.id
-          : await this.createUserAndWallet({
-              entityManager,
-              address: userToInvite.address,
-            });
 
         try {
           await entityManager.insert(DbMember, {
@@ -150,11 +156,12 @@ export class MembersRepository implements IMembersRepository {
             role: userToInvite.role,
             status: 'INVITED',
             invitedBy,
+            inviteExpiresAt: args.inviteExpiresAt,
           });
         } catch (err) {
           if (isUniqueConstraintError(err)) {
             throw new UniqueConstraintError(
-              `${userToInvite.address} is already in this space or has a pending invite.`,
+              'User is already in this space or has a pending invite.',
             );
           }
           throw err;
@@ -167,6 +174,7 @@ export class MembersRepository implements IMembersRepository {
           role: userToInvite.role,
           status: 'INVITED',
           invitedBy,
+          inviteExpiresAt: args.inviteExpiresAt,
         });
       }
     });
@@ -187,6 +195,44 @@ export class MembersRepository implements IMembersRepository {
     return userId;
   }
 
+  private async getUserIdToInvite(args: {
+    entityManager: EntityManager;
+    userToInvite: {
+      name: Member['name'];
+      address?: Address;
+      email?: string;
+      role: Member['role'];
+    };
+    invitedWallets: Array<{
+      address: Address;
+      user: { id: User['id'] };
+    }>;
+  }): Promise<User['id']> {
+    const address = args.userToInvite.address;
+    if (address) {
+      const wallet = args.invitedWallets.find((wallet) => {
+        return isAddressEqual(wallet.address, address);
+      });
+
+      return (
+        wallet?.user.id ??
+        (await this.createUserAndWallet({
+          entityManager: args.entityManager,
+          address,
+        }))
+      );
+    }
+
+    if (args.userToInvite.email) {
+      return await this.usersRepository.findOrCreateInviteeByEmail(
+        args.userToInvite.email,
+        args.entityManager,
+      );
+    }
+
+    throw new ConflictException('Invitee address or email is required.');
+  }
+
   public async acceptInvite(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
@@ -203,10 +249,15 @@ export class MembersRepository implements IMembersRepository {
     });
     const member = space.members[0];
 
+    if (member.inviteExpiresAt && member.inviteExpiresAt <= new Date()) {
+      throw new GoneException('Invite has expired.');
+    }
+
     await this.postgresDatabaseService.transaction(async (entityManager) => {
       await entityManager.update(DbMember, member.id, {
         status: 'ACTIVE',
         name: args.payload.name,
+        inviteExpiresAt: null,
       });
 
       await this.usersRepository.updateStatus({
@@ -237,6 +288,38 @@ export class MembersRepository implements IMembersRepository {
         status: 'DECLINED',
       });
     });
+  }
+
+  public async resendInvite(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+    userId: User['id'];
+    inviteExpiresAt: Member['inviteExpiresAt'];
+  }): Promise<void> {
+    const actingUserId = getAuthenticatedUserIdOrFail(args.authPayload);
+    const activeAdmins = await this.findActiveAdminsOrFail(args.spaceId);
+
+    this.assertIsActiveAdmin({ members: activeAdmins, userId: actingUserId });
+
+    const membersRepository =
+      await this.postgresDatabaseService.getRepository(DbMember);
+    const updateResult = await membersRepository
+      .createQueryBuilder()
+      .update(DbMember)
+      .set({
+        status: 'INVITED',
+        inviteExpiresAt: args.inviteExpiresAt,
+      })
+      .where('user_id = :userId', { userId: args.userId })
+      .andWhere('space_id = :spaceId', { spaceId: args.spaceId })
+      .andWhere('status IN (:...statuses)', {
+        statuses: [MemberStatus.INVITED, MemberStatus.DECLINED],
+      })
+      .execute();
+
+    if (updateResult.affected === 0) {
+      throw new NotFoundException('Invitation not found.');
+    }
   }
 
   public async findAuthorizedMembersOrFail(args: {

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -297,13 +297,9 @@ export class MembersRepository implements IMembersRepository {
     });
   }
 
-  public async resendInvite(args: {
-    authPayload: AuthPayload;
-    spaceId: Space['id'];
-    address?: Address;
-    email?: string;
-    inviteExpiresAt: Member['inviteExpiresAt'];
-  }): Promise<void> {
+  public async resendInvite(
+    args: Parameters<IMembersRepository['resendInvite']>[0],
+  ): Promise<void> {
     const actingUserId = getAuthenticatedUserIdOrFail(args.authPayload);
     const activeAdmins = await this.findActiveAdminsOrFail(args.spaceId);
 

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -169,7 +169,7 @@ export class MembersRepository implements IMembersRepository {
         }
 
         const invitation: Invitation = {
-          userId: userIdToInvite,
+          userId: userToInvite.email ? undefined : userIdToInvite,
           spaceId: space.id,
           name: userToInvite.name,
           role: userToInvite.role,
@@ -177,10 +177,6 @@ export class MembersRepository implements IMembersRepository {
           invitedBy,
           inviteExpiresAt: args.inviteExpiresAt,
         };
-        if (userToInvite.email) {
-          // Avoid exposing internal user IDs for email-based invite probes.
-          invitation.userId = undefined;
-        }
         invitations.push(invitation);
       }
     });

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   GoneException,
@@ -14,7 +15,7 @@ import type {
   FindOptionsWhere,
 } from 'typeorm';
 import { In } from 'typeorm';
-import { type Address, isAddressEqual } from 'viem';
+import { type Address, getAddress, isAddressEqual } from 'viem';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
@@ -235,7 +236,7 @@ export class MembersRepository implements IMembersRepository {
       );
     }
 
-    throw new ConflictException('Invitee address or email is required.');
+    throw new BadRequestException('Invitee address or email is required.');
   }
 
   public async acceptInvite(args: {
@@ -298,7 +299,8 @@ export class MembersRepository implements IMembersRepository {
   public async resendInvite(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    userId: User['id'];
+    address?: Address;
+    email?: string;
     inviteExpiresAt: Member['inviteExpiresAt'];
   }): Promise<void> {
     const actingUserId = getAuthenticatedUserIdOrFail(args.authPayload);
@@ -308,19 +310,35 @@ export class MembersRepository implements IMembersRepository {
 
     const membersRepository =
       await this.postgresDatabaseService.getRepository(DbMember);
-    const updateResult = await membersRepository
+    const queryBuilder = membersRepository
       .createQueryBuilder()
       .update(DbMember)
       .set({
         status: 'INVITED',
         inviteExpiresAt: args.inviteExpiresAt,
       })
-      .where('user_id = :userId', { userId: args.userId })
-      .andWhere('space_id = :spaceId', { spaceId: args.spaceId })
+      .where('space_id = :spaceId', { spaceId: args.spaceId })
       .andWhere('status IN (:...statuses)', {
         statuses: [MemberStatus.INVITED, MemberStatus.DECLINED],
-      })
-      .execute();
+      });
+
+    if (args.email) {
+      queryBuilder.andWhere(
+        'user_id IN (SELECT id FROM users WHERE email = :email)',
+        { email: args.email.trim().toLowerCase() },
+      );
+    } else if (args.address) {
+      queryBuilder.andWhere(
+        'user_id IN (SELECT user_id FROM wallets WHERE address = :address)',
+        { address: getAddress(args.address) },
+      );
+    } else {
+      throw new BadRequestException(
+        'Exactly one of address or email is required.',
+      );
+    }
+
+    const updateResult = await queryBuilder.execute();
 
     if (updateResult.affected === 0) {
       throw new NotFoundException('Invitation not found.');

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -966,6 +966,36 @@ describe('UsersRepository', () => {
       expect(user.email).toBe(email.toLowerCase());
     });
 
+    it('should link a verified OIDC login to a pending email invite user', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const extUserId = faker.string.uuid();
+      const email = faker.internet.email().toLowerCase();
+      const userInsertResult = await dbUserRepository.insert({
+        status: 'PENDING',
+        email,
+      });
+      const userId = userInsertResult.identifiers[0].id as number;
+
+      await expect(
+        usersRepository.findOrCreateByExtUserIdWithEmail(extUserId, {
+          address: email,
+          verified: true,
+        }),
+      ).resolves.toBe(userId);
+
+      const user = await dbUserRepository.findOneOrFail({
+        where: { id: userId },
+      });
+      expect(user).toEqual(
+        expect.objectContaining({
+          email,
+          extUserId,
+          status: 'PENDING',
+        }),
+      );
+      await expect(dbUserRepository.find()).resolves.toHaveLength(1);
+    });
+
     it('should not overwrite an existing email for the same user', async () => {
       const dbUserRepository = dataSource.getRepository(User);
       const extUserId = faker.string.uuid();

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -30,7 +30,7 @@ export interface IUsersRepository {
   create(
     status: keyof typeof UserStatus,
     entityManager: EntityManager,
-    options?: { extUserId?: string },
+    options?: { extUserId?: string; email?: string },
   ): Promise<User['id']>;
 
   getWithWallets(authPayload: AuthPayload): Promise<{
@@ -56,6 +56,11 @@ export interface IUsersRepository {
   findByWalletAddress(address: Address): Promise<User | undefined>;
 
   findOrCreateByWalletAddress(address: Address): Promise<User['id']>;
+
+  findOrCreateInviteeByEmail(
+    email: string,
+    entityManager: EntityManager,
+  ): Promise<User['id']>;
 
   findOrCreateByExtUserIdWithEmail(
     extUserId: string,

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -15,6 +15,7 @@ describe('UsersRepository', () => {
   let userRepository: {
     findOne: jest.Mock;
     findOneOrFail: jest.Mock;
+    update: jest.Mock;
   };
   let target: UsersRepository;
 
@@ -24,6 +25,7 @@ describe('UsersRepository', () => {
     userRepository = {
       findOne: jest.fn(),
       findOneOrFail: jest.fn(),
+      update: jest.fn(),
     };
 
     postgresDatabaseService = {
@@ -101,6 +103,60 @@ describe('UsersRepository', () => {
           verified: false,
         }),
       ).resolves.toBe(userId);
+    });
+
+    it('should link a verified OIDC login to a pending email invite user', async () => {
+      const userId = faker.number.int({ min: 1 });
+      const extUserId = faker.string.uuid();
+      const email = faker.internet.email();
+      userRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: userId });
+      userRepository.update.mockResolvedValue({ affected: 1 });
+
+      await expect(
+        target.findOrCreateByExtUserIdWithEmail(extUserId, {
+          address: email,
+          verified: true,
+        }),
+      ).resolves.toBe(userId);
+
+      expect(userRepository.findOne).toHaveBeenNthCalledWith(2, {
+        where: {
+          email: email.toLowerCase(),
+          extUserId: expect.anything(),
+          status: 'PENDING',
+        },
+        select: { id: true },
+      });
+      expect(userRepository.update).toHaveBeenCalledWith(
+        { id: userId, extUserId: expect.anything() },
+        { extUserId },
+      );
+    });
+
+    it('should return a concurrently linked verified OIDC user id', async () => {
+      const invitedUserId = faker.number.int({ min: 1 });
+      const linkedUserId = faker.number.int({ min: invitedUserId + 1 });
+      const extUserId = faker.string.uuid();
+      const email = faker.internet.email();
+      userRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: invitedUserId })
+        .mockResolvedValueOnce({ id: linkedUserId });
+      userRepository.update.mockResolvedValue({ affected: 0 });
+
+      await expect(
+        target.findOrCreateByExtUserIdWithEmail(extUserId, {
+          address: email,
+          verified: true,
+        }),
+      ).resolves.toBe(linkedUserId);
+
+      expect(userRepository.findOne).toHaveBeenNthCalledWith(3, {
+        where: { extUserId },
+        select: { id: true },
+      });
     });
 
     it('should throw when an unverified email belongs to a different user', async () => {

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -6,8 +6,12 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import type { FindOptionsRelations, FindOptionsWhere } from 'typeorm';
-import { EntityManager } from 'typeorm';
+import type {
+  FindOptionsRelations,
+  FindOptionsWhere,
+  Repository,
+} from 'typeorm';
+import { EntityManager, IsNull } from 'typeorm';
 import type { Address } from 'viem';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
@@ -73,11 +77,12 @@ export class UsersRepository implements IUsersRepository {
   public async create(
     status: keyof typeof UserStatus,
     entityManager: EntityManager,
-    options?: { extUserId?: string },
+    options?: { extUserId?: string; email?: string },
   ): Promise<User['id']> {
     const userInsertResult = await entityManager.insert(DbUser, {
       status,
       ...(options?.extUserId && { extUserId: options.extUserId }),
+      ...(options?.email && { email: options.email.trim().toLowerCase() }),
     });
 
     return userInsertResult.identifiers[0].id;
@@ -220,8 +225,39 @@ export class UsersRepository implements IUsersRepository {
     }
   }
 
+  public async findOrCreateInviteeByEmail(
+    email: string,
+    entityManager: EntityManager,
+  ): Promise<User['id']> {
+    const userRepository = entityManager.getRepository(DbUser);
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const existingUser = await userRepository.findOne({
+      where: { email: normalizedEmail },
+    });
+    if (existingUser) {
+      return existingUser.id;
+    }
+
+    try {
+      return await this.create('PENDING', entityManager, {
+        email: normalizedEmail,
+      });
+    } catch (error) {
+      if (!this.isUniqueConstraintViolation(error, 'idx_users_email')) {
+        throw error;
+      }
+
+      const user = await userRepository.findOneOrFail({
+        where: { email: normalizedEmail },
+      });
+      return user.id;
+    }
+  }
+
   /**
-   * Finds or creates an OIDC user, then validates or persists the optional email claim.
+   * Finds or creates an OIDC user, linking verified email invites when possible.
+   * The optional email claim is validated or persisted after the user is resolved.
    */
   public async findOrCreateByExtUserIdWithEmail(
     extUserId: string,
@@ -240,6 +276,18 @@ export class UsersRepository implements IUsersRepository {
         await this.handleUserEmail(existingUser.id, email);
       }
       return existingUser.id;
+    }
+
+    if (email?.verified) {
+      const invitedUserId = await this.linkPendingInviteeByVerifiedEmail(
+        extUserId,
+        email.address,
+        userRepository,
+      );
+
+      if (invitedUserId !== null) {
+        return invitedUserId;
+      }
     }
 
     let userId: User['id'];
@@ -265,6 +313,55 @@ export class UsersRepository implements IUsersRepository {
     await this.handleUserEmail(userId, email);
 
     return userId;
+  }
+
+  private async linkPendingInviteeByVerifiedEmail(
+    extUserId: string,
+    email: string,
+    userRepository: Repository<DbUser>,
+  ): Promise<User['id'] | null> {
+    const normalizedEmail = email.trim().toLowerCase();
+    const invitedUser = await userRepository.findOne({
+      where: {
+        email: normalizedEmail,
+        extUserId: IsNull(),
+        status: 'PENDING',
+      },
+      select: { id: true },
+    });
+
+    if (!invitedUser) {
+      return null;
+    }
+
+    try {
+      const updateResult = await userRepository.update(
+        { id: invitedUser.id, extUserId: IsNull() },
+        { extUserId },
+      );
+
+      if (updateResult.affected === 1) {
+        return invitedUser.id;
+      }
+
+      // Another callback may have linked the pending invitee after our lookup.
+      const user = await userRepository.findOne({
+        where: { extUserId },
+        select: { id: true },
+      });
+      return user?.id ?? null;
+    } catch (error) {
+      if (!this.isUniqueConstraintViolation(error, 'idx_users_ext_user_id')) {
+        throw error;
+      }
+
+      // A concurrent OIDC callback may have linked the pending invitee first.
+      const user = await userRepository.findOneOrFail({
+        where: { extUserId },
+        select: { id: true },
+      });
+      return user.id;
+    }
   }
 
   private async handleUserEmail(


### PR DESCRIPTION
Resolves: https://linear.app/safe-global/issue/WA-2022/email-invite-creation-endpoint

This PR adds email-based space invite creation alongside the existing wallet-address invite flow, so admins can invite people before they have a wallet connected.

## Summary

- allow invite requests to contain either a wallet address or an email address
- create or reuse pending users for email invitees inside the invite transaction
- store invite expiration on member records and return it with invitation/member responses
- expose invitee email only to admins and the invited user
- keep pending invite emails hidden from regular member-list responses
- add focused service, repository, and e2e coverage for email invites and invite visibility

## Notes

- Existing wallet-address invites remain supported.
- This PR creates the invite record only; email delivery is handled separately.