### PR TITLE
fix: rename gasVolatilityBuffer to gasPriceVolatilityBuffer in pricin…

### DIFF
--- a/src/modules/fees/domain/entities/__tests__/tx-fees-response.builder.ts
+++ b/src/modules/fees/domain/entities/__tests__/tx-fees-response.builder.ts
@@ -27,7 +27,7 @@ export function pricingContextSnapshotBuilder(): IBuilder<PricingContextSnapshot
     .with('phase', faker.number.int({ min: 1, max: 3 }))
     .with('priceSource', PriceSource.COINGECKO)
     .with('priceTimestamp', faker.number.int())
-    .with('gasVolatilityBuffer', faker.number.float({ min: 1, max: 2 }));
+    .with('gasPriceVolatilityBuffer', faker.number.float({ min: 1, max: 2 }));
 }
 
 export function txFeesResponseBuilder(): IBuilder<TxFeesResponse> {

--- a/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-response.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-response.schema.spec.ts
@@ -51,7 +51,7 @@ describe('PricingContextSnapshotSchema', () => {
       phase: 1,
       priceSource: 'COINGECKO',
       priceTimestamp: 1700000000,
-      gasVolatilityBuffer: 1.3,
+      gasPriceVolatilityBuffer: 1.3,
     };
 
     const result = PricingContextSnapshotSchema.safeParse(pricingContext);
@@ -64,7 +64,7 @@ describe('PricingContextSnapshotSchema', () => {
       phase: 1,
       priceSource: 'INVALID_SOURCE',
       priceTimestamp: 1700000000,
-      gasVolatilityBuffer: 1.3,
+      gasPriceVolatilityBuffer: 1.3,
     };
 
     const result = PricingContextSnapshotSchema.safeParse(pricingContext);
@@ -89,7 +89,7 @@ describe('TxFeesResponseSchema', () => {
         phase: 1,
         priceSource: 'COINGECKO',
         priceTimestamp: 1700000000,
-        gasVolatilityBuffer: 1.3,
+        gasPriceVolatilityBuffer: 1.3,
       },
     };
 

--- a/src/modules/fees/domain/entities/schemas/tx-fees-response.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/tx-fees-response.schema.ts
@@ -19,7 +19,7 @@ export const PricingContextSnapshotSchema = z.object({
   phase: z.number(),
   priceSource: z.enum(PriceSource),
   priceTimestamp: z.number(),
-  gasVolatilityBuffer: z.number(),
+  gasPriceVolatilityBuffer: z.number(),
 });
 
 export const TxFeesResponseSchema = z.object({

--- a/src/modules/fees/routes/entities/fee-preview-response.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-response.entity.ts
@@ -68,16 +68,16 @@ export class FeePreviewPricingContext {
   priceTimestamp: number;
 
   @ApiProperty({
-    description: 'Gas volatility buffer multiplier',
+    description: 'Gas price volatility buffer multiplier',
     example: 1.3,
   })
-  gasVolatilityBuffer: number;
+  gasPriceVolatilityBuffer: number;
 
   constructor(pricingContext: TxFeesResponse['pricingContextSnapshot']) {
     this.phase = pricingContext.phase;
     this.priceSource = pricingContext.priceSource;
     this.priceTimestamp = pricingContext.priceTimestamp;
-    this.gasVolatilityBuffer = pricingContext.gasVolatilityBuffer;
+    this.gasPriceVolatilityBuffer = pricingContext.gasPriceVolatilityBuffer;
   }
 }
 


### PR DESCRIPTION
Related to: https://github.com/safe-global/safe-fee-service/pull/74/changes#diff-6b33c3ddd5f190a9c756f22dd271e59a360f9ceb6a4c5d119ceb8c4e7102fb19

**Entity and schema updates:**

* Renamed the property from `gasVolatilityBuffer` to `gasPriceVolatilityBuffer` in the `PricingContextSnapshotSchema` definition (`tx-fees-response.schema.ts`).
* Updated the `FeePreviewPricingContext` entity and its constructor to use the new property name and updated the API property description accordingly (`fee-preview-response.entity.ts`).

**Test and builder updates:**

* Updated all relevant test cases to use `gasPriceVolatilityBuffer` instead of `gasVolatilityBuffer` in `tx-fees-response.schema.spec.ts`.
* Changed the builder function to use the new property name in `tx-fees-response.builder.ts`.