### PR TITLE
fix: Biome wrong import statements

### DIFF
--- a/src/modules/positions/datasources/zerion-positions-api.service.ts
+++ b/src/modules/positions/datasources/zerion-positions-api.service.ts
@@ -39,7 +39,7 @@ import type {
 } from '@/modules/balances/domain/entities/balance.entity';
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import type { Position } from '@/modules/positions/domain/entities/position.entity';
-import type { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
+import { ZerionChainMappingService } from '@/modules/zerion/datasources/zerion-chain-mapping.service';
 import { type Raw, rawify } from '@/validation/entities/raw.entity';
 
 @Injectable()

--- a/src/modules/positions/routes/positions.controller.ts
+++ b/src/modules/positions/routes/positions.controller.ts
@@ -10,7 +10,7 @@ import {
 import { ApiOkResponse, ApiQuery, ApiTags } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { Protocol } from '@/modules/positions/routes/entities/protocol.entity';
-import type { PositionsService } from '@/modules/positions/routes/positions.service';
+import { PositionsService } from '@/modules/positions/routes/positions.service';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 


### PR DESCRIPTION
## Summary

Biome's useImportType rule auto-promotes imports to type when it only sees type-level usage, but NestJS needs the runtime class token for DI.

## Changes
- update imports
