### PR TITLE
feat(csv-export): add gas fee columns to transaction history CSV export

### DIFF
--- a/src/modules/csv-export/v1/csv-export.module.ts
+++ b/src/modules/csv-export/v1/csv-export.module.ts
@@ -12,6 +12,7 @@ import {
   type ILoggingService,
   LoggingService,
 } from '@/logging/logging.interface';
+import { ChainsModule } from '@/modules/chains/chains.module';
 import { CsvExportConsumer } from '@/modules/csv-export/v1/consumers/csv-export.consumer';
 import { CsvExportController } from '@/modules/csv-export/v1/csv-export.controller';
 import { CsvExportService } from '@/modules/csv-export/v1/csv-export.service';
@@ -41,6 +42,7 @@ import { CsvService } from '../csv-utils/csv.service';
       'csvExport.fileStorage.aws.basePath',
     ),
     ExportApiManagerModule,
+    ChainsModule,
   ],
   controllers: [CsvExportController],
   providers: [

--- a/src/modules/csv-export/v1/csv-export.service.spec.ts
+++ b/src/modules/csv-export/v1/csv-export.service.spec.ts
@@ -17,6 +17,9 @@ import type { Page } from '@/domain/entities/page.entity';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import type { IJobQueueService } from '@/domain/interfaces/job-queue.interface';
 import type { ILoggingService } from '@/logging/logging.interface';
+import type { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
+import { nativeCurrencyBuilder } from '@/modules/chains/domain/entities/__tests__/native.currency.builder';
+import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
 import type { CsvService } from '@/modules/csv-export/csv-utils/csv.service';
 import { CsvExportService } from '@/modules/csv-export/v1/csv-export.service';
 import type { IExportApi } from '@/modules/csv-export/v1/datasources/export-api.interface';
@@ -69,6 +72,11 @@ const loggingService = {
   error: jest.fn(),
 } as jest.MockedObjectDeep<ILoggingService>;
 const mockLoggingService = jest.mocked(loggingService);
+
+const chainsRepository = {
+  getChain: jest.fn(),
+} as jest.MockedObjectDeep<IChainsRepository>;
+const mockChainsRepository = jest.mocked(chainsRepository);
 
 describe('CsvExportService', () => {
   let service: CsvExportService;
@@ -144,6 +152,13 @@ describe('CsvExportService', () => {
       }
     });
 
+    mockChainsRepository.getChain.mockResolvedValue({
+      nativeCurrency: nativeCurrencyBuilder()
+        .with('decimals', 18)
+        .with('symbol', 'ETH')
+        .build(),
+    } as Chain);
+
     setupCsvServiceMock();
   };
 
@@ -160,6 +175,7 @@ describe('CsvExportService', () => {
         mockCloudStorageApiService,
         mockConfigurationService,
         mockLoggingService,
+        mockChainsRepository,
       );
     });
 
@@ -423,6 +439,39 @@ describe('CsvExportService', () => {
       );
       expect(streamData[0].payment).toBeNull();
       expect(streamData[0].gasTokenSymbol).toBeNull();
+    });
+
+    it('should format payment using chain native currency when gasToken is zero address', async () => {
+      const nativeDecimals = 18;
+      const nativeSymbol = 'ETH';
+      const rawPayment = '13147530168800274'; // ~0.0131 ETH in wei
+
+      mockChainsRepository.getChain.mockResolvedValue({
+        nativeCurrency: nativeCurrencyBuilder()
+          .with('decimals', nativeDecimals)
+          .with('symbol', nativeSymbol)
+          .build(),
+      } as Chain);
+
+      const mockTxWithNativeGasToken = transactionExportBuilder()
+        .with('gasToken', '0x0000000000000000000000000000000000000000')
+        .with('payment', rawPayment)
+        .with('gasTokenSymbol', null)
+        .with('gasTokenDecimals', null)
+        .build();
+
+      const mockPageNative = pageBuilder()
+        .with('results', [mockTxWithNativeGasToken])
+        .with('next', null)
+        .build();
+
+      mockExportApi.export.mockResolvedValueOnce(rawify(mockPageNative));
+
+      await service.export(exportArgs);
+
+      expect(streamData).toHaveLength(1);
+      expect(streamData[0].payment).toBe('0.013147530168800274');
+      expect(streamData[0].gasTokenSymbol).toBe(nativeSymbol);
     });
 
     it('should handle pagination with default values', async () => {
@@ -699,6 +748,12 @@ describe('CsvExportService', () => {
             return 3600;
         }
       });
+      mockChainsRepository.getChain.mockResolvedValue({
+        nativeCurrency: nativeCurrencyBuilder()
+          .with('decimals', 18)
+          .with('symbol', 'ETH')
+          .build(),
+      } as Chain);
     };
 
     beforeEach(async () => {
@@ -714,6 +769,7 @@ describe('CsvExportService', () => {
         mockCloudStorageApiService,
         mockConfigurationService,
         mockLoggingService,
+        mockChainsRepository,
       );
     });
 

--- a/src/modules/csv-export/v1/csv-export.service.spec.ts
+++ b/src/modules/csv-export/v1/csv-export.service.spec.ts
@@ -400,6 +400,31 @@ describe('CsvExportService', () => {
       );
     });
 
