### PR TITLE
feat(auth): introduce EmailAddress schema

### DIFF
--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
+import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
 
 const relayRulesValidator = z
   .string()
@@ -65,7 +66,7 @@ export const RootConfigurationSchema = z
     AWS_KMS_ENCRYPTION_KEY_ID: z.string().optional(),
     AWS_SECRET_ACCESS_KEY: z.string().optional(),
     AWS_REGION: z.string().optional(),
-    AWS_SES_FROM_EMAIL: z.email().optional(),
+    AWS_SES_FROM_EMAIL: EmailAddressSchema.optional(),
     AWS_SES_FROM_NAME: z.string().optional(),
     BLOCKLIST_ENCRYPTED_DATA: z.string(),
     BLOCKLIST_SECRET_KEY: z.string(),
@@ -103,7 +104,7 @@ export const RootConfigurationSchema = z
       .optional(),
     // TODO: Reassess EMAIL_ keys after email integration
     EMAIL_API_APPLICATION_CODE: z.string(),
-    EMAIL_API_FROM_EMAIL: z.email(),
+    EMAIL_API_FROM_EMAIL: EmailAddressSchema,
     EMAIL_API_KEY: z.string(),
     EXPIRATION_DEVIATE_PERCENT: z.coerce.number().min(0).max(100).optional(),
     FINGERPRINT_ENCRYPTION_KEY: z.string(),
@@ -111,7 +112,7 @@ export const RootConfigurationSchema = z
     JWT_ISSUER: z.string(),
     JWT_SECRET: z.string(),
     PUSH_NOTIFICATIONS_API_PROJECT: z.string(),
-    PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: z.email(),
+    PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: EmailAddressSchema,
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY: z.string(),
     PUSH_NOTIFICATIONS_API_OAUTH2_TOKEN_TTL_BUFFER_IN_SECONDS: z.coerce
       .number()

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
-import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
 
 const relayRulesValidator = z
   .string()
@@ -66,7 +65,7 @@ export const RootConfigurationSchema = z
     AWS_KMS_ENCRYPTION_KEY_ID: z.string().optional(),
     AWS_SECRET_ACCESS_KEY: z.string().optional(),
     AWS_REGION: z.string().optional(),
-    AWS_SES_FROM_EMAIL: EmailAddressSchema.optional(),
+    AWS_SES_FROM_EMAIL: z.email().optional(),
     AWS_SES_FROM_NAME: z.string().optional(),
     BLOCKLIST_ENCRYPTED_DATA: z.string(),
     BLOCKLIST_SECRET_KEY: z.string(),
@@ -104,7 +103,7 @@ export const RootConfigurationSchema = z
       .optional(),
     // TODO: Reassess EMAIL_ keys after email integration
     EMAIL_API_APPLICATION_CODE: z.string(),
-    EMAIL_API_FROM_EMAIL: EmailAddressSchema,
+    EMAIL_API_FROM_EMAIL: z.email(),
     EMAIL_API_KEY: z.string(),
     EXPIRATION_DEVIATE_PERCENT: z.coerce.number().min(0).max(100).optional(),
     FINGERPRINT_ENCRYPTION_KEY: z.string(),
@@ -112,7 +111,7 @@ export const RootConfigurationSchema = z
     JWT_ISSUER: z.string(),
     JWT_SECRET: z.string(),
     PUSH_NOTIFICATIONS_API_PROJECT: z.string(),
-    PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: EmailAddressSchema,
+    PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL: z.email(),
     PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY: z.string(),
     PUSH_NOTIFICATIONS_API_OAUTH2_TOKEN_TTL_BUFFER_IN_SECONDS: z.coerce
       .number()

