### PR TITLE
feat: forward fiatCode in relay fee preview and return relayCost object

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -1096,10 +1096,11 @@ export class CacheRouter {
     operation: number;
     gasToken: Address;
     threshold: number;
+    fiatCode?: string;
   }): CacheDir {
     const hash = crypto.createHash('sha256');
     hash.update(
-      `${args.to}_${args.value}_${args.data}_${args.operation}_${args.gasToken}_${args.threshold}`,
+      `${args.to}_${args.value}_${args.data}_${args.operation}_${args.gasToken}_${args.threshold}_${args.fiatCode ?? 'USD'}`,
     );
     return new CacheDir(
       CacheRouter.getRelayFeePreviewCacheKey(args),

--- a/src/datasources/fee-service-api/fee-service-api.service.ts
+++ b/src/datasources/fee-service-api/fee-service-api.service.ts
@@ -78,6 +78,7 @@ export class FeeServiceApi implements IFeeServiceApi {
       operation: args.request.operation,
       gasToken: args.request.gasToken,
       threshold: args.request.numberSignatures,
+      fiatCode: args.request.fiatCode,
     });
     const url = `${this.relayFeeConfiguration.baseUri}/v1/chains/${args.chainId}/safes/${args.safeAddress}/transactions/relay-fees`;
 

--- a/src/modules/fees/domain/entities/__tests__/tx-fees-response.builder.ts
+++ b/src/modules/fees/domain/entities/__tests__/tx-fees-response.builder.ts
@@ -5,9 +5,10 @@ import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
 import { PriceSource } from '@/modules/fees/domain/entities/price-source.entity';
 import type {
+  LegacyTxFeesResponse,
   PricingContextSnapshot,
+  RelayCost,
   TxDataResponse,
-  TxFeesResponse,
 } from '@/modules/fees/domain/entities/tx-fees-response.entity';
 
 export function txDataResponseBuilder(): IBuilder<TxDataResponse> {
@@ -30,8 +31,25 @@ export function pricingContextSnapshotBuilder(): IBuilder<PricingContextSnapshot
     .with('gasVolatilityBuffer', faker.number.float({ min: 1, max: 2 }));
 }
 
-export function txFeesResponseBuilder(): IBuilder<TxFeesResponse> {
-  return new Builder<TxFeesResponse>()
+export function relayCostBuilder(): IBuilder<RelayCost> {
+  return new Builder<RelayCost>()
+    .with('fiatCode', faker.finance.currencyCode())
+    .with('fiatValue', faker.number.float({ min: 0, max: 100 }).toString());
+}
+
+export function txFeesResponseBuilder() {
+  return new Builder<{
+    txData: TxDataResponse;
+    relayCost: RelayCost;
+    pricingContextSnapshot: PricingContextSnapshot;
+  }>()
+    .with('txData', txDataResponseBuilder().build())
+    .with('relayCost', relayCostBuilder().build())
+    .with('pricingContextSnapshot', pricingContextSnapshotBuilder().build());
+}
+
+export function legacyTxFeesResponseBuilder(): IBuilder<LegacyTxFeesResponse> {
+  return new Builder<LegacyTxFeesResponse>()
     .with('txData', txDataResponseBuilder().build())
     .with('relayCostUsd', faker.number.float({ min: 0, max: 100 }))
     .with('pricingContextSnapshot', pricingContextSnapshotBuilder().build());

--- a/src/modules/fees/domain/entities/__tests__/tx-fees-response.builder.ts
+++ b/src/modules/fees/domain/entities/__tests__/tx-fees-response.builder.ts
@@ -5,10 +5,10 @@ import type { IBuilder } from '@/__tests__/builder';
 import { Builder } from '@/__tests__/builder';
 import { PriceSource } from '@/modules/fees/domain/entities/price-source.entity';
 import type {
-  LegacyTxFeesResponse,
   PricingContextSnapshot,
   RelayCost,
   TxDataResponse,
+  TxFeesResponse,
 } from '@/modules/fees/domain/entities/tx-fees-response.entity';
 
 export function txDataResponseBuilder(): IBuilder<TxDataResponse> {
@@ -37,20 +37,9 @@ export function relayCostBuilder(): IBuilder<RelayCost> {
     .with('fiatValue', faker.number.float({ min: 0, max: 100 }).toString());
 }
 
-export function txFeesResponseBuilder() {
-  return new Builder<{
-    txData: TxDataResponse;
-    relayCost: RelayCost;
-    pricingContextSnapshot: PricingContextSnapshot;
-  }>()
+export function txFeesResponseBuilder(): IBuilder<TxFeesResponse> {
+  return new Builder<TxFeesResponse>()
     .with('txData', txDataResponseBuilder().build())
     .with('relayCost', relayCostBuilder().build())
-    .with('pricingContextSnapshot', pricingContextSnapshotBuilder().build());
-}
-
-export function legacyTxFeesResponseBuilder(): IBuilder<LegacyTxFeesResponse> {
-  return new Builder<LegacyTxFeesResponse>()
-    .with('txData', txDataResponseBuilder().build())
-    .with('relayCostUsd', faker.number.float({ min: 0, max: 100 }))
     .with('pricingContextSnapshot', pricingContextSnapshotBuilder().build());
 }

--- a/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-response.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-response.schema.spec.ts
@@ -2,7 +2,10 @@
 
 import { faker } from '@faker-js/faker';
 import { getAddress, zeroAddress } from 'viem';
-import { txFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
+import {
+  legacyTxFeesResponseBuilder,
+  txFeesResponseBuilder,
+} from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
 import {
   PricingContextSnapshotSchema,
   TxDataResponseSchema,
@@ -74,8 +77,16 @@ describe('PricingContextSnapshotSchema', () => {
 });
 
 describe('TxFeesResponseSchema', () => {
-  it('should validate a valid tx-fees response', () => {
+  it('should validate a response with relayCost', () => {
     const response = txFeesResponseBuilder().build();
+
+    const result = TxFeesResponseSchema.safeParse(response);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a legacy response with relayCostUsd', () => {
+    const response = legacyTxFeesResponseBuilder().build();
 
     const result = TxFeesResponseSchema.safeParse(response);
 
@@ -84,7 +95,7 @@ describe('TxFeesResponseSchema', () => {
 
   it('should not allow a missing txData', () => {
     const response = {
-      relayCostUsd: 38.22,
+      relayCost: { fiatCode: 'USD', fiatValue: '38.22' },
       pricingContextSnapshot: {
         phase: 1,
         priceSource: 'COINGECKO',
@@ -98,18 +109,27 @@ describe('TxFeesResponseSchema', () => {
     expect(!result.success && result.error.issues).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          code: 'invalid_type',
-          path: ['txData'],
+          code: 'invalid_union',
+          errors: expect.arrayContaining([
+            expect.arrayContaining([
+              expect.objectContaining({
+                code: 'invalid_type',
+                path: ['txData'],
+              }),
+            ]),
+          ]),
         }),
       ]),
     );
   });
 
-  it('should not allow a missing relayCostUsd', () => {
-    const response = txFeesResponseBuilder().build();
-    const { relayCostUsd: _, ...withoutRelayCostUsd } = response;
+  it('should not allow a response missing both relayCost and relayCostUsd', () => {
+    const { txData, pricingContextSnapshot } = txFeesResponseBuilder().build();
 
-    const result = TxFeesResponseSchema.safeParse(withoutRelayCostUsd);
+    const result = TxFeesResponseSchema.safeParse({
+      txData,
+      pricingContextSnapshot,
+    });
 
     expect(result.success).toBe(false);
   });

--- a/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-response.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/tx-fees-response.schema.spec.ts
@@ -2,10 +2,7 @@
 
 import { faker } from '@faker-js/faker';
 import { getAddress, zeroAddress } from 'viem';
-import {
-  legacyTxFeesResponseBuilder,
-  txFeesResponseBuilder,
-} from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
+import { txFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
 import {
   PricingContextSnapshotSchema,
   TxDataResponseSchema,
@@ -77,7 +74,7 @@ describe('PricingContextSnapshotSchema', () => {
 });
 
 describe('TxFeesResponseSchema', () => {
-  it('should validate a response with relayCost', () => {
+  it('should validate a valid tx-fees response', () => {
     const response = txFeesResponseBuilder().build();
 
     const result = TxFeesResponseSchema.safeParse(response);
@@ -85,45 +82,26 @@ describe('TxFeesResponseSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should validate a legacy response with relayCostUsd', () => {
-    const response = legacyTxFeesResponseBuilder().build();
-
-    const result = TxFeesResponseSchema.safeParse(response);
-
-    expect(result.success).toBe(true);
-  });
-
   it('should not allow a missing txData', () => {
-    const response = {
-      relayCost: { fiatCode: 'USD', fiatValue: '38.22' },
-      pricingContextSnapshot: {
-        phase: 1,
-        priceSource: 'COINGECKO',
-        priceTimestamp: 1700000000,
-        gasVolatilityBuffer: 1.3,
-      },
-    };
+    const { relayCost, pricingContextSnapshot } =
+      txFeesResponseBuilder().build();
 
-    const result = TxFeesResponseSchema.safeParse(response);
+    const result = TxFeesResponseSchema.safeParse({
+      relayCost,
+      pricingContextSnapshot,
+    });
 
     expect(!result.success && result.error.issues).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          code: 'invalid_union',
-          errors: expect.arrayContaining([
-            expect.arrayContaining([
-              expect.objectContaining({
-                code: 'invalid_type',
-                path: ['txData'],
-              }),
-            ]),
-          ]),
+          code: 'invalid_type',
+          path: ['txData'],
         }),
       ]),
     );
   });
 
-  it('should not allow a response missing both relayCost and relayCostUsd', () => {
+  it('should not allow a missing relayCost', () => {
     const { txData, pricingContextSnapshot } = txFeesResponseBuilder().build();
 
     const result = TxFeesResponseSchema.safeParse({

--- a/src/modules/fees/domain/entities/schemas/tx-fees-request.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/tx-fees-request.schema.ts
@@ -12,4 +12,5 @@ export const TxFeesRequestSchema = z.object({
   operation: z.enum(Operation),
   numberSignatures: z.number().int().min(1),
   gasToken: AddressSchema,
+  fiatCode: z.string().optional(),
 });

--- a/src/modules/fees/domain/entities/schemas/tx-fees-response.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/tx-fees-response.schema.ts
@@ -27,16 +27,8 @@ export const RelayCostSchema = z.object({
   fiatValue: z.string(),
 });
 
-const TxFeesResponseBaseSchema = z.object({
+export const TxFeesResponseSchema = z.object({
   txData: TxDataResponseSchema,
+  relayCost: RelayCostSchema,
   pricingContextSnapshot: PricingContextSnapshotSchema,
 });
-
-export const LegacyTxFeesResponseSchema = TxFeesResponseBaseSchema.extend({
-  relayCostUsd: z.number(),
-});
-
-export const TxFeesResponseSchema = z.union([
-  TxFeesResponseBaseSchema.extend({ relayCost: RelayCostSchema }),
-  LegacyTxFeesResponseSchema,
-]);

--- a/src/modules/fees/domain/entities/schemas/tx-fees-response.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/tx-fees-response.schema.ts
@@ -22,8 +22,21 @@ export const PricingContextSnapshotSchema = z.object({
   gasVolatilityBuffer: z.number(),
 });
 
-export const TxFeesResponseSchema = z.object({
+export const RelayCostSchema = z.object({
+  fiatCode: z.string(),
+  fiatValue: z.string(),
+});
+
+const TxFeesResponseBaseSchema = z.object({
   txData: TxDataResponseSchema,
-  relayCostUsd: z.number(),
   pricingContextSnapshot: PricingContextSnapshotSchema,
 });
+
+export const LegacyTxFeesResponseSchema = TxFeesResponseBaseSchema.extend({
+  relayCostUsd: z.number(),
+});
+
+export const TxFeesResponseSchema = z.union([
+  TxFeesResponseBaseSchema.extend({ relayCost: RelayCostSchema }),
+  LegacyTxFeesResponseSchema,
+]);

--- a/src/modules/fees/domain/entities/tx-fees-response.entity.ts
+++ b/src/modules/fees/domain/entities/tx-fees-response.entity.ts
@@ -2,7 +2,6 @@
 
 import type { z } from 'zod';
 import type {
-  LegacyTxFeesResponseSchema,
   PricingContextSnapshotSchema,
   RelayCostSchema,
   TxDataResponseSchema,
@@ -16,7 +15,5 @@ export type PricingContextSnapshot = z.infer<
 >;
 
 export type RelayCost = z.infer<typeof RelayCostSchema>;
-
-export type LegacyTxFeesResponse = z.infer<typeof LegacyTxFeesResponseSchema>;
 
 export type TxFeesResponse = z.infer<typeof TxFeesResponseSchema>;

--- a/src/modules/fees/domain/entities/tx-fees-response.entity.ts
+++ b/src/modules/fees/domain/entities/tx-fees-response.entity.ts
@@ -2,7 +2,9 @@
 
 import type { z } from 'zod';
 import type {
+  LegacyTxFeesResponseSchema,
   PricingContextSnapshotSchema,
+  RelayCostSchema,
   TxDataResponseSchema,
   TxFeesResponseSchema,
 } from '@/modules/fees/domain/entities/schemas/tx-fees-response.schema';
@@ -12,5 +14,9 @@ export type TxDataResponse = z.infer<typeof TxDataResponseSchema>;
 export type PricingContextSnapshot = z.infer<
   typeof PricingContextSnapshotSchema
 >;
+
+export type RelayCost = z.infer<typeof RelayCostSchema>;
+
+export type LegacyTxFeesResponse = z.infer<typeof LegacyTxFeesResponseSchema>;
 
 export type TxFeesResponse = z.infer<typeof TxFeesResponseSchema>;

--- a/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
@@ -11,7 +11,10 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import configuration from '@/config/entities/__tests__/configuration';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { NetworkService } from '@/datasources/network/network.service.interface';
-import { txFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
+import {
+  legacyTxFeesResponseBuilder,
+  txFeesResponseBuilder,
+} from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
 import { feePreviewTransactionDtoBuilder } from '@/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder';
 import { rawify } from '@/validation/entities/raw.entity';
 
@@ -88,12 +91,15 @@ describe('Fees Controller', () => {
       });
   });
 
-  it('should return fee preview when relay-fee is enabled', async () => {
+  it('should return fee preview with relayCost when fee service returns new format', async () => {
     const safeAddress = getAddress(faker.finance.ethereumAddress());
     const feePreviewDto = feePreviewTransactionDtoBuilder()
       .with('value', '1000000000000000000')
+      .with('fiatCode', 'EUR')
       .build();
-    const mockFeeResponse = txFeesResponseBuilder().build();
+    const mockFeeResponse = txFeesResponseBuilder()
+      .with('relayCost', { fiatCode: 'EUR', fiatValue: '0.0025' })
+      .build();
 
     networkService.post.mockImplementation(({ url }) => {
       if (
@@ -110,7 +116,48 @@ describe('Fees Controller', () => {
       .send(feePreviewDto)
       .expect(200)
       .expect(({ body }) => {
-        expect(body).toMatchObject(mockFeeResponse);
+        expect(body.relayCost).toEqual({
+          fiatCode: 'EUR',
+          fiatValue: '0.0025',
+        });
+        expect(body.txData).toBeDefined();
+        expect(body.pricingContextSnapshot).toBeDefined();
+      });
+  });
+
+  it('should normalize legacy relayCostUsd to relayCost when fee service returns old format', async () => {
+    const safeAddress = getAddress(faker.finance.ethereumAddress());
+    const feePreviewDto = feePreviewTransactionDtoBuilder()
+      .with('value', '1000000000000000000')
+      .build();
+    const mockLegacyFeeResponse = legacyTxFeesResponseBuilder()
+      .with('relayCostUsd', 0.0025)
+      .build();
+
+    networkService.post.mockImplementation(({ url }) => {
+      if (
+        url ===
+        `${feeServiceBaseUri}/v1/chains/${ENABLED_CHAIN_ID}/safes/${safeAddress}/transactions/relay-fees`
+      ) {
+        return Promise.resolve({
+          data: rawify(mockLegacyFeeResponse),
+          status: 200,
+        });
+      }
+      return Promise.reject(new Error(`Could not match ${url}`));
+    });
+
+    await request(app.getHttpServer())
+      .post(`/v1/chains/${ENABLED_CHAIN_ID}/fees/${safeAddress}/preview`)
+      .send(feePreviewDto)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.relayCost).toEqual({
+          fiatCode: 'USD',
+          fiatValue: '0.0025',
+        });
+        expect(body.txData).toBeDefined();
+        expect(body.pricingContextSnapshot).toBeDefined();
       });
   });
 

--- a/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/fee-preview.fees.controller.integration.spec.ts
@@ -11,10 +11,7 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import configuration from '@/config/entities/__tests__/configuration';
 import type { INetworkService } from '@/datasources/network/network.service.interface';
 import { NetworkService } from '@/datasources/network/network.service.interface';
-import {
-  legacyTxFeesResponseBuilder,
-  txFeesResponseBuilder,
-} from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
+import { txFeesResponseBuilder } from '@/modules/fees/domain/entities/__tests__/tx-fees-response.builder';
 import { feePreviewTransactionDtoBuilder } from '@/modules/fees/routes/entities/__tests__/fee-preview-transaction.dto.builder';
 import { rawify } from '@/validation/entities/raw.entity';
 
@@ -118,42 +115,6 @@ describe('Fees Controller', () => {
       .expect(({ body }) => {
         expect(body.relayCost).toEqual({
           fiatCode: 'EUR',
-          fiatValue: '0.0025',
-        });
-        expect(body.txData).toBeDefined();
-        expect(body.pricingContextSnapshot).toBeDefined();
-      });
-  });
-
-  it('should normalize legacy relayCostUsd to relayCost when fee service returns old format', async () => {
-    const safeAddress = getAddress(faker.finance.ethereumAddress());
-    const feePreviewDto = feePreviewTransactionDtoBuilder()
-      .with('value', '1000000000000000000')
-      .build();
-    const mockLegacyFeeResponse = legacyTxFeesResponseBuilder()
-      .with('relayCostUsd', 0.0025)
-      .build();
-
-    networkService.post.mockImplementation(({ url }) => {
-      if (
-        url ===
-        `${feeServiceBaseUri}/v1/chains/${ENABLED_CHAIN_ID}/safes/${safeAddress}/transactions/relay-fees`
-      ) {
-        return Promise.resolve({
-          data: rawify(mockLegacyFeeResponse),
-          status: 200,
-        });
-      }
-      return Promise.reject(new Error(`Could not match ${url}`));
-    });
-
-    await request(app.getHttpServer())
-      .post(`/v1/chains/${ENABLED_CHAIN_ID}/fees/${safeAddress}/preview`)
-      .send(feePreviewDto)
-      .expect(200)
-      .expect(({ body }) => {
-        expect(body.relayCost).toEqual({
-          fiatCode: 'USD',
           fiatValue: '0.0025',
         });
         expect(body.txData).toBeDefined();

--- a/src/modules/fees/routes/entities/fee-preview-response.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-response.entity.ts
@@ -109,17 +109,9 @@ export class FeePreviewResponse {
 
   constructor(txFeesResponse: TxFeesResponse) {
     this.txData = new FeePreviewTxData(txFeesResponse.txData);
+    this.relayCost = new FeePreviewRelayCost(txFeesResponse.relayCost);
     this.pricingContextSnapshot = new FeePreviewPricingContext(
       txFeesResponse.pricingContextSnapshot,
     );
-
-    const relayCost =
-      'relayCost' in txFeesResponse
-        ? txFeesResponse.relayCost
-        : {
-            fiatCode: 'USD',
-            fiatValue: txFeesResponse.relayCostUsd.toString(),
-          };
-    this.relayCost = new FeePreviewRelayCost(relayCost);
   }
 }

--- a/src/modules/fees/routes/entities/fee-preview-response.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-response.entity.ts
@@ -3,7 +3,10 @@ import { ApiProperty } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { zeroAddress } from 'viem';
 import { PriceSource } from '@/modules/fees/domain/entities/price-source.entity';
-import type { TxFeesResponse } from '@/modules/fees/domain/entities/tx-fees-response.entity';
+import type {
+  RelayCost,
+  TxFeesResponse,
+} from '@/modules/fees/domain/entities/tx-fees-response.entity';
 
 export class FeePreviewTxData {
   @ApiProperty({ description: 'Chain ID', example: 1 })
@@ -81,21 +84,42 @@ export class FeePreviewPricingContext {
   }
 }
 
+export class FeePreviewRelayCost {
+  @ApiProperty({ description: 'Fiat currency code', example: 'USD' })
+  fiatCode: string;
+
+  @ApiProperty({ description: 'Relay cost as a string', example: '0.0025' })
+  fiatValue: string;
+
+  constructor(relayCost: RelayCost) {
+    this.fiatCode = relayCost.fiatCode;
+    this.fiatValue = relayCost.fiatValue;
+  }
+}
+
 export class FeePreviewResponse {
   @ApiProperty({ type: FeePreviewTxData })
   txData: FeePreviewTxData;
 
-  @ApiProperty({ description: 'Relay cost in USD', example: 38.22 })
-  relayCostUsd: number;
+  @ApiProperty({ type: FeePreviewRelayCost })
+  relayCost: FeePreviewRelayCost;
 
   @ApiProperty({ type: FeePreviewPricingContext })
   pricingContextSnapshot: FeePreviewPricingContext;
 
   constructor(txFeesResponse: TxFeesResponse) {
     this.txData = new FeePreviewTxData(txFeesResponse.txData);
-    this.relayCostUsd = txFeesResponse.relayCostUsd;
     this.pricingContextSnapshot = new FeePreviewPricingContext(
       txFeesResponse.pricingContextSnapshot,
     );
+
+    const relayCost =
+      'relayCost' in txFeesResponse
+        ? txFeesResponse.relayCost
+        : {
+            fiatCode: 'USD',
+            fiatValue: txFeesResponse.relayCostUsd.toString(),
+          };
+    this.relayCost = new FeePreviewRelayCost(relayCost);
   }
 }

--- a/src/modules/fees/routes/entities/fee-preview-transaction.dto.entity.ts
+++ b/src/modules/fees/routes/entities/fee-preview-transaction.dto.entity.ts
@@ -37,6 +37,14 @@ export class FeePreviewTransactionDto
   })
   numberSignatures: number;
 
+  @ApiProperty({
+    description:
+      'Fiat currency code for relay cost conversion (e.g. EUR, GBP). Defaults to USD.',
+    example: 'EUR',
+    required: false,
+  })
+  fiatCode?: string;
+
   constructor(dto: z.infer<typeof FeePreviewTransactionDtoSchema>) {
     this.to = dto.to;
     this.value = dto.value;
@@ -44,5 +52,6 @@ export class FeePreviewTransactionDto
     this.operation = dto.operation;
     this.gasToken = dto.gasToken;
     this.numberSignatures = dto.numberSignatures;
+    this.fiatCode = dto.fiatCode;
   }
 }

--- a/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
+++ b/src/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema.ts
@@ -7,4 +7,5 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 export const FeePreviewTransactionDtoSchema = TransactionBaseSchema.extend({
   gasToken: AddressSchema,
   numberSignatures: z.number().int().min(1),
+  fiatCode: z.string().optional(),
 });


### PR DESCRIPTION
  ## Summary

  Part of PLA-1446 (https://linear.app/safe-global/issue/PLA-1446/fee-service-accept-fiat-selector-in-relay-cost-preview-and-return). CGW follow up after fee service support for fiat selector.

  - Accept optional `fiatCode` in the `POST .../fees/:safeAddress/preview` body and forward it to the fee service
  - Handle both legacy (`relayCostUsd`) and new (`relayCost`) fee service response formats for backwards compatibility during rollout
  - Always return `relayCost: { fiatCode, fiatValue }` in the CGW response, normalising the legacy format to `{ fiatCode: 'USD', fiatValue: '...' }` when needed
  - Include `fiatCode` in the relay fee preview cache key so different currencies are cached independently

  ## Related
  Fee service PR: https://github.com/safe-global/safe-fee-service/pull/85