+    it('should stream null payment fields when fee is paid from signer wallet', async () => {
+      const mockTransactionExportNoFee = transactionExportBuilder()
+        .with('payment', null)
+        .with('gasToken', null)
+        .with('gasTokenSymbol', null)
+        .with('gasTokenDecimals', null)
+        .build();
+
+      const mockPageNoFee = pageBuilder()
+        .with('results', [mockTransactionExportNoFee])
+        .with('next', null)
+        .build();
+
+      mockExportApi.export.mockResolvedValueOnce(rawify(mockPageNoFee));
+
+      await service.export(exportArgs);
+
+      expect(streamData).toHaveLength(1);
+      expect(streamData[0]).toEqual(
+        transformTransactionExport(mockTransactionExportNoFee),
+      );
+      expect(streamData[0].payment).toBeNull();
+      expect(streamData[0].gasTokenSymbol).toBeNull();
+    });
+
     it('should handle pagination with default values', async () => {
       const exportArgsNoPagination = {
         ...exportArgs,

--- a/src/modules/csv-export/v1/csv-export.service.ts
+++ b/src/modules/csv-export/v1/csv-export.service.ts
@@ -19,6 +19,7 @@ import {
   LoggingService,
 } from '@/logging/logging.interface';
 import { asError } from '@/logging/utils';
+import { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
 import { CsvService } from '@/modules/csv-export/csv-utils/csv.service';
 import { IExportApiManager } from '@/modules/csv-export/v1/datasources/export-api.manager.interface';
 import { CSV_OPTIONS } from '@/modules/csv-export/v1/entities/csv-export.options';
@@ -29,6 +30,7 @@ import {
   toJobStatusDto,
 } from '@/modules/csv-export/v1/entities/job-status.dto';
 import {
+  formatTransactionExportGasFees,
   type TransactionExport,
   TransactionExportPageSchema,
 } from '@/modules/csv-export/v1/entities/transaction-export.entity';
@@ -56,6 +58,8 @@ export class CsvExportService {
     private readonly configurationService: IConfigurationService,
     @Inject(LoggingService)
     private readonly loggingService: ILoggingService,
+    @Inject(IChainsRepository)
+    private readonly chainsRepository: IChainsRepository,
   ) {
     this.signedUrlTtlSeconds = this.configurationService.getOrThrow<number>(
       'csvExport.signedUrlTtlSeconds',
@@ -175,7 +179,11 @@ export class CsvExportService {
     let pageCount = 0;
     let totalProcessed = 0;
 
-    const api = await this.exportApiManager.getApi(chainId);
+    const [api, chain] = await Promise.all([
+      this.exportApiManager.getApi(chainId),
+      this.chainsRepository.getChain(chainId),
+    ]);
+    const { nativeCurrency } = chain;
 
     do {
       try {
@@ -200,9 +208,12 @@ export class CsvExportService {
           hasNext: !!page.next,
         });
 
-        // Yield each record individually
         for (const r of page.results) {
-          yield r;
+          yield formatTransactionExportGasFees(
+            r,
+            nativeCurrency.decimals,
+            nativeCurrency.symbol,
+          );
         }
 
         nextUrl = page.next;

--- a/src/modules/csv-export/v1/entities/__tests__/transaction-export.builder.ts
+++ b/src/modules/csv-export/v1/entities/__tests__/transaction-export.builder.ts
@@ -4,7 +4,10 @@ import type { Hash } from 'viem';
 import { formatUnits, getAddress } from 'viem';
 import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
-import type { TransactionExport } from '@/modules/csv-export/v1/entities/transaction-export.entity';
+import {
+  formatTransactionExportGasFees,
+  type TransactionExport,
+} from '@/modules/csv-export/v1/entities/transaction-export.entity';
 
 /**
  * Creates a builder for transaction export data
@@ -37,20 +40,23 @@ export function transactionExportBuilder(): IBuilder<TransactionExport> {
 }
 
 /**
- * Transforms transaction export's amount and payment and gasToken fields to user-friendly format
+ * Simulates the full two-step transformation applied by the service:
+ * schema transform (amount formatting) + gas fees formatting with native currency.
  */
 export function transformTransactionExport(
   data: TransactionExport,
+  nativeDecimals = 18,
+  nativeSymbol = 'ETH',
 ): TransactionExport {
-  const { amount, assetDecimals, payment, gasTokenDecimals, ...rest } = data;
-  return {
+  const { amount, assetDecimals, ...rest } = data;
+  const schemaTransformed: TransactionExport = {
     ...rest,
     assetDecimals,
     amount: formatUnits(BigInt(amount), assetDecimals ?? 0),
-    gasTokenDecimals: gasTokenDecimals ?? null,
-    payment:
-      payment != null
-        ? formatUnits(BigInt(payment), gasTokenDecimals ?? 0)
-        : null,
   };
+  return formatTransactionExportGasFees(
+    schemaTransformed,
+    nativeDecimals,
+    nativeSymbol,
+  );
 }

--- a/src/modules/csv-export/v1/entities/__tests__/transaction-export.builder.ts
+++ b/src/modules/csv-export/v1/entities/__tests__/transaction-export.builder.ts
@@ -29,16 +29,28 @@ export function transactionExportBuilder(): IBuilder<TransactionExport> {
     .with('note', faker.lorem.sentence())
     .with('transactionHash', faker.string.hexadecimal({ length: 64 }) as Hash)
     .with('contractAddress', getAddress(faker.finance.ethereumAddress()))
-    .with('nonce', faker.number.int().toString());
+    .with('nonce', faker.number.int().toString())
+    .with('gasToken', getAddress(faker.finance.ethereumAddress()))
+    .with('payment', faker.number.bigInt().toString())
+    .with('gasTokenSymbol', faker.finance.currencyCode())
+    .with('gasTokenDecimals', faker.number.int({ min: 0, max: 18 }));
 }
 
 /**
- * Transforms transaction export's amount field to user-friendly format
+ * Transforms transaction export's amount and payment and gasToken fields to user-friendly format
  */
 export function transformTransactionExport(
   data: TransactionExport,
 ): TransactionExport {
-  const { amount, assetDecimals, ...rest } = data;
-  const convertedAmount = formatUnits(BigInt(amount), assetDecimals ?? 0);
-  return { ...rest, amount: convertedAmount, assetDecimals };
+  const { amount, assetDecimals, payment, gasTokenDecimals, ...rest } = data;
+  return {
+    ...rest,
+    assetDecimals,
+    amount: formatUnits(BigInt(amount), assetDecimals ?? 0),
+    gasTokenDecimals: gasTokenDecimals ?? null,
+    payment:
+      payment != null
+        ? formatUnits(BigInt(payment), gasTokenDecimals ?? 0)
+        : null,
+  };
 }

--- a/src/modules/csv-export/v1/entities/csv-export.options.ts
+++ b/src/modules/csv-export/v1/entities/csv-export.options.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { CsvOptions } from '@/modules/csv-export/csv-utils/csv.service';
 
 export const CSV_OPTIONS: CsvOptions = {
@@ -17,6 +18,8 @@ export const CSV_OPTIONS: CsvOptions = {
     { key: 'proposerAddress', header: 'Proposer Address' },
     { key: 'executorAddress', header: 'Executor Address' },
     { key: 'note', header: 'Note' },
+    { key: 'payment', header: 'Amount Gas' },
+    { key: 'gasTokenSymbol', header: 'Gas token' },
   ],
   cast: {
     date: (value: Date): string => value.toISOString(),

--- a/src/modules/csv-export/v1/entities/transaction-export.entity.spec.ts
+++ b/src/modules/csv-export/v1/entities/transaction-export.entity.spec.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
+import omit from 'lodash/omit';
 import type { Address, Hex } from 'viem';
 import { getAddress } from 'viem';
 import { transactionExportBuilder } from '@/modules/csv-export/v1/entities/__tests__/transaction-export.builder';
@@ -94,6 +95,10 @@ describe('TransactionExportSchema', () => {
       .with('note', null)
       .with('contractAddress', null)
       .with('nonce', null)
+      .with('gasToken', null)
+      .with('payment', null)
+      .with('gasTokenSymbol', null)
+      .with('gasTokenDecimals', null)
       .build();
 
     const result = TransactionExportSchema.safeParse(transactionExport);
@@ -110,6 +115,29 @@ describe('TransactionExportSchema', () => {
       expect(result.data.note).toBeNull();
       expect(result.data.contractAddress).toBeNull();
       expect(result.data.nonce).toBeNull();
+      expect(result.data.gasToken).toBeNull();
+      expect(result.data.payment).toBeNull();
+      expect(result.data.gasTokenSymbol).toBeNull();
+      expect(result.data.gasTokenDecimals).toBeNull();
+    }
+  });
+
+  it('should parse successfully when gas fee fields are absent (backwards compatibility)', () => {
+    const rawData = omit(transactionExportBuilder().build(), [
+      'gasToken',
+      'payment',
+      'gasTokenSymbol',
+      'gasTokenDecimals',
+    ]);
+
+    const result = TransactionExportSchema.safeParse(rawData);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.gasToken).toBeUndefined();
+      expect(result.data.payment).toBeNull();
+      expect(result.data.gasTokenSymbol).toBeUndefined();
+      expect(result.data.gasTokenDecimals).toBeNull();
     }
   });
 
@@ -280,6 +308,78 @@ describe('TransactionExportSchema', () => {
       message: 'Invalid input: expected date, received Date',
       path: ['executedAt'],
       received: 'Invalid Date',
+    });
+  });
+
+  it('should transform payment using gasTokenDecimals', () => {
+    const rawPayment = '1000000000000000000'; // 1 token in wei
+    const expectedPayment = '1';
+
+    const transactionExport = transactionExportBuilder()
+      .with('payment', rawPayment)
+      .with('gasTokenDecimals', 18)
+      .build();
+
+    const result = TransactionExportSchema.safeParse(transactionExport);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.payment).toBe(expectedPayment);
+  });
+
+  it('should set payment to null when payment is null', () => {
+    const transactionExport = transactionExportBuilder()
+      .with('payment', null)
+      .with('gasTokenDecimals', null)
+      .build();
+
+    const result = TransactionExportSchema.safeParse(transactionExport);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.payment).toBeNull();
+  });
+
+  it('should not transform payment when gasTokenDecimals is null (defaults to 0)', () => {
+    const rawPayment = '100';
+    const expectedPayment = '100';
+
+    const transactionExport = transactionExportBuilder()
+      .with('payment', rawPayment)
+      .with('gasTokenDecimals', null)
+      .build();
+
+    const result = TransactionExportSchema.safeParse(transactionExport);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.payment).toBe(expectedPayment);
+  });
+
+  it('should validate gasToken as a valid address', () => {
+    const transactionExport = transactionExportBuilder()
+      .with('gasToken', '0x123' as Address)
+      .build();
+
+    const result = TransactionExportSchema.safeParse(transactionExport);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toStrictEqual({
+      code: 'custom',
+      message: 'Invalid address',
+      path: ['gasToken'],
+    });
+  });
+
+  it('should validate payment as numeric string', () => {
+    const transactionExport = transactionExportBuilder()
+      .with('payment', 'not-numeric')
+      .build();
+
+    const result = TransactionExportSchema.safeParse(transactionExport);
+
+    expect(!result.success && result.error.issues.length).toBe(1);
+    expect(result.error?.issues[0]).toStrictEqual({
+      code: 'custom',
+      message: 'Invalid base-10 numeric string',
+      path: ['payment'],
     });
   });
 });

--- a/src/modules/csv-export/v1/entities/transaction-export.entity.spec.ts
+++ b/src/modules/csv-export/v1/entities/transaction-export.entity.spec.ts
@@ -135,9 +135,9 @@ describe('TransactionExportSchema', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.gasToken).toBeUndefined();
-      expect(result.data.payment).toBeNull();
+      expect(result.data.payment).toBeUndefined();
       expect(result.data.gasTokenSymbol).toBeUndefined();
-      expect(result.data.gasTokenDecimals).toBeNull();
+      expect(result.data.gasTokenDecimals).toBeUndefined();
     }
   });
 
