### PR TITLE
refactor(members): lift admin check from MembersRepository to MembersService

### DIFF
--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -97,5 +97,31 @@ describe('MembersService', () => {
       ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
       expect(membersRepositoryMock.inviteUsers).not.toHaveBeenCalled();
     });
+
+    it.each([
+      ['SIWE', siweAuthPayloadDtoBuilder],
+      ['OIDC', oidcAuthPayloadDtoBuilder],
+    ] as const)('should call inviteUsers when the %s caller is an active admin', async (_label, builder) => {
+      const authPayload = new AuthPayload(builder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const inviteUsersDto: InviteUsersDto = { users: [] };
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.inviteUsers.mockResolvedValue([]);
+
+      await expect(
+        service.inviteUser({ authPayload, spaceId, inviteUsersDto }),
+      ).resolves.toEqual([]);
+      expect(membersRepositoryMock.findActiveAdmin).toHaveBeenCalled();
+      expect(membersRepositoryMock.inviteUsers).toHaveBeenCalledWith({
+        authPayload,
+        spaceId,
+        users: [],
+      });
+    });
   });
 });

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -4,6 +4,7 @@ import { faker } from '@faker-js/faker';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import { oidcAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { MembersService } from '@/modules/spaces/routes/members.service';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import { userBuilder } from '@/modules/users/datasources/entities/__tests__/users.entity.db.builder';
@@ -12,6 +13,7 @@ import type { IMembersRepository } from '@/modules/users/domain/members.reposito
 const MAX_INVITES = 10;
 
 const membersRepositoryMock = {
+  findActiveAdmin: jest.fn(),
   findAuthorizedMembersOrFail: jest.fn(),
   inviteUsers: jest.fn(),
 } as jest.MockedObjectDeep<IMembersRepository>;
@@ -60,6 +62,20 @@ describe('MembersService', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('inviteUser', () => {
+    it('should throw when the caller is not authenticated', async () => {
+      const authPayload = new AuthPayload();
+      const spaceId = faker.number.int({ min: 1 });
+      const inviteUsersDto: InviteUsersDto = { users: [] };
+
+      await expect(
+        service.inviteUser({ authPayload, spaceId, inviteUsersDto }),
+      ).rejects.toThrow('Not authenticated');
+      expect(membersRepositoryMock.findActiveAdmin).not.toHaveBeenCalled();
+      expect(membersRepositoryMock.inviteUsers).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
+import { ForbiddenException } from '@nestjs/common';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
-import { oidcAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import {
+  oidcAuthPayloadDtoBuilder,
+  siweAuthPayloadDtoBuilder,
+} from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { MembersService } from '@/modules/spaces/routes/members.service';
@@ -75,6 +79,22 @@ describe('MembersService', () => {
         service.inviteUser({ authPayload, spaceId, inviteUsersDto }),
       ).rejects.toThrow('Not authenticated');
       expect(membersRepositoryMock.findActiveAdmin).not.toHaveBeenCalled();
+      expect(membersRepositoryMock.inviteUsers).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['SIWE', siweAuthPayloadDtoBuilder],
+      ['OIDC', oidcAuthPayloadDtoBuilder],
+    ] as const)('should throw ForbiddenException for the %s caller when findActiveAdmin returns null', async (_label, builder) => {
+      const authPayload = new AuthPayload(builder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const inviteUsersDto: InviteUsersDto = { users: [] };
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(null);
+
+      await expect(
+        service.inviteUser({ authPayload, spaceId, inviteUsersDto }),
+      ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
       expect(membersRepositoryMock.inviteUsers).not.toHaveBeenCalled();
     });
   });

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -34,14 +34,10 @@ export class MembersService {
     spaceId: Space['id'];
     inviteUsersDto: InviteUsersDto;
   }): Promise<Array<Invitation>> {
-    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
-    const activeAdmin = await this.membersRepository.findActiveAdmin({
-      userId,
+    await this.assertActiveAdmin({
+      authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
-    if (!activeAdmin) {
-      throw new ForbiddenException('User is not an active admin.');
-    }
     if (args.inviteUsersDto.users.length > this.maxInvites) {
       throw new ConflictException('Too many invites.');
     }
@@ -151,5 +147,19 @@ export class MembersService {
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
+  }
+
+  private async assertActiveAdmin(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<void> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+    const activeAdmin = await this.membersRepository.findActiveAdmin({
+      userId,
+      spaceId: args.spaceId,
+    });
+    if (!activeAdmin) {
+      throw new ForbiddenException('User is not an active admin.');
+    }
   }
 }

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ConflictException, Inject } from '@nestjs/common';
+import { ConflictException, ForbiddenException, Inject } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { AcceptInviteDto } from '@/modules/spaces/routes/entities/accept-invite.dto.entity';
 import type { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
@@ -33,6 +34,14 @@ export class MembersService {
     spaceId: Space['id'];
     inviteUsersDto: InviteUsersDto;
   }): Promise<Array<Invitation>> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+    const activeAdmin = await this.membersRepository.findActiveAdmin({
+      userId,
+      spaceId: args.spaceId,
+    });
+    if (!activeAdmin) {
+      throw new ForbiddenException('User is not an active admin.');
+    }
     if (args.inviteUsersDto.users.length > this.maxInvites) {
       throw new ConflictException('Too many invites.');
     }

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -518,6 +518,31 @@ describe('MembersRepository', () => {
     });
   });
 
+  describe('findActiveAdmin', () => {
+    it('should return null when the user is a MEMBER, not an ADMIN', async () => {
+      const { userId, user } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      await dbMembersRepository.insert({
+        user,
+        space: space.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'MEMBER',
+        status: 'ACTIVE',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      await expect(
+        membersRepository.findActiveAdmin({
+          userId,
+          spaceId: space.generatedMaps[0].id,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
   describe('inviteUsers', () => {
     it('should invite users to a space and return the members', async () => {
       const spaceName = nameBuilder();
@@ -682,43 +707,6 @@ describe('MembersRepository', () => {
           },
         },
       ]);
-    });
-
-    it('should not allow inviting users if the user is not an ADMIN', async () => {
-      const spaceName = nameBuilder();
-      const memberName = nameBuilder();
-      const { user: owner, authPayload } = await createSiweUser();
-      const space = await dbSpacesRepository.insert({
-        name: spaceName,
-        status: 'ACTIVE',
-      });
-      const spaceId = space.generatedMaps[0].id;
-      await dbMembersRepository.insert({
-        user: owner,
-        space: space.generatedMaps[0],
-        name: memberName,
-        role: 'MEMBER',
-        status: 'ACTIVE',
-        invitedBy: getAddress(faker.finance.ethereumAddress()),
-      });
-      const users = faker.helpers.multiple(
-        () => {
-          return {
-            address: getAddress(faker.finance.ethereumAddress()),
-            role: faker.helpers.arrayElement(MemberRoleKeys),
-            name: faker.person.firstName(),
-          };
-        },
-        { count: { min: 2, max: 5 } },
-      );
-
-      await expect(
-        membersRepository.inviteUsers({
-          authPayload,
-          spaceId,
-          users,
-        }),
-      ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
     });
 
     it('should not allow inviting users if the user is a NON-ACTIVE ADMIN', async () => {

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -582,6 +582,24 @@ describe('MembersRepository', () => {
         }),
       ).resolves.toBeNull();
     });
+
+    it('should return null for an INVITED admin even when another ACTIVE admin exists in the same space', async () => {
+      const { spaceId } = await createSpaceAsAdmin();
+      const space = await dbSpacesRepository.findOneByOrFail({ id: spaceId });
+      const { userId, user } = await createSiweUser();
+      await dbMembersRepository.insert({
+        user,
+        space,
+        name: nameBuilder(),
+        role: 'ADMIN',
+        status: 'INVITED',
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      await expect(
+        membersRepository.findActiveAdmin({ userId, spaceId }),
+      ).resolves.toBeNull();
+    });
   });
 
   describe('inviteUsers', () => {
@@ -771,47 +789,6 @@ describe('MembersRepository', () => {
       ).rejects.toThrow('Space not found.');
     });
 
-    it('should throw an error if the signer_address member is not ACTIVE', async () => {
-      const spaceName = nameBuilder();
-      const adminName = nameBuilder();
-      const { user: admin } = await createSiweUser();
-      const { user: invitedAdmin, authPayload: invitedAdminAuthPayload } =
-        await createSiweUser();
-      const space = await dbSpacesRepository.insert({
-        name: spaceName,
-        status: 'ACTIVE',
-      });
-      const spaceId = space.generatedMaps[0].id;
-      await dbMembersRepository.insert({
-        user: admin,
-        space: space.generatedMaps[0],
-        name: adminName,
-        role: 'ADMIN',
-        status: 'ACTIVE',
-        invitedBy: getAddress(faker.finance.ethereumAddress()),
-      });
-      await dbMembersRepository.insert({
-        user: invitedAdmin,
-        space: space.generatedMaps[0],
-        name: adminName,
-        role: 'ADMIN',
-        status: 'INVITED',
-        invitedBy: getAddress(faker.finance.ethereumAddress()),
-      });
-      const users: Array<{
-        address: Address;
-        role: keyof typeof MemberRole;
-        name: string;
-      }> = [];
-
-      await expect(
-        membersRepository.inviteUsers({
-          authPayload: invitedAdminAuthPayload,
-          spaceId,
-          users,
-        }),
-      ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
-    });
   });
 
   describe('acceptInvite', () => {

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -567,6 +567,21 @@ describe('MembersRepository', () => {
         }),
       ).resolves.toBeNull();
     });
+
+    it('should return null when the user is an ACTIVE ADMIN of a different space', async () => {
+      const { userId } = await createSpaceAsAdmin();
+      const otherSpace = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+
+      await expect(
+        membersRepository.findActiveAdmin({
+          userId,
+          spaceId: otherSpace.generatedMaps[0].id,
+        }),
+      ).resolves.toBeNull();
+    });
   });
 
   describe('inviteUsers', () => {
@@ -733,48 +748,6 @@ describe('MembersRepository', () => {
           },
         },
       ]);
-    });
-
-    it('should not allow inviting users if the signer is an admin of another space', async () => {
-      const sourceSpaceName = nameBuilder();
-      const targetSpaceName = nameBuilder();
-      const memberName = nameBuilder();
-      const { user: owner, authPayload } = await createSiweUser();
-      const sourceSpace = await dbSpacesRepository.insert({
-        name: sourceSpaceName,
-        status: 'ACTIVE',
-      });
-      const targetSpace = await dbSpacesRepository.insert({
-        name: targetSpaceName,
-        status: 'ACTIVE',
-      });
-      const targetSpaceId = targetSpace.generatedMaps[0].id;
-      await dbMembersRepository.insert({
-        user: owner,
-        space: sourceSpace.generatedMaps[0],
-        name: memberName,
-        role: 'ADMIN',
-        status: 'ACTIVE',
-        invitedBy: getAddress(faker.finance.ethereumAddress()),
-      });
-      const users = faker.helpers.multiple(
-        () => {
-          return {
-            address: getAddress(faker.finance.ethereumAddress()),
-            role: faker.helpers.arrayElement(MemberRoleKeys),
-            name: faker.person.firstName(),
-          };
-        },
-        { count: { min: 1, max: 3 } },
-      );
-
-      await expect(
-        membersRepository.inviteUsers({
-          authPayload,
-          spaceId: targetSpaceId,
-          users,
-        }),
-      ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
     });
 
     it('should throw an error if the space does not exist', async () => {
@@ -3036,6 +3009,33 @@ describe('MembersRepository', () => {
       userId,
       user: user.generatedMaps[0],
       authPayload: new AuthPayload(authPayloadDto),
+    };
+  }
+
+  async function createSpaceAsAdmin(): Promise<{
+    spaceId: Space['id'];
+    userId: number;
+    user: Record<string, unknown>;
+    authPayload: AuthPayload;
+  }> {
+    const { userId, user, authPayload } = await createSiweUser();
+    const space = await dbSpacesRepository.insert({
+      name: nameBuilder(),
+      status: 'ACTIVE',
+    });
+    await dbMembersRepository.insert({
+      user,
+      space: space.generatedMaps[0],
+      name: nameBuilder(),
+      status: 'ACTIVE',
+      role: 'ADMIN',
+      invitedBy: getAddress(faker.finance.ethereumAddress()),
+    });
+    return {
+      spaceId: space.generatedMaps[0].id,
+      userId,
+      user,
+      authPayload,
     };
   }
 });

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -684,26 +684,6 @@ describe('MembersRepository', () => {
       ]);
     });
 
-    it('should throw an error if not authenticated', async () => {
-      const spaceId = faker.number.int({
-        min: 69420,
-        max: DB_MAX_SAFE_INTEGER,
-      });
-      const users: Array<{
-        address: Address;
-        role: keyof typeof MemberRole;
-        name: string;
-      }> = [];
-
-      await expect(
-        membersRepository.inviteUsers({
-          authPayload: new AuthPayload(),
-          spaceId,
-          users,
-        }),
-      ).rejects.toThrow('Not authenticated');
-    });
-
     it('should not allow inviting users if the user is not an ADMIN', async () => {
       const spaceName = nameBuilder();
       const memberName = nameBuilder();

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -519,6 +519,34 @@ describe('MembersRepository', () => {
   });
 
   describe('findActiveAdmin', () => {
+    it('should return the member when the user is an ACTIVE ADMIN of the space', async () => {
+      const { spaceId, userId } = await createSpaceAsAdmin();
+
+      await expect(
+        membersRepository.findActiveAdmin({ userId, spaceId }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          role: 'ADMIN',
+          status: 'ACTIVE',
+        }),
+      );
+    });
+
+    it('should return null when the user has no member record in the space', async () => {
+      const { userId } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+
+      await expect(
+        membersRepository.findActiveAdmin({
+          userId,
+          spaceId: space.generatedMaps[0].id,
+        }),
+      ).resolves.toBeNull();
+    });
+
     it('should return null when the user is a MEMBER, not an ADMIN', async () => {
       const { userId, user } = await createSiweUser();
       const space = await dbSpacesRepository.insert({
@@ -598,6 +626,18 @@ describe('MembersRepository', () => {
 
       await expect(
         membersRepository.findActiveAdmin({ userId, spaceId }),
+      ).resolves.toBeNull();
+    });
+
+    it('should return null when the caller is an ACTIVE ADMIN of a different space, even if the queried space has its own ACTIVE admin', async () => {
+      const { userId } = await createSpaceAsAdmin();
+      const { spaceId: otherSpaceId } = await createSpaceAsAdmin();
+
+      await expect(
+        membersRepository.findActiveAdmin({
+          userId,
+          spaceId: otherSpaceId,
+        }),
       ).resolves.toBeNull();
     });
   });
@@ -788,7 +828,6 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow('Space not found.');
     });
-
   });
 
   describe('acceptInvite', () => {

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -541,6 +541,32 @@ describe('MembersRepository', () => {
         }),
       ).resolves.toBeNull();
     });
+
+    it('should return null when the ADMIN status is not ACTIVE', async () => {
+      const nonActiveStatus = faker.helpers.arrayElement(
+        MemberStatusKeys.filter((s) => s !== 'ACTIVE'),
+      );
+      const { userId, user } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      await dbMembersRepository.insert({
+        user,
+        space: space.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'ADMIN',
+        status: nonActiveStatus,
+        invitedBy: getAddress(faker.finance.ethereumAddress()),
+      });
+
+      await expect(
+        membersRepository.findActiveAdmin({
+          userId,
+          spaceId: space.generatedMaps[0].id,
+        }),
+      ).resolves.toBeNull();
+    });
   });
 
   describe('inviteUsers', () => {
@@ -707,43 +733,6 @@ describe('MembersRepository', () => {
           },
         },
       ]);
-    });
-
-    it('should not allow inviting users if the user is a NON-ACTIVE ADMIN', async () => {
-      const spaceName = nameBuilder();
-      const memberName = nameBuilder();
-      const { user: owner, authPayload } = await createSiweUser();
-      const space = await dbSpacesRepository.insert({
-        name: spaceName,
-        status: 'ACTIVE',
-      });
-      const spaceId = space.generatedMaps[0].id;
-      await dbMembersRepository.insert({
-        user: owner,
-        space: space.generatedMaps[0],
-        name: memberName,
-        role: 'ADMIN',
-        status: 'INVITED',
-        invitedBy: getAddress(faker.finance.ethereumAddress()),
-      });
-      const users = faker.helpers.multiple(
-        () => {
-          return {
-            address: getAddress(faker.finance.ethereumAddress()),
-            role: faker.helpers.arrayElement(MemberRoleKeys),
-            name: faker.person.firstName(),
-          };
-        },
-        { count: { min: 2, max: 5 } },
-      );
-
-      await expect(
-        membersRepository.inviteUsers({
-          authPayload,
-          spaceId,
-          users,
-        }),
-      ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
     });
 
     it('should not allow inviting users if the signer is an admin of another space', async () => {

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -32,6 +32,11 @@ export interface IMembersRepository {
 
   find(args?: FindManyOptions<DbMember>): Promise<Array<DbMember>>;
 
+  findActiveAdmin(args: {
+    userId: User['id'];
+    spaceId: Space['id'];
+  }): Promise<DbMember | null>;
+
   inviteUsers(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -88,6 +88,23 @@ export class MembersRepository implements IMembersRepository {
     return await membersRepository.find(args);
   }
 
+  public async findActiveAdmin(args: {
+    userId: User['id'];
+    spaceId: Space['id'];
+  }): Promise<DbMember | null> {
+    const membersRepository =
+      await this.postgresDatabaseService.getRepository(DbMember);
+
+    return await membersRepository.findOne({
+      where: {
+        user: { id: args.userId },
+        space: { id: args.spaceId },
+        status: 'ACTIVE',
+        role: 'ADMIN',
+      },
+    });
+  }
+
   public async inviteUsers(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
@@ -102,15 +119,9 @@ export class MembersRepository implements IMembersRepository {
     const space = await this.spacesRepository.findOneOrFail({
       where: { id: args.spaceId },
     });
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    const activeAdmin = await membersRepository.findOne({
-      where: {
-        user: { id: userId },
-        space: { id: args.spaceId },
-        status: 'ACTIVE',
-        role: 'ADMIN',
-      },
+    const activeAdmin = await this.findActiveAdmin({
+      userId,
+      spaceId: args.spaceId,
     });
     if (!activeAdmin) {
       throw new ForbiddenException('User is not an active admin.');

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -114,18 +114,9 @@ export class MembersRepository implements IMembersRepository {
       role: Member['role'];
     }>;
   }): Promise<Array<Invitation>> {
-    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
-
     const space = await this.spacesRepository.findOneOrFail({
       where: { id: args.spaceId },
     });
-    const activeAdmin = await this.findActiveAdmin({
-      userId,
-      spaceId: args.spaceId,
-    });
-    if (!activeAdmin) {
-      throw new ForbiddenException('User is not an active admin.');
-    }
 
     const invitedAddresses = args.users.map((user) => user.address);
     const invitedWallets = await this.walletsRepository.find({


### PR DESCRIPTION
## Summary

Prerequisite work for [WA-2313 (BE: Invitation can be resent)](https://linear.app/safe-global/issue/WA-2313/be-invitation-can-be-resent), which requires the same active-admin authz check. Lifts the check out of `MembersRepository.inviteUsers` and into `MembersService`, behind a reusable `assertActiveAdmin` private helper.

- Adds `findActiveAdmin` to `MembersRepository` — thin "is this user an active admin of this space?" query, returns `Member | null`. Integration tests include confounder cases (another active admin in the same space).
- Moves the admin + auth assertion from `MembersRepository.inviteUsers` to `MembersService.inviteUser`.
- Extracts `assertActiveAdmin` as a private helper on `MembersService`.

No behavior change for HTTP callers.