### PR TITLE
fix: restore runtime imports for @ApiProperty class types

### DIFF
--- a/src/modules/chains/routes/entities/chain.entity.ts
+++ b/src/modules/chains/routes/entities/chain.entity.ts
@@ -6,14 +6,14 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 import type { Address } from 'viem';
-import type {
+import {
   BeaconChainExplorerUriTemplate as ApiBeaconChainExplorerUriTemplate,
-  BeaconChainExplorerUriTemplate,
+  type BeaconChainExplorerUriTemplate,
 } from '@/modules/chains/domain/entities/beacon-chain-explorer-uri-template.entity';
-import type { BalancesProvider } from '@/modules/chains/routes/entities/balances-provider.entity';
-import type {
+import { BalancesProvider } from '@/modules/chains/routes/entities/balances-provider.entity';
+import {
   BlockExplorerUriTemplate as ApiBlockExplorerUriTemplate,
-  BlockExplorerUriTemplate,
+  type BlockExplorerUriTemplate,
 } from '@/modules/chains/routes/entities/block-explorer-uri-template.entity';
 import {
   GasPriceFixed as ApiGasPriceFixed,
@@ -27,17 +27,17 @@ import {
   GasPriceOracle as ApiGasPriceOracle,
   type GasPriceOracle,
 } from '@/modules/chains/routes/entities/gas-price-oracle.entity';
-import type {
+import {
   NativeCurrency as ApiNativeCurrency,
-  NativeCurrency,
+  type NativeCurrency,
 } from '@/modules/chains/routes/entities/native-currency.entity';
-import type {
+import {
   RpcUri as ApiRpcUri,
-  RpcUri,
+  type RpcUri,
 } from '@/modules/chains/routes/entities/rpc-uri.entity';
-import type {
+import {
   Theme as ApiTheme,
-  Theme,
+  type Theme,
 } from '@/modules/chains/routes/entities/theme.entity';
 
 @ApiExtraModels(ApiGasPriceOracle, ApiGasPriceFixed, ApiGasPriceFixedEIP1559)

--- a/src/modules/messages/routes/entities/message-confirmation.entity.ts
+++ b/src/modules/messages/routes/entities/message-confirmation.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import type { Hex } from 'viem';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class MessageConfirmation {
   @ApiProperty()

--- a/src/modules/messages/routes/entities/message.entity.ts
+++ b/src/modules/messages/routes/entities/message.entity.ts
@@ -8,7 +8,7 @@ import {
 import type { Hash, Hex } from 'viem';
 import { MessageConfirmation } from '@/modules/messages/routes/entities/message-confirmation.entity';
 import { TypedData } from '@/modules/messages/routes/entities/typed-data.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export enum MessageStatus {
   NeedsConfirmation = 'NEEDS_CONFIRMATION',

--- a/src/modules/positions/routes/entities/protocol.entity.ts
+++ b/src/modules/positions/routes/entities/protocol.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import { PositionGroup } from '@/modules/positions/routes/entities/position-group.entity';
-import type { ProtocolMetadata } from '@/modules/positions/routes/entities/protocol-metadata.entity';
+import { ProtocolMetadata } from '@/modules/positions/routes/entities/protocol-metadata.entity';
 
 @ApiExtraModels(PositionGroup)
 export class Protocol {

--- a/src/modules/safe-apps/routes/entities/safe-app.entity.ts
+++ b/src/modules/safe-apps/routes/entities/safe-app.entity.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import type { SafeAppAccessControl } from '@/modules/safe-apps/routes/entities/safe-app-access-control.entity';
+import { SafeAppAccessControl } from '@/modules/safe-apps/routes/entities/safe-app-access-control.entity';
 import { SafeAppProvider } from '@/modules/safe-apps/routes/entities/safe-app-provider.entity';
 import { SafeAppSocialProfile } from '@/modules/safe-apps/routes/entities/safe-app-social-profile.entity';
 

--- a/src/modules/transactions/routes/entities/custom-transaction.entity.ts
+++ b/src/modules/transactions/routes/entities/custom-transaction.entity.ts
@@ -4,7 +4,7 @@ import {
   TransactionInfo,
   TransactionInfoType,
 } from '@/modules/transactions/routes/entities/transaction-info.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class CustomTransactionInfo extends TransactionInfo {
   @ApiProperty({ enum: [TransactionInfoType.Custom] })

--- a/src/modules/transactions/routes/entities/incoming-transfer.entity.ts
+++ b/src/modules/transactions/routes/entities/incoming-transfer.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
-import type { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
+import { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
 
 export class IncomingTransfer {
   @ApiProperty({ enum: ['TRANSACTION'] })

--- a/src/modules/transactions/routes/entities/module-execution-info.entity.ts
+++ b/src/modules/transactions/routes/entities/module-execution-info.entity.ts
@@ -4,7 +4,7 @@ import {
   ExecutionInfo,
   ExecutionInfoType,
 } from '@/modules/transactions/routes/entities/execution-info.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class ModuleExecutionInfo extends ExecutionInfo {
   @ApiProperty({ enum: [ExecutionInfoType.Module] })

--- a/src/modules/transactions/routes/entities/module-transaction.entity.ts
+++ b/src/modules/transactions/routes/entities/module-transaction.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
-import type { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
+import { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
 
 export class ModuleTransaction {
   @ApiProperty({ enum: ['TRANSACTION'] })

--- a/src/modules/transactions/routes/entities/multisig-transaction.entity.ts
+++ b/src/modules/transactions/routes/entities/multisig-transaction.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
-import type { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
+import { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
 
 export class MultisigTransaction {
   @ApiProperty({ enum: ['TRANSACTION'] })

--- a/src/modules/transactions/routes/entities/queued-items/transaction-queued-item.entity.ts
+++ b/src/modules/transactions/routes/entities/queued-items/transaction-queued-item.entity.ts
@@ -5,7 +5,7 @@ import {
   QueuedItem,
   QueuedItemType,
 } from '@/modules/transactions/routes/entities/queued-item.entity';
-import type { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
+import { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
 
 export class TransactionQueuedItem extends QueuedItem {
   @ApiProperty({ enum: [QueuedItemType.Transaction] })

--- a/src/modules/transactions/routes/entities/settings-change-transaction.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-change-transaction.entity.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
-import type { DataDecoded } from '@/modules/data-decoder/routes/entities/data-decoded.entity';
+import { DataDecoded } from '@/modules/data-decoder/routes/entities/data-decoded.entity';
 import { AddOwner } from '@/modules/transactions/routes/entities/settings-changes/add-owner.entity';
 import { ChangeMasterCopy } from '@/modules/transactions/routes/entities/settings-changes/change-master-copy.entity';
 import { ChangeThreshold } from '@/modules/transactions/routes/entities/settings-changes/change-threshold.entity';

--- a/src/modules/transactions/routes/entities/settings-changes/add-owner.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/add-owner.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class AddOwner extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.AddOwner] })

--- a/src/modules/transactions/routes/entities/settings-changes/change-master-copy.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/change-master-copy.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class ChangeMasterCopy extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.ChangeMasterCopy] })

--- a/src/modules/transactions/routes/entities/settings-changes/disable-module.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/disable-module.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class DisableModule extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.DisableModule] })

--- a/src/modules/transactions/routes/entities/settings-changes/enable-module.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/enable-module.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class EnableModule extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.EnableModule] })

--- a/src/modules/transactions/routes/entities/settings-changes/remove-owner.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/remove-owner.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class RemoveOwner extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.RemoveOwner] })

--- a/src/modules/transactions/routes/entities/settings-changes/set-fallback-handler.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/set-fallback-handler.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class SetFallbackHandler extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.SetFallbackHandler] })

--- a/src/modules/transactions/routes/entities/settings-changes/set-guard.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/set-guard.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class SetGuard extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.SetGuard] })

