### PR TITLE
feat: Add `payment` and `fee` fields to transaction details

### DIFF
--- a/src/modules/safe/domain/entities/__tests__/multisig-transaction.builder.ts
+++ b/src/modules/safe/domain/entities/__tests__/multisig-transaction.builder.ts
@@ -83,6 +83,7 @@ export function multisigTransactionBuilder(): BuilderWithConfirmations<MultisigT
       .with('executor', getAddress(faker.finance.ethereumAddress()))
       .with('executionDate', faker.date.recent())
       .with('fee', faker.string.numeric())
+      .with('payment', faker.string.numeric())
       .with('gasPrice', faker.string.numeric())
       .with('gasToken', getAddress(faker.finance.ethereumAddress()))
       .with('gasUsed', faker.number.int())

--- a/src/modules/safe/domain/entities/__tests__/multisig-transaction.entity.spec.ts
+++ b/src/modules/safe/domain/entities/__tests__/multisig-transaction.entity.spec.ts
@@ -114,6 +114,7 @@ describe('MultisigTransaction', () => {
       'gasPrice' as const,
       'ethGasPrice' as const,
       'fee' as const,
+      'payment' as const,
     ])('should require %s to be a numeric string', (key) => {
       const multisigTransaction = multisigTransactionBuilder()
         .with(key, faker.string.alpha())
@@ -168,6 +169,7 @@ describe('MultisigTransaction', () => {
       'ethGasPrice' as const,
       'gasUsed' as const,
       'fee' as const,
+      'payment' as const,
       'origin' as const,
       'confirmations' as const,
       'signatures' as const,

--- a/src/modules/safe/domain/entities/multisig-transaction.entity.ts
+++ b/src/modules/safe/domain/entities/multisig-transaction.entity.ts
@@ -52,6 +52,7 @@ export const MultisigTransactionSchema = TransactionBaseSchema.extend({
   ethGasPrice: NullableNumericStringSchema,
   gasUsed: NullableNumberSchema,
   fee: NullableNumericStringSchema,
+  payment: NullableNumericStringSchema,
   origin: NullableStringSchema,
   confirmationsRequired: z.number(),
   confirmations: z.array(ConfirmationSchema).nullish().default(null),

--- a/src/modules/transactions/routes/entities/transaction-details/multisig-execution-details.entity.ts
+++ b/src/modules/transactions/routes/entities/transaction-details/multisig-execution-details.entity.ts
@@ -52,6 +52,10 @@ export class MultisigExecutionDetails extends ExecutionDetails {
   @ApiProperty()
   gasToken: string;
   @ApiProperty()
+  fee: string;
+  @ApiProperty()
+  payment: string;
+  @ApiProperty()
   refundReceiver: AddressInfo;
   @ApiProperty()
   safeTxHash: string;
@@ -88,6 +92,8 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     baseGas: string,
     gasPrice: string,
     gasToken: string,
+    fee: string,
+    payment: string,
     refundReceiver: AddressInfo,
     safeTxHash: string,
     executor: AddressInfo | null,
@@ -107,6 +113,8 @@ export class MultisigExecutionDetails extends ExecutionDetails {
     this.baseGas = baseGas;
     this.gasPrice = gasPrice;
     this.gasToken = gasToken;
+    this.fee = fee;
+    this.payment = payment;
     this.refundReceiver = refundReceiver;
     this.safeTxHash = safeTxHash;
     this.executor = executor;

--- a/src/modules/transactions/routes/entities/txs-multisig-transaction.entity.ts
+++ b/src/modules/transactions/routes/entities/txs-multisig-transaction.entity.ts
@@ -64,6 +64,8 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
   @ApiProperty()
   fee: string | null;
   @ApiProperty()
+  payment: string | null;
+  @ApiProperty()
   origin: string | null;
   @ApiProperty()
   confirmationsRequired: number;
@@ -101,6 +103,7 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
     ethGasPrice: string | null;
     gasUsed: number | null;
     fee: string | null;
+    payment: string | null;
     origin: string | null;
     confirmationsRequired: number;
     confirmations: Array<Confirmation> | null;
@@ -132,6 +135,7 @@ export class TXSMultisigTransaction implements DomainMultisigTransaction {
     this.ethGasPrice = args.ethGasPrice;
     this.gasUsed = args.gasUsed;
     this.fee = args.fee;
+    this.payment = args.payment;
     this.origin = args.origin;
     this.confirmationsRequired = args.confirmationsRequired;
     this.confirmations = args.confirmations;

--- a/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
+++ b/src/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction-execution-details.mapper.ts
@@ -71,6 +71,8 @@ export class MultisigTransactionExecutionDetailsMapper {
       transaction.baseGas?.toString() ?? '0',
       transaction.gasPrice?.toString() ?? '0',
       gasToken,
+      transaction.fee ?? '0',
+      transaction.payment ?? '0',
       refundReceiver,
       transaction.safeTxHash,
       executor,


### PR DESCRIPTION
## Summary 

This pull request adds support for a new `payment` field to multisig transaction entities and their related classes, schemas, and tests

The `payment` field is required for the accurate display of fees when a user decides to pay using the Safe