--- a/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
+++ b/src/modules/auth/oidc/auth0/domain/auth0.repository.spec.ts
@@ -5,6 +5,7 @@ import type { IAuth0Api } from '@/modules/auth/oidc/auth0/datasources/auth0-api.
 import { Auth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository';
 import type { Auth0TokenVerifier } from '@/modules/auth/oidc/auth0/domain/auth0-token.verifier';
 import { rawify } from '@/validation/entities/raw.entity';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const auth0ApiMock = {
   getAuthorizationUrl: jest.fn(),
@@ -63,7 +64,7 @@ describe('Auth0Repository', () => {
         iat: faker.date.past(),
         nbf: faker.date.recent(),
         exp: faker.date.future(),
-        email: faker.internet.email().toLowerCase(),
+        email: fakeEmailAddress(),
         email_verified: true,
       };
 

--- a/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
+++ b/src/modules/auth/oidc/auth0/domain/entities/auth0-token.entity.ts
@@ -2,12 +2,13 @@
 
 import { z } from 'zod';
 import { JwtClaimsSchema } from '@/datasources/jwt/jwt-claims.entity';
+import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
 
 // Auth0 ID token claims:
 // https://auth0.com/docs/tokens/references/id-token-structure
 export const Auth0TokenSchema = JwtClaimsSchema.extend({
   sub: z.string().min(1),
-  email: z.email().max(255).optional(),
+  email: EmailAddressSchema.optional(),
   email_verified: z.boolean().optional(),
 }).superRefine((token, ctx) => {
   if (token.email_verified === true && token.email === undefined) {

--- a/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
+++ b/src/modules/auth/oidc/routes/oidc-auth.service.spec.ts
@@ -12,6 +12,7 @@ import { AuthMethod } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { IAuth0Repository } from '@/modules/auth/oidc/auth0/domain/auth0.repository.interface';
 import { OidcAuthService } from '@/modules/auth/oidc/routes/oidc-auth.service';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const authRepositoryMock = {
   signToken: jest.fn(),
@@ -162,7 +163,7 @@ describe('OidcAuthService', () => {
 
       const extUserId = `auth0|${faker.string.uuid()}`;
       const userId = faker.number.int();
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
 
       auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
         sub: extUserId,
@@ -190,7 +191,7 @@ describe('OidcAuthService', () => {
 
       const extUserId = `auth0|${faker.string.uuid()}`;
       const userId = faker.number.int();
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
 
       auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({
         sub: extUserId,
@@ -246,7 +247,7 @@ describe('OidcAuthService', () => {
       jest.setSystemTime(now);
 
       const extUserId = `auth0|${faker.string.uuid()}`;
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       const error = new Error('Database connection failed');
 
       auth0RepositoryMock.authenticateWithAuthorizationCode.mockResolvedValue({

--- a/src/modules/auth/routes/auth.controller.integration.spec.ts
+++ b/src/modules/auth/routes/auth.controller.integration.spec.ts
@@ -26,6 +26,7 @@ import { siweMessageBuilder } from '@/modules/siwe/domain/entities/__tests__/siw
 import { TestUsersModule } from '@/modules/users/__tests__/test.users.module';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { UsersModule } from '@/modules/users/users.module';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 describe('AuthController', () => {
   let app: INestApplication<Server>;
@@ -714,7 +715,7 @@ describe('AuthController', () => {
     it('should return 200 with email for a valid OIDC access token when stored', async () => {
       const authPayloadDto = oidcAuthPayloadDtoBuilder().build();
       const accessToken = jwtService.sign(authPayloadDto);
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       usersRepository.findEmailById.mockResolvedValue(email);
 
       await request(app.getHttpServer())

--- a/src/modules/auth/routes/auth.service.spec.ts
+++ b/src/modules/auth/routes/auth.service.spec.ts
@@ -20,6 +20,7 @@ import { AuthService } from '@/modules/auth/routes/auth.service';
 import { siweMessageBuilder } from '@/modules/siwe/domain/entities/__tests__/siwe-message.builder';
 import type { ISiweRepository } from '@/modules/siwe/domain/siwe.repository.interface';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const siweRepositoryMock = {
   generateNonce: jest.fn(),
@@ -317,7 +318,7 @@ describe('AuthService', () => {
 
     it('should return email for OIDC sessions when email is stored', async () => {
       const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       usersRepositoryMock.findEmailById.mockResolvedValue(email);
 
       await expect(target.getUserSession(authPayload)).resolves.toEqual({

--- a/src/modules/auth/routes/entities/user-session.entity.ts
+++ b/src/modules/auth/routes/entities/user-session.entity.ts
@@ -3,6 +3,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { AuthMethod } from '@/modules/auth/domain/entities/auth-payload.entity';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
 
 export class UserSession {
   @ApiProperty()
@@ -21,5 +22,5 @@ export class UserSession {
     description:
       'Verified email address. Present only for OIDC-authenticated users when stored.',
   })
-  email?: string;
+  email?: EmailAddress;
 }

--- a/src/modules/spaces/routes/address-book-requests.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/address-book-requests.controller.e2e-spec.ts
@@ -17,6 +17,7 @@ import {
 import { NotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/notifications.repository.module';
 import { TestNotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/test.notification.repository.module';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 describe('AddressBookRequestsController', () => {
   let app: INestApplication<Server>;
@@ -496,7 +497,7 @@ describe('AddressBookRequestsController', () => {
     userId: number;
     email: string;
   }> => {
-    const email = faker.internet.email().toLowerCase();
+    const email = fakeEmailAddress();
     const userId = await usersRepository.findOrCreateByExtUserIdWithEmail(
       faker.string.uuid(),
       { address: email, verified: true },

--- a/src/modules/spaces/routes/address-books.service.spec.ts
+++ b/src/modules/spaces/routes/address-books.service.spec.ts
@@ -16,6 +16,7 @@ import { UserIdentityResolverService } from '@/modules/users/domain/user-identit
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { walletBuilder } from '@/modules/wallets/datasources/entities/__tests__/wallets.entity.db.builder';
 import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const repositoryMock = {
   findAllBySpaceId: jest.fn(),
@@ -130,7 +131,7 @@ describe('AddressBooksService', () => {
       const spaceId = faker.number.int();
       const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
       const userId = faker.number.int({ min: 1, max: 1000 });
-      const email = faker.internet.email();
+      const email = fakeEmailAddress();
       const items = [
         addressBookItemBuilder()
           .with('createdBy', userId)
@@ -191,7 +192,7 @@ describe('AddressBooksService', () => {
     it('should resolve different identities for different creators', async () => {
       const spaceId = faker.number.int();
       const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
-      const user1Email = faker.internet.email();
+      const user1Email = fakeEmailAddress();
       const user1 = userBuilder().with('email', user1Email).build();
       const user2 = userBuilder().with('email', null).build();
       const user2Wallet = walletBuilder().with('user', user2).build();

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -22,6 +22,7 @@ import { NotificationsRepositoryV2Module } from '@/modules/notifications/domain/
 import { TestNotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/test.notification.repository.module';
 import { MembersController } from '@/modules/spaces/routes/members.controller';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 describe('MembersController', () => {
   let app: INestApplication<Server>;
@@ -1301,7 +1302,7 @@ describe('MembersController', () => {
 
     it('should return email for active members', async () => {
       const spaceName = nameBuilder();
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
 
       const userId = await usersRepository.findOrCreateByExtUserIdWithEmail(
         faker.string.uuid(),
@@ -1342,7 +1343,7 @@ describe('MembersController', () => {
       const spaceName = nameBuilder();
       const invitedAddress = getAddress(faker.finance.ethereumAddress());
       const invitedName = faker.person.firstName();
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
 
       const userId = await usersRepository.findOrCreateByExtUserIdWithEmail(
         faker.string.uuid(),

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -8,6 +8,7 @@ import { MembersService } from '@/modules/spaces/routes/members.service';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import { userBuilder } from '@/modules/users/datasources/entities/__tests__/users.entity.db.builder';
 import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const MAX_INVITES = 10;
 
@@ -34,7 +35,7 @@ describe('MembersService', () => {
 
   describe('get', () => {
     it('should hide stored email for invited members', async () => {
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       const member = memberBuilder()
         .with('status', 'INVITED')
         .with(

--- a/src/modules/spaces/routes/user-address-book.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/user-address-book.controller.e2e-spec.ts
@@ -17,6 +17,7 @@ import {
 import { NotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/notifications.repository.module';
 import { TestNotificationsRepositoryV2Module } from '@/modules/notifications/domain/v2/test.notification.repository.module';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 describe('UserAddressBookController', () => {
   let app: INestApplication<Server>;
@@ -393,7 +394,7 @@ describe('UserAddressBookController', () => {
     userId: number;
     email: string;
   }> => {
-    const email = faker.internet.email().toLowerCase();
+    const email = fakeEmailAddress();
     const userId = await usersRepository.findOrCreateByExtUserIdWithEmail(
       faker.string.uuid(),
       { address: email, verified: true },

--- a/src/modules/users/datasources/entities/users.entity.db.ts
+++ b/src/modules/users/datasources/entities/users.entity.db.ts
@@ -14,6 +14,7 @@ import {
   UserStatus,
 } from '@/modules/users/domain/entities/user.entity';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
 
 @Entity('users')
 @Check(
@@ -54,7 +55,7 @@ export class User implements DomainUser {
     length: 255,
     nullable: true,
   })
-  email!: string | null;
+  email!: EmailAddress | null;
 
   @OneToMany(
     () => Wallet,

--- a/src/modules/users/domain/__tests__/user-identity-resolver.service.spec.ts
+++ b/src/modules/users/domain/__tests__/user-identity-resolver.service.spec.ts
@@ -7,6 +7,7 @@ import { UserIdentityResolverService } from '@/modules/users/domain/user-identit
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { Wallet as DbWallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const mockUsersRepository = jest.mocked({
   find: jest.fn(),
@@ -49,7 +50,7 @@ describe('UserIdentityResolverService', () => {
   it('prefers wallet address when present', async () => {
     const wallet = getAddress(faker.finance.ethereumAddress());
     mockUsersRepository.find.mockResolvedValue([
-      buildUser({ id: 1, email: 'a@b.com' }),
+      buildUser({ id: 1, email: fakeEmailAddress() }),
     ]);
     mockWalletsRepository.find.mockResolvedValue([
       buildWallet({ user: buildUser({ id: 1 }), address: wallet }),
@@ -60,13 +61,12 @@ describe('UserIdentityResolverService', () => {
   });
 
   it('falls back to email when no wallet', async () => {
-    mockUsersRepository.find.mockResolvedValue([
-      buildUser({ id: 2, email: 'c@d.com' }),
-    ]);
+    const email = fakeEmailAddress();
+    mockUsersRepository.find.mockResolvedValue([buildUser({ id: 2, email })]);
     mockWalletsRepository.find.mockResolvedValue([]);
 
     const result = await service.resolveMany([2]);
-    expect(result.get(2)).toBe('c@d.com');
+    expect(result.get(2)).toBe(email);
   });
 
   it('returns "Unknown user" when no wallet and no email', async () => {

--- a/src/modules/users/domain/entities/user.entity.ts
+++ b/src/modules/users/domain/entities/user.entity.ts
@@ -6,6 +6,8 @@ import type { Member } from '@/modules/users/domain/entities/member.entity';
 import { MemberSchema } from '@/modules/users/domain/entities/member.entity';
 import type { Wallet } from '@/modules/wallets/domain/entities/wallet.entity';
 import { WalletSchema } from '@/modules/wallets/domain/entities/wallet.entity';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
+import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
 
 export enum UserStatus {
   PENDING = 0,
@@ -19,14 +21,14 @@ export const UserSchema: z.ZodType<
   z.infer<typeof RowSchema> & {
     status: keyof typeof UserStatus;
     extUserId: string | null;
-    email: string | null;
+    email: EmailAddress | null;
     wallets: Array<Wallet>;
     members: Array<Member>;
   }
 > = RowSchema.extend({
   status: z.enum(getStringEnumKeys(UserStatus)),
   extUserId: z.string().min(1).max(255).nullable(),
-  email: z.email().max(255).nullable(),
+  email: EmailAddressSchema.nullable(),
   wallets: z.array(WalletSchema),
   members: z.array(z.lazy(() => MemberSchema)),
 });

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -25,6 +25,7 @@ import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-e
 import { UsersRepository } from '@/modules/users/domain/users.repository';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const mockLoggingService = {
   debug: jest.fn(),
@@ -917,7 +918,7 @@ describe('UsersRepository', () => {
   describe('findOrCreateByExtUserIdWithEmail', () => {
     it('should enforce unique non-null user emails', async () => {
       const dbUserRepository = dataSource.getRepository(User);
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
 
       await dbUserRepository.insert({
         status: 'ACTIVE',
@@ -953,7 +954,7 @@ describe('UsersRepository', () => {
         extUserId,
       });
       const userId = userInsertResult.identifiers[0].id as number;
-      const email = faker.internet.email();
+      const email = fakeEmailAddress();
 
       await usersRepository.findOrCreateByExtUserIdWithEmail(extUserId, {
         address: email,
@@ -963,13 +964,13 @@ describe('UsersRepository', () => {
       const user = await dbUserRepository.findOneOrFail({
         where: { id: userId },
       });
-      expect(user.email).toBe(email.toLowerCase());
+      expect(user.email).toBe(email);
     });
 
     it('should not overwrite an existing email for the same user', async () => {
       const dbUserRepository = dataSource.getRepository(User);
       const extUserId = faker.string.uuid();
-      const existingEmail = faker.internet.email().toLowerCase();
+      const existingEmail = fakeEmailAddress();
       const userInsertResult = await dbUserRepository.insert({
         status: 'ACTIVE',
         extUserId,
@@ -978,7 +979,7 @@ describe('UsersRepository', () => {
       const userId = userInsertResult.identifiers[0].id as number;
 
       await usersRepository.findOrCreateByExtUserIdWithEmail(extUserId, {
-        address: faker.internet.email().toLowerCase(),
+        address: fakeEmailAddress(),
         verified: true,
       });
 
@@ -990,7 +991,7 @@ describe('UsersRepository', () => {
 
     it('should throw when the email belongs to a different user', async () => {
       const dbUserRepository = dataSource.getRepository(User);
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       const extUserId = faker.string.uuid();
 
       await dbUserRepository.insert({
@@ -1008,7 +1009,7 @@ describe('UsersRepository', () => {
 
     it('should throw when an unverified email belongs to a different user', async () => {
       const dbUserRepository = dataSource.getRepository(User);
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       const extUserId = faker.string.uuid();
 
       await dbUserRepository.insert({

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -13,6 +13,7 @@ import type {
   UserStatus,
 } from '@/modules/users/domain/entities/user.entity';
 import type { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
 
 export const IUsersRepository = Symbol('IUsersRepository');
 
@@ -64,10 +65,10 @@ export interface IUsersRepository {
 
   findOrCreateByExtUserIdWithEmail(
     extUserId: string,
-    email?: { address: string; verified: boolean },
+    email?: { address: EmailAddress; verified: boolean },
   ): Promise<User['id']>;
 
-  findEmailById(userId: User['id']): Promise<string | undefined>;
+  findEmailById(userId: User['id']): Promise<EmailAddress | undefined>;
 
   update(args: {
     userId: User['id'];

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@/modules/users/domain/errors/user-email-already-in-use.error';
 import { UsersRepository } from '@/modules/users/domain/users.repository';
 import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 describe('UsersRepository', () => {
   const walletsRepository = {} as jest.MockedObjectDeep<IWalletsRepository>;
@@ -57,12 +58,12 @@ describe('UsersRepository', () => {
       const extUserId = faker.string.uuid();
       userRepository.findOne.mockResolvedValue({
         id: userId,
-        email: faker.internet.email().toLowerCase(),
+        email: fakeEmailAddress(),
       });
 
       await expect(
         target.findOrCreateByExtUserIdWithEmail(extUserId, {
-          address: faker.internet.email(),
+          address: fakeEmailAddress(),
           verified: true,
         }),
       ).resolves.toBe(userId);
@@ -73,7 +74,7 @@ describe('UsersRepository', () => {
     it('should return when an unverified email is unused', async () => {
       const userId = faker.number.int({ min: 1 });
       const extUserId = faker.string.uuid();
-      const email = faker.internet.email();
+      const email = fakeEmailAddress();
       userRepository.findOne
         .mockResolvedValueOnce({ id: userId })
         .mockResolvedValueOnce(null);
@@ -99,7 +100,7 @@ describe('UsersRepository', () => {
 
       await expect(
         target.findOrCreateByExtUserIdWithEmail(faker.string.uuid(), {
-          address: faker.internet.email(),
+          address: fakeEmailAddress(),
           verified: false,
         }),
       ).resolves.toBe(userId);
@@ -113,7 +114,7 @@ describe('UsersRepository', () => {
 
       const result = target.findOrCreateByExtUserIdWithEmail(
         faker.string.uuid(),
-        { address: faker.internet.email(), verified: false },
+        { address: fakeEmailAddress(), verified: false },
       );
 
       await expect(result).rejects.toThrow(UserEmailAlreadyInUseError);
@@ -129,7 +130,7 @@ describe('UsersRepository', () => {
   describe('findEmailById', () => {
     it('should return the persisted email', async () => {
       const userId = faker.number.int({ min: 1 });
-      const email = faker.internet.email().toLowerCase();
+      const email = fakeEmailAddress();
       userRepository.findOne.mockResolvedValue({ email });
 
       await expect(target.findEmailById(userId)).resolves.toBe(email);

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -20,6 +20,7 @@ import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-e
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
 
 @Injectable()
 export class UsersRepository implements IUsersRepository {
@@ -234,7 +235,7 @@ export class UsersRepository implements IUsersRepository {
    */
   public async findOrCreateByExtUserIdWithEmail(
     extUserId: string,
-    email?: { address: string; verified: boolean },
+    email?: { address: EmailAddress; verified: boolean },
   ): Promise<User['id']> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
@@ -278,7 +279,7 @@ export class UsersRepository implements IUsersRepository {
 
   private async handleUserEmail(
     userId: User['id'],
-    email?: { address: string; verified: boolean },
+    email?: { address: EmailAddress; verified: boolean },
   ): Promise<void> {
     if (!email) {
       return;
@@ -293,17 +294,16 @@ export class UsersRepository implements IUsersRepository {
 
   private async persistVerifiedEmail(
     userId: User['id'],
-    email: string,
+    email: EmailAddress,
   ): Promise<void> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
-    const normalizedEmail = email.trim().toLowerCase();
 
     try {
       await userRepository
         .createQueryBuilder()
         .update(DbUser)
-        .set({ email: normalizedEmail })
+        .set({ email })
         .where('id = :userId', { userId })
         .andWhere('email IS NULL')
         .execute();
@@ -317,15 +317,14 @@ export class UsersRepository implements IUsersRepository {
 
   private async assertEmailNotTaken(
     userId: User['id'],
-    email: string,
+    email: EmailAddress,
   ): Promise<void> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
-    const normalizedEmail = email.trim().toLowerCase();
     // The DB unique index is the integrity guard for verified writes; this
     // check blocks unverified duplicate emails before minting a CGW session.
     const user = await userRepository.findOne({
-      where: { email: normalizedEmail },
+      where: { email },
       select: { id: true },
     });
 
@@ -334,7 +333,9 @@ export class UsersRepository implements IUsersRepository {
     }
   }
 
-  public async findEmailById(userId: User['id']): Promise<string | undefined> {
+  public async findEmailById(
+    userId: User['id'],
+  ): Promise<EmailAddress | undefined> {
     const userRepository =
       await this.postgresDatabaseService.getRepository(DbUser);
     const user = await userRepository.findOne({

--- a/src/validation/entities/schemas/__tests__/email-address.builder.ts
+++ b/src/validation/entities/schemas/__tests__/email-address.builder.ts
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
+import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
+
+export const fakeEmailAddress = (): EmailAddress =>
+  EmailAddressSchema.parse(faker.internet.email());

--- a/src/validation/entities/schemas/__tests__/email-address.builder.ts
+++ b/src/validation/entities/schemas/__tests__/email-address.builder.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
-import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
-import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
+import {
+  type EmailAddress,
+  EmailAddressSchema,
+} from '@/validation/entities/schemas/email-address.schema';
 
 export const fakeEmailAddress = (): EmailAddress =>
   EmailAddressSchema.parse(faker.internet.email());

--- a/src/validation/entities/schemas/__tests__/email-address.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/email-address.schema.spec.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import {
+  type EmailAddress,
+  EmailAddressSchema,
+} from '@/validation/entities/schemas/email-address.schema';
+
+describe('EmailAddressSchema', () => {
+  it('should validate a lowercase email and return it unchanged', () => {
+    const value = faker.internet.email().toLowerCase();
+
+    const result = EmailAddressSchema.safeParse(value);
+
+    expect(result.success && result.data).toBe(value);
+  });
+
+  it('should lowercase a mixed-case email', () => {
+    const value = `${faker.internet.username()}@EXAMPLE.COM`;
+
+    const result = EmailAddressSchema.safeParse(value);
+
+    expect(result.success && result.data).toBe(value.toLowerCase());
+  });
+
+  it('should reject a non-email string', () => {
+    const result = EmailAddressSchema.safeParse('not-an-email');
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an email exceeding the max length', () => {
+    const oversized = `${'a'.repeat(251)}@b.co`; // 256 chars
+
+    const result = EmailAddressSchema.safeParse(oversized);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should brand the inferred type so plain strings are not assignable', () => {
+    const parsed = EmailAddressSchema.parse('user@example.com');
+    // The branded value flows freely.
+    const _branded: EmailAddress = parsed;
+
+    // A plain string is not assignable to EmailAddress: this @ts-expect-error
+    // fails the build if the schema ever loses its `.brand<'EmailAddress'>()`.
+    // @ts-expect-error: plain string must not be assignable to EmailAddress
+    const _plain: EmailAddress = 'user@example.com';
+
+    expect(_branded).toBe('user@example.com');
+    expect(_plain).toBe('user@example.com');
+  });
+});

--- a/src/validation/entities/schemas/__tests__/email-address.schema.spec.ts
+++ b/src/validation/entities/schemas/__tests__/email-address.schema.spec.ts
@@ -46,6 +46,8 @@ describe('EmailAddressSchema', () => {
     // @ts-expect-error: plain string must not be assignable to EmailAddress
     const _plain: EmailAddress = 'user@example.com';
 
+    // Runtime assertions only exist to keep the bindings used; the real test
+    // is the @ts-expect-error directive above.
     expect(_branded).toBe('user@example.com');
     expect(_plain).toBe('user@example.com');
   });

--- a/src/validation/entities/schemas/email-address.schema.ts
+++ b/src/validation/entities/schemas/email-address.schema.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+
+export const EMAIL_ADDRESS_MAX_LENGTH = 255;
+
+export type EmailAddress = string & { readonly __brand: 'EmailAddress' };
+
+export const EmailAddressSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .pipe(
+    z.email({ error: 'Invalid email address' }).max(EMAIL_ADDRESS_MAX_LENGTH),
+  )
+  .transform((value) => value as EmailAddress);

--- a/src/validation/entities/schemas/email-address.schema.ts
+++ b/src/validation/entities/schemas/email-address.schema.ts
@@ -3,13 +3,9 @@ import { z } from 'zod';
 
 export const EMAIL_ADDRESS_MAX_LENGTH = 255;
 
-export type EmailAddress = string & { readonly __brand: 'EmailAddress' };
-
 export const EmailAddressSchema = z
-  .string()
-  .trim()
+  .email()
   .toLowerCase()
-  .pipe(
-    z.email({ error: 'Invalid email address' }).max(EMAIL_ADDRESS_MAX_LENGTH),
-  )
-  .transform((value) => value as EmailAddress);
+  .max(EMAIL_ADDRESS_MAX_LENGTH);
+
+export type EmailAddress = z.infer<typeof EmailAddressSchema>;

--- a/src/validation/entities/schemas/email-address.schema.ts
+++ b/src/validation/entities/schemas/email-address.schema.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
 
-export const EMAIL_ADDRESS_MAX_LENGTH = 255;
+const EMAIL_ADDRESS_MAX_LENGTH = 255;
 
 export const EmailAddressSchema = z
   .email()
   .toLowerCase()
-  .max(EMAIL_ADDRESS_MAX_LENGTH);
+  .max(EMAIL_ADDRESS_MAX_LENGTH)
+  .brand<'EmailAddress'>();
 
 export type EmailAddress = z.infer<typeof EmailAddressSchema>;


### PR DESCRIPTION
## Summary

Introduces a shared `EmailAddressSchema` and branded `EmailAddress` type for email validation across the codebase. Pre-work for [WA-2327 (email invites)](https://linear.app/safe-global/issue/WA-2327/add-email-invite-endpoint).

- Adds `EmailAddressSchema` under `validation/entities/schemas/`, matching the `UuidSchema` pattern: `z.email().toLowerCase().max(255).brand<'EmailAddress'>()`. `z.email()` already rejects strings with surrounding whitespace, so no explicit `.trim()` is needed.
- Replaces inline `z.email().max(255)` declarations across `User`, DB `User`, `Auth0Token`, and `UserSession` with the shared schema. The three env-var emails in `configuration.schema.ts` keep their plain `z.email()` shape — they're identifiers, not user emails, and out of scope here.
- `UsersRepository.persistVerifiedEmail` / `assertEmailNotTaken` drop their hand-rolled `.toLowerCase()` — the schema produces an already-normalized `EmailAddress` at the boundary.
- Adds `fakeEmailAddress()` test helper under `validation/entities/schemas/__tests__/` so fixtures across auth, users, and spaces specs can produce `EmailAddress`-typed values cleanly.
- Spec asserts the brand at compile time via `@ts-expect-error`: removing `.brand<'EmailAddress'>()` from the schema breaks the build because plain `string` would then be assignable to `EmailAddress` and the directive would be flagged as unused.

Three commits: production change, test migration, brand + revert of config-var changes per review feedback.

No HTTP-visible behavior change. Existing DB lowercase check constraint stays as defense-in-depth.