@@ -311,9 +311,8 @@ describe('TransactionExportSchema', () => {
     });
   });
 
-  it('should transform payment using gasTokenDecimals', () => {
-    const rawPayment = '1000000000000000000'; // 1 token in wei
-    const expectedPayment = '1';
+  it('should keep payment as raw numeric string (formatting happens in service)', () => {
+    const rawPayment = '1000000000000000000';
 
     const transactionExport = transactionExportBuilder()
       .with('payment', rawPayment)
@@ -323,7 +322,7 @@ describe('TransactionExportSchema', () => {
     const result = TransactionExportSchema.safeParse(transactionExport);
 
     expect(result.success).toBe(true);
-    expect(result.data?.payment).toBe(expectedPayment);
+    expect(result.data?.payment).toBe(rawPayment);
   });
 
   it('should set payment to null when payment is null', () => {
@@ -338,9 +337,8 @@ describe('TransactionExportSchema', () => {
     expect(result.data?.payment).toBeNull();
   });
 
-  it('should not transform payment when gasTokenDecimals is null (defaults to 0)', () => {
+  it('should keep payment as raw numeric string when gasTokenDecimals is null', () => {
     const rawPayment = '100';
-    const expectedPayment = '100';
 
     const transactionExport = transactionExportBuilder()
       .with('payment', rawPayment)
@@ -350,7 +348,7 @@ describe('TransactionExportSchema', () => {
     const result = TransactionExportSchema.safeParse(transactionExport);
 
     expect(result.success).toBe(true);
-    expect(result.data?.payment).toBe(expectedPayment);
+    expect(result.data?.payment).toBe(rawPayment);
   });
 
   it('should validate gasToken as a valid address', () => {

--- a/src/modules/csv-export/v1/entities/transaction-export.entity.ts
+++ b/src/modules/csv-export/v1/entities/transaction-export.entity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { formatUnits } from 'viem';
+import { formatUnits, isAddressEqual, zeroAddress } from 'viem';
 import { z } from 'zod';
 import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -29,21 +29,40 @@ export const TransactionExportSchema = z
     gasTokenSymbol: z.string().nullish(),
     gasTokenDecimals: z.number().nullish(),
   })
-  .transform(
-    ({ amount, assetDecimals, payment, gasTokenDecimals, ...rest }) => ({
-      ...rest,
-      assetDecimals,
-      amount: formatUnits(BigInt(amount), assetDecimals ?? 0),
-      gasTokenDecimals: gasTokenDecimals ?? null,
-      payment:
-        payment != null
-          ? formatUnits(BigInt(payment), gasTokenDecimals ?? 0)
-          : null,
-    }),
-  );
+  .transform(({ amount, assetDecimals, ...rest }) => ({
+    ...rest,
+    assetDecimals,
+    amount: formatUnits(BigInt(amount), assetDecimals ?? 0),
+  }));
 
 export const TransactionExportPageSchema = buildPageSchema(
   TransactionExportSchema,
 );
 
 export type TransactionExport = z.infer<typeof TransactionExportSchema>;
+
+/**
+ * Formats the gas fee payment amount using the correct decimals and symbol.
+ * When gasToken is the zero address (native token), uses chain nativeCurrency
+ * values instead of the null gasTokenDecimals/gasTokenSymbol from the API.
+ */
+export function formatTransactionExportGasFees(
+  tx: TransactionExport,
+  nativeDecimals: number,
+  nativeSymbol: string,
+): TransactionExport {
+  const { payment, gasToken, gasTokenDecimals, gasTokenSymbol } = tx;
+
+  if (gasToken == null || payment == null) {
+    return { ...tx, payment: null };
+  }
+
+  const isNativeToken = isAddressEqual(gasToken, zeroAddress);
+  const decimals = isNativeToken ? nativeDecimals : (gasTokenDecimals ?? 0);
+
+  return {
+    ...tx,
+    payment: formatUnits(BigInt(payment), decimals),
+    gasTokenSymbol: isNativeToken ? nativeSymbol : (gasTokenSymbol ?? null),
+  };
+}

--- a/src/modules/csv-export/v1/entities/transaction-export.entity.ts
+++ b/src/modules/csv-export/v1/entities/transaction-export.entity.ts
@@ -24,12 +24,23 @@ export const TransactionExportSchema = z
     transactionHash: HexSchema,
     contractAddress: AddressSchema.nullable(),
     nonce: z.string().nullable(),
+    gasToken: AddressSchema.nullish(),
+    payment: NumericStringSchema.nullish(),
+    gasTokenSymbol: z.string().nullish(),
+    gasTokenDecimals: z.number().nullish(),
   })
-  .transform(({ amount, assetDecimals, ...rest }) => ({
-    ...rest,
-    assetDecimals,
-    amount: formatUnits(BigInt(amount), assetDecimals ?? 0),
-  }));
+  .transform(
+    ({ amount, assetDecimals, payment, gasTokenDecimals, ...rest }) => ({
+      ...rest,
+      assetDecimals,
+      amount: formatUnits(BigInt(amount), assetDecimals ?? 0),
+      gasTokenDecimals: gasTokenDecimals ?? null,
+      payment:
+        payment != null
+          ? formatUnits(BigInt(payment), gasTokenDecimals ?? 0)
+          : null,
+    }),
+  );
 
 export const TransactionExportPageSchema = buildPageSchema(
   TransactionExportSchema,


### PR DESCRIPTION
- Closes https://linear.app/safe-global/issue/PLA-1419/history-csv-export-should-contain-paid-from-the-safe-info#comment-9b93eec1

- Related with https://github.com/safe-global/safe-transaction-service/pull/2878/changes

  ## Summary                                                                                                                                                                                                                                       
                  
  - Adds `gasToken`, `payment`, `gasTokenSymbol` and `gasTokenDecimals` fields                                                                                                                                                                         
    to `TransactionExportSchema`, parsing the new fields returned by the Tx Service
    `/api/v1/safes/{address}/export/` endpoint (PLA-1419)
      - New fields are parsed as .nullish() in the schema so older API versions that don't return them don't break existing exports
      - Adds a backwards-compatibility test that verifies parsing succeeds when the new fields are absent from the API response                                                                                                                                   
  - Formats the raw `payment` amount using `formatUnits(payment, gasTokenDecimals)`,                                                                                                                                                                       
    matching the existing pattern for `amount`/`assetDecimals`                                                                                                                                                                                     
  - Adds two new columns to the CSV output: **"Amount Gas"** and **"Gas token"**;                                                                                                                                                                  
    both are empty when the fee was paid from the signer wallet (`fee` is null)   
    
    
   `payment` is the amount the Safe paid out to refund the executor for gas costs. When a Safe transaction is executed, the executor can optionally be reimbursed directly from the Safe using a configured gas token. If the executor paid gas from their own wallet, this field is null.

  This is the "paid from the Safe" info referenced in the ticket, the new columns expose that refund amount (payment), the token used (gasToken, gasTokenSymbol, gasTokenDecimals) so it shows up in the CSV export for accounting purposes.