### PR TITLE
Fix: isCancellation returns true when safeTx is empty with non-zero refund params

### DIFF
--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.spec.ts
@@ -313,19 +313,22 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const dataSize = 0;
     const chainId = faker.string.numeric();
     const dataDecoded = dataDecodedBuilder().with('method', method).build();
-    const baseTransaction = multisigTransactionBuilder()
-      .with('to', getAddress(toAddress.value))
-      .with('safe', getAddress(toAddress.value))
-      .with('value', '0')
-      .with('operation', 0)
-      .with('baseGas', faker.number.int({ min: 1 }))
-      .with('gasPrice', faker.string.numeric({ exclude: ['0'] }))
-      .with('gasToken', NULL_ADDRESS)
-      .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
-      .with('safeTxGas', faker.number.int({ min: 1 }));
+    // Builder.with() mutates and returns `this`, so each case must start from a
+    // fresh builder — otherwise prior overrides leak into subsequent cases.
+    const baseTransactionBuilder = (): ReturnType<typeof multisigTransactionBuilder> =>
+      multisigTransactionBuilder()
+        .with('to', getAddress(toAddress.value))
+        .with('safe', getAddress(toAddress.value))
+        .with('value', '0')
+        .with('operation', 0)
+        .with('baseGas', faker.number.int({ min: 1 }))
+        .with('gasPrice', faker.string.numeric({ exclude: ['0'] }))
+        .with('gasToken', NULL_ADDRESS)
+        .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
+        .with('safeTxGas', faker.number.int({ min: 1 }));
 
     const safeTxWithSafeTxGasZero = await mapper.mapCustomTransaction(
-      baseTransaction.with('safeTxGas', 0).build(),
+      baseTransactionBuilder().with('safeTxGas', 0).build(),
       dataSize,
       chainId,
       null,
@@ -337,7 +340,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     ).toBe(false);
 
     const safeTxWithBaseGasZero = await mapper.mapCustomTransaction(
-      baseTransaction.with('safeTxGas', 2409).with('baseGas', 0).build(),
+      baseTransactionBuilder().with('baseGas', 0).build(),
       dataSize,
       chainId,
       null,
@@ -349,7 +352,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     ).toBe(false);
 
     const safeTxWithGasPriceZero = await mapper.mapCustomTransaction(
-      baseTransaction.with('baseGas', 75608).with('gasPrice', '0').build(),
+      baseTransactionBuilder().with('gasPrice', '0').build(),
       dataSize,
       chainId,
       null,
@@ -361,7 +364,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     ).toBe(false);
 
     const safeTxWithRefundReceiverZero = await mapper.mapCustomTransaction(
-      baseTransaction.with('refundReceiver', NULL_ADDRESS).build(),
+      baseTransactionBuilder().with('refundReceiver', NULL_ADDRESS).build(),
       dataSize,
       chainId,
       null,
@@ -373,7 +376,7 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     ).toBe(false);
 
     const safeTxWithOnlyGasTokenNonZero = await mapper.mapCustomTransaction(
-      baseTransaction
+      baseTransactionBuilder()
         .with('baseGas', 0)
         .with('gasPrice', '0')
         .with('gasToken', getAddress(faker.finance.ethereumAddress()))

--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.spec.ts
@@ -315,7 +315,9 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     const dataDecoded = dataDecodedBuilder().with('method', method).build();
     // Builder.with() mutates and returns `this`, so each case must start from a
     // fresh builder — otherwise prior overrides leak into subsequent cases.
-    const baseTransactionBuilder = (): ReturnType<typeof multisigTransactionBuilder> =>
+    const baseTransactionBuilder = (): ReturnType<
+      typeof multisigTransactionBuilder
+    > =>
       multisigTransactionBuilder()
         .with('to', getAddress(toAddress.value))
         .with('safe', getAddress(toAddress.value))
@@ -373,6 +375,20 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     expect(safeTxWithRefundReceiverZero).toBeInstanceOf(CustomTransactionInfo);
     expect(
       (safeTxWithRefundReceiverZero as CustomTransactionInfo).isCancellation,
+    ).toBe(false);
+
+    // gasToken === null must not be treated as cancellation, even when every
+    // other refund param is non-zero/non-null (i.e. the non-zero branch).
+    const safeTxWithGasTokenNull = await mapper.mapCustomTransaction(
+      baseTransactionBuilder().with('gasToken', null).build(),
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+    expect(safeTxWithGasTokenNull).toBeInstanceOf(CustomTransactionInfo);
+    expect(
+      (safeTxWithGasTokenNull as CustomTransactionInfo).isCancellation,
     ).toBe(false);
 
     const safeTxWithOnlyGasTokenNonZero = await mapper.mapCustomTransaction(

--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.spec.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.spec.ts
@@ -192,6 +192,205 @@ describe('Multisig Custom Transaction mapper (Unit)', () => {
     });
   });
 
+  it('should build a cancellation CustomTransactionInfo (empty refund params)', async () => {
+    const toAddress = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
+    const method = faker.word.sample();
+    const value = '0';
+    const dataSize = 0;
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder()
+      .with('to', getAddress(toAddress.value))
+      .with('safe', getAddress(toAddress.value))
+      .with('value', value)
+      .with('operation', 0)
+      .with('baseGas', faker.helpers.arrayElement([null, 0]))
+      .with('gasPrice', faker.helpers.arrayElement([null, '0']))
+      .with('gasToken', faker.helpers.arrayElement([null, NULL_ADDRESS]))
+      .with('refundReceiver', faker.helpers.arrayElement([null, NULL_ADDRESS]))
+      .with('safeTxGas', faker.helpers.arrayElement([null, 0]))
+      .build();
+    const dataDecoded = dataDecodedBuilder().with('method', method).build();
+
+    const customTransaction = await mapper.mapCustomTransaction(
+      transaction,
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+
+    expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
+    expect(customTransaction).toMatchObject({
+      to: toAddress,
+      dataSize: dataSize.toString(),
+      value,
+      methodName: method,
+      isCancellation: true,
+    });
+  });
+
+  it('should build a cancellation CustomTransactionInfo (non-zero refund params, native gas token)', async () => {
+    const toAddress = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
+    const method = faker.word.sample();
+    const value = '0';
+    const dataSize = 0;
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder()
+      .with('to', getAddress(toAddress.value))
+      .with('safe', getAddress(toAddress.value))
+      .with('value', value)
+      .with('operation', 0)
+      .with('baseGas', faker.number.int({ min: 1 }))
+      .with('gasPrice', faker.string.numeric({ exclude: ['0'] }))
+      .with('gasToken', NULL_ADDRESS)
+      .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
+      .with('safeTxGas', faker.number.int({ min: 1 }))
+      .build();
+    const dataDecoded = dataDecodedBuilder().with('method', method).build();
+
+    const customTransaction = await mapper.mapCustomTransaction(
+      transaction,
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+
+    expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
+    expect(customTransaction).toMatchObject({
+      to: toAddress,
+      dataSize: dataSize.toString(),
+      value,
+      methodName: method,
+      isCancellation: true,
+    });
+  });
+
+  it('should build a cancellation CustomTransactionInfo (non-zero refund params, ERC-20 gas token)', async () => {
+    const toAddress = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
+    const method = faker.word.sample();
+    const value = '0';
+    const dataSize = 0;
+    const chainId = faker.string.numeric();
+    const transaction = multisigTransactionBuilder()
+      .with('to', getAddress(toAddress.value))
+      .with('safe', getAddress(toAddress.value))
+      .with('value', value)
+      .with('operation', 0)
+      .with('baseGas', faker.number.int({ min: 1 }))
+      .with('gasPrice', faker.string.numeric({ exclude: ['0'] }))
+      .with('gasToken', getAddress(faker.finance.ethereumAddress()))
+      .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
+      .with('safeTxGas', faker.number.int({ min: 1 }))
+      .build();
+    const dataDecoded = dataDecodedBuilder().with('method', method).build();
+
+    const customTransaction = await mapper.mapCustomTransaction(
+      transaction,
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+
+    expect(customTransaction).toBeInstanceOf(CustomTransactionInfo);
+    expect(customTransaction).toMatchObject({
+      to: toAddress,
+      dataSize: dataSize.toString(),
+      value,
+      methodName: method,
+      isCancellation: true,
+    });
+  });
+
+  it('should not classify as cancellation when only some required refund params are non-zero', async () => {
+    const toAddress = new AddressInfo(faker.finance.ethereumAddress());
+    addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);
+    const method = faker.word.sample();
+    const dataSize = 0;
+    const chainId = faker.string.numeric();
+    const dataDecoded = dataDecodedBuilder().with('method', method).build();
+    const baseTransaction = multisigTransactionBuilder()
+      .with('to', getAddress(toAddress.value))
+      .with('safe', getAddress(toAddress.value))
+      .with('value', '0')
+      .with('operation', 0)
+      .with('baseGas', faker.number.int({ min: 1 }))
+      .with('gasPrice', faker.string.numeric({ exclude: ['0'] }))
+      .with('gasToken', NULL_ADDRESS)
+      .with('refundReceiver', getAddress(faker.finance.ethereumAddress()))
+      .with('safeTxGas', faker.number.int({ min: 1 }));
+
+    const safeTxWithSafeTxGasZero = await mapper.mapCustomTransaction(
+      baseTransaction.with('safeTxGas', 0).build(),
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+    expect(safeTxWithSafeTxGasZero).toBeInstanceOf(CustomTransactionInfo);
+    expect(
+      (safeTxWithSafeTxGasZero as CustomTransactionInfo).isCancellation,
+    ).toBe(false);
+
+    const safeTxWithBaseGasZero = await mapper.mapCustomTransaction(
+      baseTransaction.with('safeTxGas', 2409).with('baseGas', 0).build(),
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+    expect(safeTxWithBaseGasZero).toBeInstanceOf(CustomTransactionInfo);
+    expect(
+      (safeTxWithBaseGasZero as CustomTransactionInfo).isCancellation,
+    ).toBe(false);
+
+    const safeTxWithGasPriceZero = await mapper.mapCustomTransaction(
+      baseTransaction.with('baseGas', 75608).with('gasPrice', '0').build(),
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+    expect(safeTxWithGasPriceZero).toBeInstanceOf(CustomTransactionInfo);
+    expect(
+      (safeTxWithGasPriceZero as CustomTransactionInfo).isCancellation,
+    ).toBe(false);
+
+    const safeTxWithRefundReceiverZero = await mapper.mapCustomTransaction(
+      baseTransaction.with('refundReceiver', NULL_ADDRESS).build(),
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+    expect(safeTxWithRefundReceiverZero).toBeInstanceOf(CustomTransactionInfo);
+    expect(
+      (safeTxWithRefundReceiverZero as CustomTransactionInfo).isCancellation,
+    ).toBe(false);
+
+    const safeTxWithOnlyGasTokenNonZero = await mapper.mapCustomTransaction(
+      baseTransaction
+        .with('baseGas', 0)
+        .with('gasPrice', '0')
+        .with('gasToken', getAddress(faker.finance.ethereumAddress()))
+        .with('refundReceiver', NULL_ADDRESS)
+        .with('safeTxGas', 0)
+        .build(),
+      dataSize,
+      chainId,
+      null,
+      dataDecoded,
+    );
+    expect(safeTxWithOnlyGasTokenNonZero).toBeInstanceOf(CustomTransactionInfo);
+    expect(
+      (safeTxWithOnlyGasTokenNonZero as CustomTransactionInfo).isCancellation,
+    ).toBe(false);
+  });
+
   it('should build a CustomTransactionInfo with humanDescription', async () => {
     const toAddress = new AddressInfo(faker.finance.ethereumAddress());
     addressInfoHelper.getOrDefault.mockResolvedValue(toAddress);

--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
@@ -95,23 +95,27 @@ export class CustomTransactionMapper {
         (!value || Number(value) === 0) &&
         operation === Operation.CALL;
 
+      const areAllRefundParamsEmptyOrDefault =
+        (!baseGas || Number(baseGas) === 0) &&
+        (!gasPrice || Number(gasPrice) === 0) &&
+        (!gasToken || gasToken === NULL_ADDRESS) &&
+        (!refundReceiver || refundReceiver === NULL_ADDRESS) &&
+        (!safeTxGas || safeTxGas === 0);
+
+      const areAllRefundParamsSet =
+        baseGas !== null &&
+        Number(baseGas) !== 0 &&
+        gasPrice !== null &&
+        Number(gasPrice) !== 0 &&
+        refundReceiver !== null &&
+        gasToken !== null &&
+        refundReceiver !== NULL_ADDRESS &&
+        safeTxGas !== null &&
+        safeTxGas !== 0;
+
       return (
-        (isEmptySelfCall &&
-          (!baseGas || Number(baseGas) === 0) &&
-          (!gasPrice || Number(gasPrice) === 0) &&
-          (!gasToken || gasToken === NULL_ADDRESS) &&
-          (!refundReceiver || refundReceiver === NULL_ADDRESS) &&
-          (!safeTxGas || safeTxGas === 0)) ||
-        (isEmptySelfCall &&
-          baseGas !== null &&
-          Number(baseGas) !== 0 &&
-          gasPrice !== null &&
-          Number(gasPrice) !== 0 &&
-          refundReceiver !== null &&
-          gasToken !== null &&
-          refundReceiver !== NULL_ADDRESS &&
-          safeTxGas !== null &&
-          safeTxGas !== 0)
+        isEmptySelfCall &&
+        (areAllRefundParamsEmptyOrDefault || areAllRefundParamsSet)
       );
     }
     return false;

--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
@@ -89,16 +89,28 @@ export class CustomTransactionMapper {
         safeTxGas,
       } = transaction;
 
-      return (
+      const isEmptyTx =
         to === safe &&
         dataSize === 0 &&
         (!value || Number(value) === 0) &&
-        operation === Operation.CALL &&
-        (!baseGas || Number(baseGas) === 0) &&
-        (!gasPrice || Number(gasPrice) === 0) &&
-        (!gasToken || gasToken === NULL_ADDRESS) &&
-        (!refundReceiver || refundReceiver === NULL_ADDRESS) &&
-        (!safeTxGas || safeTxGas === 0)
+        operation === Operation.CALL;
+
+      return (
+        (isEmptyTx &&
+          (!baseGas || Number(baseGas) === 0) &&
+          (!gasPrice || Number(gasPrice) === 0) &&
+          (!gasToken || gasToken === NULL_ADDRESS) &&
+          (!refundReceiver || refundReceiver === NULL_ADDRESS) &&
+          (!safeTxGas || safeTxGas === 0)) ||
+        (isEmptyTx &&
+          baseGas !== null &&
+          Number(baseGas) !== 0 &&
+          gasPrice !== null &&
+          Number(gasPrice) !== 0 &&
+          refundReceiver !== null &&
+          refundReceiver !== NULL_ADDRESS &&
+          safeTxGas !== null &&
+          safeTxGas !== 0)
       );
     }
     return false;

--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
@@ -108,6 +108,7 @@ export class CustomTransactionMapper {
           gasPrice !== null &&
           Number(gasPrice) !== 0 &&
           refundReceiver !== null &&
+          gasToken !== null &&
           refundReceiver !== NULL_ADDRESS &&
           safeTxGas !== null &&
           safeTxGas !== 0)

--- a/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
+++ b/src/modules/transactions/routes/mappers/common/custom-transaction.mapper.ts
@@ -89,20 +89,20 @@ export class CustomTransactionMapper {
         safeTxGas,
       } = transaction;
 
-      const isEmptyTx =
+      const isEmptySelfCall =
         to === safe &&
         dataSize === 0 &&
         (!value || Number(value) === 0) &&
         operation === Operation.CALL;
 
       return (
-        (isEmptyTx &&
+        (isEmptySelfCall &&
           (!baseGas || Number(baseGas) === 0) &&
           (!gasPrice || Number(gasPrice) === 0) &&
           (!gasToken || gasToken === NULL_ADDRESS) &&
           (!refundReceiver || refundReceiver === NULL_ADDRESS) &&
           (!safeTxGas || safeTxGas === 0)) ||
-        (isEmptyTx &&
+        (isEmptySelfCall &&
           baseGas !== null &&
           Number(baseGas) !== 0 &&
           gasPrice !== null &&


### PR DESCRIPTION
Closes: https://linear.app/safe-global/issue/PLA-1456/on-chain-rejection-tx-in-not-recognized-as-rejection-tx-when-safe-from

**Key changes:**

### Cancellation Transaction Detection Improvements

- Updated the `isCancellation` logic in `custom-transaction.mapper.ts` to correctly identify cancellation transactions not only when all refund parameters are zero or null, but also when all are non-zero and set, covering both native and ERC-20 gas token cases.

### Unit Test Coverage Expansion

- Added comprehensive unit tests in `custom-transaction.mapper.spec.ts` to verify the new cancellation classification logic, including:
  - Empty refund parameters (all zero/null)
  - Non-zero refund parameters with native gas token
  - Non-zero refund parameters with ERC-20 gas token
  - Cases where only some refund parameters are non-zero, ensuring these are not misclassified as cancellations