--- a/src/modules/transactions/routes/entities/settings-changes/swap-owner.entity.ts
+++ b/src/modules/transactions/routes/entities/settings-changes/swap-owner.entity.ts
@@ -4,7 +4,7 @@ import {
   SettingsChange,
   SettingsChangeType,
 } from '@/modules/transactions/routes/entities/settings-changes/settings-change.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class SwapOwner extends SettingsChange {
   @ApiProperty({ enum: [SettingsChangeType.SwapOwner] })

--- a/src/modules/transactions/routes/entities/staking/native-staking-deposit-info.entity.ts
+++ b/src/modules/transactions/routes/entities/staking/native-staking-deposit-info.entity.ts
@@ -6,7 +6,7 @@ import {
   StakingStatus,
   type StakingTimeInfo,
 } from '@/modules/transactions/routes/entities/staking/staking.entity';
-import type { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
+import { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
   TransactionInfoType,

--- a/src/modules/transactions/routes/entities/staking/native-staking-validators-exit-info.entity.ts
+++ b/src/modules/transactions/routes/entities/staking/native-staking-validators-exit-info.entity.ts
@@ -2,7 +2,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { StakingStatus } from '@/modules/transactions/routes/entities/staking/staking.entity';
-import type { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
+import { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
   TransactionInfoType,

--- a/src/modules/transactions/routes/entities/staking/native-staking-withdraw-info.entity.ts
+++ b/src/modules/transactions/routes/entities/staking/native-staking-withdraw-info.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import type { Address } from 'viem';
-import type { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
+import { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
   TransactionInfoType,

--- a/src/modules/transactions/routes/entities/transaction-details/module-execution-details.entity.ts
+++ b/src/modules/transactions/routes/entities/transaction-details/module-execution-details.entity.ts
@@ -4,7 +4,7 @@ import {
   ExecutionDetails,
   ExecutionDetailsType,
 } from '@/modules/transactions/routes/entities/transaction-details/execution-details.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class ModuleExecutionDetails extends ExecutionDetails {
   @ApiProperty({ enum: [ExecutionDetailsType.Module] })

--- a/src/modules/transactions/routes/entities/transaction-item.entity.ts
+++ b/src/modules/transactions/routes/entities/transaction-item.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
-import type { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
+import { Transaction } from '@/modules/transactions/routes/entities/transaction.entity';
 
 export class TransactionItem {
   @ApiProperty({ enum: ['TRANSACTION'] })

--- a/src/modules/transactions/routes/entities/transaction-preview.entity.ts
+++ b/src/modules/transactions/routes/entities/transaction-preview.entity.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { BaseTransaction } from '@/modules/transactions/routes/entities/base-transaction.entity';
-import type { TransactionData } from '@/modules/transactions/routes/entities/transaction-data.entity';
+import { TransactionData } from '@/modules/transactions/routes/entities/transaction-data.entity';
 import type { TransactionInfo } from '@/modules/transactions/routes/entities/transaction-info.entity';
 
 export class TransactionPreview extends BaseTransaction {

--- a/src/modules/transactions/routes/entities/transaction.entity.ts
+++ b/src/modules/transactions/routes/entities/transaction.entity.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/swagger';
 import type { Hash } from 'viem';
 import { BaseTransaction } from '@/modules/transactions/routes/entities/base-transaction.entity';
-import type { ExecutionInfo } from '@/modules/transactions/routes/entities/execution-info.entity';
+import { ExecutionInfo } from '@/modules/transactions/routes/entities/execution-info.entity';
 import { ModuleExecutionInfo } from '@/modules/transactions/routes/entities/module-execution-info.entity';
 import { MultisigExecutionInfo } from '@/modules/transactions/routes/entities/multisig-execution-info.entity';
 import { SafeAppInfo } from '@/modules/transactions/routes/entities/safe-app-info.entity';

--- a/src/modules/transactions/routes/entities/transfer-transaction-info.entity.ts
+++ b/src/modules/transactions/routes/entities/transfer-transaction-info.entity.ts
@@ -8,7 +8,7 @@ import { Erc20Transfer } from '@/modules/transactions/routes/entities/transfers/
 import { Erc721Transfer } from '@/modules/transactions/routes/entities/transfers/erc721-transfer.entity';
 import { NativeCoinTransfer } from '@/modules/transactions/routes/entities/transfers/native-coin-transfer.entity';
 import type { Transfer } from '@/modules/transactions/routes/entities/transfers/transfer.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export enum TransferDirection {
   Incoming = 'INCOMING',

--- a/src/modules/transactions/routes/entities/vaults/vault-extra-reward.entity.ts
+++ b/src/modules/transactions/routes/entities/vaults/vault-extra-reward.entity.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
-import type { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
+import { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
 
 export class VaultExtraReward {
   @ApiProperty()

--- a/src/modules/transactions/routes/entities/vaults/vault-transaction-info.entity.ts
+++ b/src/modules/transactions/routes/entities/vaults/vault-transaction-info.entity.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
-import type { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
+import { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
   TransactionInfoType,

--- a/src/modules/transactions/routes/swap-transfer-transaction-info.entity.ts
+++ b/src/modules/transactions/routes/swap-transfer-transaction-info.entity.ts
@@ -11,7 +11,7 @@ import {
   OrderStatus,
 } from '@/modules/swaps/domain/entities/order.entity';
 import type { SwapOrderTransactionInfo } from '@/modules/transactions/routes/entities/swaps/swap-order-info.entity';
-import type { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
+import { TokenInfo } from '@/modules/transactions/routes/entities/swaps/token-info.entity';
 import {
   TransactionInfo,
   TransactionInfoType,
@@ -24,7 +24,7 @@ import { Erc20Transfer } from '@/modules/transactions/routes/entities/transfers/
 import { Erc721Transfer } from '@/modules/transactions/routes/entities/transfers/erc721-transfer.entity';
 import { NativeCoinTransfer } from '@/modules/transactions/routes/entities/transfers/native-coin-transfer.entity';
 import type { Transfer } from '@/modules/transactions/routes/entities/transfers/transfer.entity';
-import type { AddressInfo } from '@/routes/common/entities/address-info.entity';
+import { AddressInfo } from '@/routes/common/entities/address-info.entity';
 
 export class SwapTransferTransactionInfo
   extends TransactionInfo


### PR DESCRIPTION
## Summary

The Biome 2.0 migration (#3030) auto-converted runtime-needed class imports in entity files to `import type { ... }`. With `emitDecoratorMetadata: true` in `tsconfig.json`, type-only imports are erased before TS emits the `Reflect.metadata("design:type", ...)` call, so every `@ApiProperty()`-decorated field whose type was a type-only-imported class lost its constructor reference. NestJS's `@nestjs/swagger` then fell back to the global `Function` placeholder, corrupting the OpenAPI schema.

Downstream, `safe-wallet-monorepo`'s `@safe-global/store` `AUTO_GENERATED/*.ts` (generated from `https://safe-client.staging.5afe.dev/api-json` via `@rtk-query/codegen-openapi`) emits broken types like:

```ts
export type Function = {}
export type Chain = {
  // ...
  nativeCurrency: Function
  blockExplorerUriTemplate: Function
  balancesProvider: Function
  publicRpcUri: Function
  rpcUri: Function
  safeAppsRpcUri: Function
  theme: Function
  // ...
}
```

That breaks `type-check` in consumer packages (e.g. `@safe-global/test/factories/chains.ts` reading `nativeCurrency.name`).

Affected classes (49 broken `: Function` references in the generated output): `NativeCurrency`, `BlockExplorerUriTemplate`, `BeaconChainExplorerUriTemplate`, `BalancesProvider`, `RpcUri`, `Theme`, `AddressInfo`, `TokenInfo`, `DataDecoded`, `Transaction`, `TransactionData`, `ExecutionInfo`, `SafeAppAccessControl`, `ProtocolMetadata`.

## Changes

Switched the affected imports to the dual-import pattern already in use for `GasPriceOracle`/`GasPriceFixed`/`GasPriceFixedEIP1559` in `chain.entity.ts`:

```ts
// Before
import type {
  NativeCurrency as ApiNativeCurrency,
  NativeCurrency,
} from '@/modules/chains/routes/entities/native-currency.entity';

// After
import {
  NativeCurrency as ApiNativeCurrency,
  type NativeCurrency,
} from '@/modules/chains/routes/entities/native-currency.entity';
```

The class is now value-imported (so `emitDecoratorMetadata` can reference it at runtime) while the type alias remains type-only. `biome.json` already has `"useImportType": "off"`, so these fixes will not auto-revert.

`viem` string-branded aliases (`Address`, `Hash`, `Hex`) and Zod-inferred types are intentionally left as `import type` — they have no runtime representation and were never broken (`emitDecoratorMetadata` correctly emits `String` for them).

31 entity files updated under `src/modules/{chains,messages,positions,safe-apps,transactions}/`.

## Verification

- `yarn lint` — clean (1711 files, no fixes applied)
- `yarn format` — clean (1711 files, no fixes applied)
- `yarn test` — 4814 passed, 18 skipped, 0 failed (293 suites)

To verify the schema fix end-to-end after this PR is deployed to staging, regenerate the consumer types in `safe-wallet-monorepo`:

```bash
yarn workspace @safe-global/store build:dev
grep -rn ": Function" packages/store/src/gateway/AUTO_GENERATED/  # should return nothing
```