### PR TITLE
feat(spaces): add queued transactions endpoint

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -1368,6 +1368,12 @@
     "required": false
   },
   {
+    "name": "SAFE_QUEUE_BASE_URI",
+    "description": "Base URI for the Safe Queue service",
+    "defaultValue": "https://api.5afe.dev/queue",
+    "required": false
+  },
+  {
     "name": "SAFE_WEB_APP_BASE_URI",
     "description": "Base URI for Safe Web Application",
     "defaultValue": "https://app.safe.global",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -412,6 +412,9 @@ export default (): ReturnType<typeof configuration> => ({
   safeDataDecoder: {
     baseUri: faker.internet.url({ appendSlash: false }),
   },
+  safeQueue: {
+    baseUri: faker.internet.url({ appendSlash: false }),
+  },
   safeTransaction: {
     useVpcUrl: false,
     apiKey: faker.string.hexadecimal({ length: 32 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -727,8 +727,7 @@ export default () => ({
       'https://safe-decoder.safe.global',
   },
   safeQueue: {
-    baseUri:
-      process.env.SAFE_QUEUE_BASE_URI || 'https://api.5afe.dev/queue',
+    baseUri: process.env.SAFE_QUEUE_BASE_URI || 'https://api.5afe.dev/queue',
   },
   safeTransaction: {
     useVpcUrl: process.env.USE_TX_SERVICE_VPC_URL?.toLowerCase() === 'true',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -728,7 +728,7 @@ export default () => ({
   },
   safeQueue: {
     baseUri:
-      process.env.SAFE_QUEUE_BASE_URI || 'https://safe-queue.safe.global',
+      process.env.SAFE_QUEUE_BASE_URI || 'https://api.5afe.dev/queue',
   },
   safeTransaction: {
     useVpcUrl: process.env.USE_TX_SERVICE_VPC_URL?.toLowerCase() === 'true',

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -726,6 +726,10 @@ export default () => ({
       process.env.SAFE_DATA_DECODER_BASE_URI ||
       'https://safe-decoder.safe.global',
   },
+  safeQueue: {
+    baseUri:
+      process.env.SAFE_QUEUE_BASE_URI || 'https://safe-queue.safe.global',
+  },
   safeTransaction: {
     useVpcUrl: process.env.USE_TX_SERVICE_VPC_URL?.toLowerCase() === 'true',
     apiKey: process.env.TX_SERVICE_API_KEY,

--- a/src/modules/spaces/datasources/entities/space-queue-transaction.entity.ts
+++ b/src/modules/spaces/datasources/entities/space-queue-transaction.entity.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import { buildPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { Operation } from '@/modules/safe/domain/entities/operation.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { CoercedNumberSchema } from '@/validation/entities/schemas/coerced-number.schema';
+import { HexSchema } from '@/validation/entities/schemas/hex.schema';
+import { HexBytesSchema } from '@/validation/entities/schemas/hexbytes.schema';
+import {
+  NullableAddressSchema,
+  NullableHexSchema,
+  NullableNumericStringSchema,
+  NullableStringSchema,
+} from '@/validation/entities/schemas/nullable.schema';
+
+const SpaceQueueConfirmationSchema = z.object({
+  owner: AddressSchema,
+  signature: HexBytesSchema.nullish().default(null),
+  signatureType: z.enum(SignatureType),
+  created: z.coerce.date(),
+});
+
+export const SpaceQueueTransactionSchema = z.object({
+  chainId: z.coerce.string(),
+  safe: AddressSchema,
+  safeTxHash: HexSchema,
+  nonce: CoercedNumberSchema,
+  to: AddressSchema,
+  value: z.coerce.string(),
+  data: NullableHexSchema,
+  operation: z.enum(Operation),
+  safeTxGas: CoercedNumberSchema.nullish().default(null),
+  baseGas: CoercedNumberSchema.nullish().default(null),
+  gasPrice: NullableNumericStringSchema,
+  gasToken: NullableAddressSchema,
+  refundReceiver: NullableAddressSchema,
+  proposer: NullableAddressSchema,
+  proposedByDelegate: NullableAddressSchema,
+  failed: z.boolean().nullish().default(null),
+  notes: NullableStringSchema,
+  originName: NullableStringSchema,
+  originUrl: NullableStringSchema,
+  txHash: NullableHexSchema,
+  created: z.coerce.date(),
+  modified: z.coerce.date().nullish().default(null),
+  confirmations: z.array(SpaceQueueConfirmationSchema).nullish().default([]),
+});
+
+export type SpaceQueueTransaction = z.infer<typeof SpaceQueueTransactionSchema>;
+
+export const SpaceQueueTransactionPageSchema = buildPageSchema(
+  SpaceQueueTransactionSchema,
+);

--- a/src/modules/spaces/datasources/space-queue-api.service.ts
+++ b/src/modules/spaces/datasources/space-queue-api.service.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
+import {
+  type INetworkService,
+  NetworkService,
+} from '@/datasources/network/network.service.interface';
+import type { Page } from '@/domain/entities/page.entity';
+import {
+  type SpaceQueueTransaction,
+  SpaceQueueTransactionPageSchema,
+} from '@/modules/spaces/datasources/entities/space-queue-transaction.entity';
+
+export const ISpaceQueueApi = Symbol('ISpaceQueueApi');
+
+export interface ISpaceQueueApi {
+  getQueuedTransactions(args: {
+    safes: Array<{ chainId: string; address: string }>;
+    limit: number;
+    offset: number;
+  }): Promise<Page<SpaceQueueTransaction>>;
+}
+
+@Injectable()
+export class SpaceQueueApi implements ISpaceQueueApi {
+  private readonly baseUrl: string;
+
+  public constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(NetworkService)
+    private readonly networkService: INetworkService,
+    private readonly httpErrorFactory: HttpErrorFactory,
+  ) {
+    this.baseUrl =
+      this.configurationService.getOrThrow<string>('safeQueue.baseUri');
+  }
+
+  public async getQueuedTransactions(args: {
+    safes: Array<{ chainId: string; address: string }>;
+    limit: number;
+    offset: number;
+  }): Promise<Page<SpaceQueueTransaction>> {
+    try {
+      const url = new URL(`${this.baseUrl}/api/v1/multisig-transactions/queue`);
+      for (const { address, chainId } of args.safes) {
+        url.searchParams.append('safes', `${address}:${chainId}`);
+      }
+      url.searchParams.set('nonce_order', 'asc');
+      url.searchParams.set('limit', String(args.limit));
+      url.searchParams.set('offset', String(args.offset));
+      const { data } = await this.networkService.get<
+        Page<SpaceQueueTransaction>
+      >({
+        url: url.toString(),
+      });
+
+      return SpaceQueueTransactionPageSchema.parse(data);
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+}

--- a/src/modules/spaces/datasources/space-queue-api.service.ts
+++ b/src/modules/spaces/datasources/space-queue-api.service.ts
@@ -45,7 +45,7 @@ export class SpaceQueueApi implements ISpaceQueueApi {
     try {
       const url = new URL(`${this.baseUrl}/api/v1/multisig-transactions/queue`);
       for (const { address, chainId } of args.safes) {
-        url.searchParams.append('safes', `${address}:${chainId}`);
+        url.searchParams.append('safes', `${chainId}:${address}`);
       }
       url.searchParams.set('nonce_order', 'asc');
       url.searchParams.set('limit', String(args.limit));

--- a/src/modules/spaces/routes/space-transactions.controller.ts
+++ b/src/modules/spaces/routes/space-transactions.controller.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Controller, Get, Inject, Param, ParseIntPipe } from '@nestjs/common';
+import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
+import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { SpaceTransactionsService } from '@/modules/spaces/routes/space-transactions.service';
+import type { QueuedItem } from '@/modules/transactions/routes/entities/queued-item.entity';
+import { QueuedItemPage } from '@/modules/transactions/routes/entities/queued-item-page.entity';
+import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
+import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
+import type { Page } from '@/routes/common/entities/page.entity';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+
+@ApiTags('spaces')
+@Controller({
+  path: 'spaces/:spaceId/transactions',
+  version: '1',
+})
+export class SpaceTransactionsController {
+  public constructor(
+    @Inject(SpaceTransactionsService)
+    private readonly spaceTransactionsService: SpaceTransactionsService,
+  ) {}
+
+  @ApiOperation({
+    summary: 'Get space transaction queue',
+    description:
+      'Retrieves a paginated list of queued (pending) transactions across all Safes in a space, ordered by nonce ascending (oldest first).',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'number',
+    description: 'Space ID to fetch queued transactions for',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+    description: 'Pagination cursor for retrieving the next set of results',
+  })
+  @ApiOkResponse({
+    type: QueuedItemPage,
+    description: 'Paginated list of queued transactions for the space',
+  })
+  @ApiNotFoundResponse({
+    description: 'Space not found',
+  })
+  @Get('queued')
+  public getTransactionQueue(
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: Space['id'],
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<Partial<Page<QueuedItem>>> {
+    return this.spaceTransactionsService.getTransactionQueue({
+      spaceId,
+      routeUrl,
+      paginationData,
+    });
+  }
+}

--- a/src/modules/spaces/routes/space-transactions.controller.ts
+++ b/src/modules/spaces/routes/space-transactions.controller.ts
@@ -1,14 +1,26 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Controller, Get, Inject, Param, ParseIntPipe } from '@nestjs/common';
 import {
+  Controller,
+  Get,
+  Inject,
+  Param,
+  ParseIntPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiForbiddenResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceTransactionsService } from '@/modules/spaces/routes/space-transactions.service';
 import type { QueuedItem } from '@/modules/transactions/routes/entities/queued-item.entity';
@@ -24,6 +36,7 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
   path: 'spaces/:spaceId/transactions',
   version: '1',
 })
+@UseGuards(AuthGuard)
 export class SpaceTransactionsController {
   public constructor(
     @Inject(SpaceTransactionsService)
@@ -51,6 +64,13 @@ export class SpaceTransactionsController {
     type: QueuedItemPage,
     description: 'Paginated list of queued transactions for the space',
   })
+  @ApiUnauthorizedResponse({
+    description:
+      'Authentication required or user unauthorized to access this space',
+  })
+  @ApiForbiddenResponse({
+    description: 'Access forbidden - user is not a member of this space',
+  })
   @ApiNotFoundResponse({
     description: 'Space not found',
   })
@@ -60,9 +80,11 @@ export class SpaceTransactionsController {
     spaceId: Space['id'],
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
+    @Auth() authPayload: AuthPayload,
   ): Promise<Partial<Page<QueuedItem>>> {
     return this.spaceTransactionsService.getTransactionQueue({
       spaceId,
+      authPayload,
       routeUrl,
       paginationData,
     });

--- a/src/modules/spaces/routes/space-transactions.service.spec.ts
+++ b/src/modules/spaces/routes/space-transactions.service.spec.ts
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import type { Address } from 'viem';
 import { getAddress } from 'viem';
 import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { IDataDecoderRepository } from '@/modules/data-decoder/domain/v2/data-decoder.repository.interface';
 import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
 import { Operation } from '@/modules/safe/domain/entities/operation.entity';
@@ -15,12 +18,17 @@ import { SpaceTransactionsService } from '@/modules/spaces/routes/space-transact
 import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
 import { TransactionQueuedItem } from '@/modules/transactions/routes/entities/queued-items/transaction-queued-item.entity';
 import type { MultisigTransactionMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper';
+import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
+import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 import type { Page } from '@/routes/common/entities/page.entity';
 import { PaginationData } from '@/routes/common/pagination/pagination.data';
 
 const addr = (): Address => getAddress(faker.finance.ethereumAddress());
 const hex = (bytes: number): `0x${string}` =>
   `0x${faker.string.hexadecimal({ length: bytes * 2, casing: 'lower', prefix: '' })}` as `0x${string}`;
+
+const buildAuthPayload = (): AuthPayload =>
+  new AuthPayload(siweAuthPayloadDtoBuilder().build());
 
 const spaceSafesRepositoryMock = {
   findBySpaceId: jest.fn(),
@@ -39,6 +47,10 @@ const safeRepositoryMock = {
 const dataDecoderRepositoryMock = {
   getTransactionDataDecoded: jest.fn(),
 } as unknown as jest.Mocked<IDataDecoderRepository>;
+
+const membersRepositoryMock = {
+  findOne: jest.fn(),
+} as unknown as jest.Mocked<IMembersRepository>;
 
 const multisigTransactionMapperMock = {
   mapTransaction: jest.fn(),
@@ -102,16 +114,48 @@ describe('SpaceTransactionsService', () => {
       spaceQueueApiMock,
       safeRepositoryMock,
       dataDecoderRepositoryMock,
+      membersRepositoryMock,
       multisigTransactionMapperMock,
     );
+    membersRepositoryMock.findOne.mockResolvedValue(memberBuilder().build());
   });
 
   describe('getTransactionQueue', () => {
+    it('throws Unauthorized when the caller is not authenticated', async () => {
+      await expect(
+        service.getTransactionQueue({
+          spaceId: 1,
+          authPayload: new AuthPayload(),
+          routeUrl: routeUrl(),
+          paginationData: new PaginationData(20, 0),
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(membersRepositoryMock.findOne).not.toHaveBeenCalled();
+      expect(spaceSafesRepositoryMock.findBySpaceId).not.toHaveBeenCalled();
+    });
+
+    it('throws Forbidden when the caller is not a member of the space', async () => {
+      membersRepositoryMock.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getTransactionQueue({
+          spaceId: 1,
+          authPayload: buildAuthPayload(),
+          routeUrl: routeUrl(),
+          paginationData: new PaginationData(20, 0),
+        }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(spaceSafesRepositoryMock.findBySpaceId).not.toHaveBeenCalled();
+    });
+
     it('returns an empty page without calling the upstream when the space has no safes', async () => {
       spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([]);
 
       const result = await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -140,6 +184,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 42,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(40, 10),
         paginationData: new PaginationData(10, 40),
       });
@@ -154,32 +199,80 @@ describe('SpaceTransactionsService', () => {
       });
     });
 
-    it('loads the Safe entity for each (chainId, address) pair', async () => {
+    it('only loads Safe entities for safes that appear in the upstream page', async () => {
       const safeA = addr();
       const safeB = addr();
+      const safeC = addr();
       spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
         { chainId: '1', address: safeA },
         { chainId: '137', address: safeB },
+        { chainId: '10', address: safeC },
       ]);
       spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
-        upstreamPage([]),
+        upstreamPage([
+          upstreamTxBuilder('1', safeA),
+          upstreamTxBuilder('1', safeA),
+        ]),
       );
-      safeRepositoryMock.getSafe.mockResolvedValue(safeBuilder().build());
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeA).build(),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
 
-      expect(safeRepositoryMock.getSafe).toHaveBeenCalledTimes(2);
+      expect(safeRepositoryMock.getSafe).toHaveBeenCalledTimes(1);
       expect(safeRepositoryMock.getSafe).toHaveBeenCalledWith({
         chainId: '1',
         address: safeA,
       });
-      expect(safeRepositoryMock.getSafe).toHaveBeenCalledWith({
-        chainId: '137',
-        address: safeB,
+    });
+
+    it('skips upstream transactions whose (chainId, safe) is not a space safe', async () => {
+      const knownSafe = addr();
+      const strayChainId = '999';
+      const straySafe = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: knownSafe },
+      ]);
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([
+          upstreamTxBuilder('1', knownSafe),
+          upstreamTxBuilder(strayChainId, straySafe),
+        ]),
+      );
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', knownSafe).build(),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      const result = await service.getTransactionQueue({
+        spaceId: 1,
+        authPayload: buildAuthPayload(),
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(result.results).toHaveLength(1);
+      expect(safeRepositoryMock.getSafe).toHaveBeenCalledTimes(1);
+      expect(safeRepositoryMock.getSafe).not.toHaveBeenCalledWith({
+        chainId: strayChainId,
+        address: straySafe,
       });
     });
 
@@ -202,6 +295,7 @@ describe('SpaceTransactionsService', () => {
 
       const result = await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -253,6 +347,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -313,6 +408,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -356,6 +452,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -397,6 +494,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -439,6 +537,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -472,6 +571,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -509,6 +609,7 @@ describe('SpaceTransactionsService', () => {
 
       await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(),
         paginationData: new PaginationData(20, 0),
       });
@@ -538,6 +639,7 @@ describe('SpaceTransactionsService', () => {
 
       const result = await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(20, 10),
         paginationData: new PaginationData(10, 20),
       });
@@ -573,12 +675,42 @@ describe('SpaceTransactionsService', () => {
 
       const result = await service.getTransactionQueue({
         spaceId: 1,
+        authPayload: buildAuthPayload(),
         routeUrl: routeUrl(0, 20),
         paginationData: new PaginationData(20, 0),
       });
 
       expect(result.previous).toBeNull();
       expect(result.next).toBeNull();
+    });
+
+    it('does not throw when the upstream returns a null count', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstreamTxBuilder('1', safeAddress)], null),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      const result = await service.getTransactionQueue({
+        spaceId: 1,
+        authPayload: buildAuthPayload(),
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(result.count).toBeNull();
+      expect(result.results).toHaveLength(1);
     });
 
     it('propagates errors raised by the queue API', async () => {
@@ -591,6 +723,7 @@ describe('SpaceTransactionsService', () => {
       await expect(
         service.getTransactionQueue({
           spaceId: 1,
+          authPayload: buildAuthPayload(),
           routeUrl: routeUrl(),
           paginationData: new PaginationData(20, 0),
         }),

--- a/src/modules/spaces/routes/space-transactions.service.spec.ts
+++ b/src/modules/spaces/routes/space-transactions.service.spec.ts
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import type { Address } from 'viem';
+import { getAddress } from 'viem';
+import { SignatureType } from '@/domain/common/entities/signature-type.entity';
+import type { IDataDecoderRepository } from '@/modules/data-decoder/domain/v2/data-decoder.repository.interface';
+import { safeBuilder } from '@/modules/safe/domain/entities/__tests__/safe.builder';
+import { Operation } from '@/modules/safe/domain/entities/operation.entity';
+import type { SafeRepository } from '@/modules/safe/domain/safe.repository';
+import type { SpaceQueueTransaction } from '@/modules/spaces/datasources/entities/space-queue-transaction.entity';
+import type { ISpaceQueueApi } from '@/modules/spaces/datasources/space-queue-api.service';
+import type { ISpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository.interface';
+import { SpaceTransactionsService } from '@/modules/spaces/routes/space-transactions.service';
+import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
+import { TransactionQueuedItem } from '@/modules/transactions/routes/entities/queued-items/transaction-queued-item.entity';
+import type { MultisigTransactionMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper';
+import type { Page } from '@/routes/common/entities/page.entity';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
+
+const addr = (): Address => getAddress(faker.finance.ethereumAddress());
+const hex = (bytes: number): `0x${string}` =>
+  `0x${faker.string.hexadecimal({ length: bytes * 2, casing: 'lower', prefix: '' })}` as `0x${string}`;
+
+const spaceSafesRepositoryMock = {
+  findBySpaceId: jest.fn(),
+} as unknown as jest.Mocked<ISpaceSafesRepository>;
+
+const spaceQueueApiMock = {
+  getQueuedTransactions: jest.fn(),
+} as unknown as jest.Mocked<ISpaceQueueApi>;
+
+const safeRepositoryMock = {
+  getSafe: jest.fn(),
+} as unknown as jest.Mocked<
+  Pick<SafeRepository, 'getSafe'>
+> as jest.Mocked<SafeRepository>;
+
+const dataDecoderRepositoryMock = {
+  getTransactionDataDecoded: jest.fn(),
+} as unknown as jest.Mocked<IDataDecoderRepository>;
+
+const multisigTransactionMapperMock = {
+  mapTransaction: jest.fn(),
+} as unknown as jest.Mocked<MultisigTransactionMapper>;
+
+type UpstreamOverrides = Partial<SpaceQueueTransaction>;
+
+const upstreamTxBuilder = (
+  chainId: string,
+  safe: Address,
+  overrides: UpstreamOverrides = {},
+): SpaceQueueTransaction => ({
+  chainId,
+  safe,
+  safeTxHash: hex(32),
+  nonce: faker.number.int({ min: 1, max: 200 }),
+  to: addr(),
+  value: '0',
+  data: hex(4),
+  operation: Operation.CALL,
+  safeTxGas: 0,
+  baseGas: 0,
+  gasPrice: '0',
+  gasToken: null,
+  refundReceiver: null,
+  proposer: addr(),
+  proposedByDelegate: null,
+  failed: null,
+  notes: null,
+  originName: null,
+  originUrl: null,
+  txHash: null,
+  created: faker.date.past(),
+  modified: faker.date.recent(),
+  confirmations: [],
+  ...overrides,
+});
+
+const upstreamPage = (
+  results: Array<SpaceQueueTransaction>,
+  count: number | null = results.length,
+): Page<SpaceQueueTransaction> => ({
+  count,
+  next: null,
+  previous: null,
+  results,
+});
+
+const routeUrl = (offset = 0, limit = 20): URL =>
+  new URL(
+    `http://localhost/v1/spaces/1/transactions/queued?cursor=limit%3D${limit}%26offset%3D${offset}`,
+  );
+
+describe('SpaceTransactionsService', () => {
+  let service: SpaceTransactionsService;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new SpaceTransactionsService(
+      spaceSafesRepositoryMock,
+      spaceQueueApiMock,
+      safeRepositoryMock,
+      dataDecoderRepositoryMock,
+      multisigTransactionMapperMock,
+    );
+  });
+
+  describe('getTransactionQueue', () => {
+    it('returns an empty page without calling the upstream when the space has no safes', async () => {
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([]);
+
+      const result = await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(result).toEqual({
+        count: 0,
+        next: null,
+        previous: null,
+        results: [],
+      });
+      expect(spaceQueueApiMock.getQueuedTransactions).not.toHaveBeenCalled();
+      expect(safeRepositoryMock.getSafe).not.toHaveBeenCalled();
+    });
+
+    it('forwards space safes and pagination data to the queue API', async () => {
+      const safeA = addr();
+      const safeB = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeA },
+        { chainId: '11155111', address: safeB },
+      ]);
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([]),
+      );
+      safeRepositoryMock.getSafe.mockResolvedValue(safeBuilder().build());
+
+      await service.getTransactionQueue({
+        spaceId: 42,
+        routeUrl: routeUrl(40, 10),
+        paginationData: new PaginationData(10, 40),
+      });
+
+      expect(spaceQueueApiMock.getQueuedTransactions).toHaveBeenCalledWith({
+        safes: [
+          { chainId: '1', address: safeA },
+          { chainId: '11155111', address: safeB },
+        ],
+        limit: 10,
+        offset: 40,
+      });
+    });
+
+    it('loads the Safe entity for each (chainId, address) pair', async () => {
+      const safeA = addr();
+      const safeB = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeA },
+        { chainId: '137', address: safeB },
+      ]);
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([]),
+      );
+      safeRepositoryMock.getSafe.mockResolvedValue(safeBuilder().build());
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(safeRepositoryMock.getSafe).toHaveBeenCalledTimes(2);
+      expect(safeRepositoryMock.getSafe).toHaveBeenCalledWith({
+        chainId: '1',
+        address: safeA,
+      });
+      expect(safeRepositoryMock.getSafe).toHaveBeenCalledWith({
+        chainId: '137',
+        address: safeB,
+      });
+    });
+
+    it('wraps each mapped transaction in a TransactionQueuedItem with ConflictType.None', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      const safe = safeBuilder().with('address', safeAddress).build();
+      safeRepositoryMock.getSafe.mockResolvedValue(safe);
+      const upstream = upstreamTxBuilder('1', safeAddress);
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstream]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      const mapped = { id: 'multisig_xxx_yyy' } as never;
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(mapped);
+
+      const result = await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0]).toBeInstanceOf(TransactionQueuedItem);
+      expect(result.results[0]).toMatchObject({
+        transaction: mapped,
+        conflictType: ConflictType.None,
+      });
+    });
+
+    it('transforms upstream fields into the domain MultisigTransaction shape', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      const safe = safeBuilder()
+        .with('address', safeAddress)
+        .with('threshold', 3)
+        .build();
+      safeRepositoryMock.getSafe.mockResolvedValue(safe);
+
+      const upstreamTxHash = hex(32);
+      const upstreamSafeTxHash = hex(32);
+      const created = new Date('2024-01-01T00:00:00Z');
+      const modified = new Date('2024-01-02T00:00:00Z');
+      const proposer = addr();
+      const upstream = upstreamTxBuilder('1', safeAddress, {
+        safeTxHash: upstreamSafeTxHash,
+        txHash: upstreamTxHash,
+        created,
+        modified,
+        proposer,
+        nonce: 7,
+        value: '1000',
+        originName: 'Safe App',
+        originUrl: 'https://example.org/app',
+      });
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstream]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      const passedTx =
+        multisigTransactionMapperMock.mapTransaction.mock.calls[0][1];
+
+      expect(passedTx).toMatchObject({
+        safe: safeAddress,
+        safeTxHash: upstreamSafeTxHash,
+        transactionHash: upstreamTxHash,
+        submissionDate: created,
+        modified,
+        nonce: 7,
+        value: '1000',
+        proposer,
+        confirmationsRequired: 3,
+        isExecuted: false,
+        isSuccessful: null,
+        executionDate: null,
+        blockNumber: null,
+        executor: null,
+        ethGasPrice: null,
+        gasUsed: null,
+        fee: null,
+        payment: null,
+        signatures: null,
+        trusted: true,
+        origin: JSON.stringify({
+          name: 'Safe App',
+          url: 'https://example.org/app',
+        }),
+      });
+    });
+
+    it('emits origin: null when the upstream has no originName', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([
+          upstreamTxBuilder('1', safeAddress, {
+            originName: null,
+            originUrl: null,
+          }),
+        ]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      const passedTx =
+        multisigTransactionMapperMock.mapTransaction.mock.calls[0][1];
+      expect(passedTx).toMatchObject({ origin: null });
+    });
+
+    it('transforms upstream confirmations (created → submissionDate, no transactionHash)', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      const owner = addr();
+      const sig = hex(65);
+      const confCreated = new Date('2024-03-01T00:00:00Z');
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([
+          upstreamTxBuilder('1', safeAddress, {
+            confirmations: [
+              {
+                owner,
+                signature: sig,
+                signatureType: SignatureType.Eoa,
+                created: confCreated,
+              },
+            ],
+          }),
+        ]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      const passedTx =
+        multisigTransactionMapperMock.mapTransaction.mock.calls[0][1];
+      expect(passedTx.confirmations).toEqual([
+        {
+          owner,
+          signature: sig,
+          signatureType: SignatureType.Eoa,
+          submissionDate: confCreated,
+          transactionHash: null,
+        },
+      ]);
+    });
+
+    it('defaults confirmations to an empty array when the upstream sends null', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([
+          upstreamTxBuilder('1', safeAddress, {
+            confirmations: null as never,
+          }),
+        ]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      const passedTx =
+        multisigTransactionMapperMock.mapTransaction.mock.calls[0][1];
+      expect(passedTx.confirmations).toEqual([]);
+    });
+
+    it('pairs each tx with the Safe matching its (chainId, address)', async () => {
+      const safeA = addr();
+      const safeB = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeA },
+        { chainId: '137', address: safeB },
+      ]);
+      const safeAEntity = safeBuilder()
+        .with('address', safeA)
+        .with('threshold', 2)
+        .build();
+      const safeBEntity = safeBuilder()
+        .with('address', safeB)
+        .with('threshold', 5)
+        .build();
+      safeRepositoryMock.getSafe.mockImplementation(async ({ address }) =>
+        address === safeA ? safeAEntity : safeBEntity,
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([
+          upstreamTxBuilder('1', safeA),
+          upstreamTxBuilder('137', safeB),
+        ]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      const calls = multisigTransactionMapperMock.mapTransaction.mock.calls;
+      expect(calls[0][0]).toBe('1');
+      expect(calls[0][1].confirmationsRequired).toBe(2);
+      expect(calls[0][2]).toBe(safeAEntity);
+      expect(calls[1][0]).toBe('137');
+      expect(calls[1][1].confirmationsRequired).toBe(5);
+      expect(calls[1][2]).toBe(safeBEntity);
+    });
+
+    it('decodes data with the chainId of each tx and the transformed payload', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '11155111', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstreamTxBuilder('11155111', safeAddress)]),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(
+        dataDecoderRepositoryMock.getTransactionDataDecoded,
+      ).toHaveBeenCalledTimes(1);
+      const [decodedArgs] =
+        dataDecoderRepositoryMock.getTransactionDataDecoded.mock.calls[0];
+      expect(decodedArgs.chainId).toBe('11155111');
+      expect(decodedArgs.transaction).toMatchObject({
+        safe: safeAddress,
+        isExecuted: false,
+      });
+    });
+
+    it('forwards the decoded data to the mapper', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstreamTxBuilder('1', safeAddress)]),
+      );
+      const decoded = { method: 'transfer' } as never;
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        decoded,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(
+        multisigTransactionMapperMock.mapTransaction.mock.calls[0][3],
+      ).toBe(decoded);
+    });
+
+    it('builds cursor-based next/previous URLs from the page count and route url', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstreamTxBuilder('1', safeAddress)], 100),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      const result = await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(20, 10),
+        paginationData: new PaginationData(10, 20),
+      });
+
+      expect(result.count).toBe(100);
+      const decode = (url: string | null): string | null =>
+        url ? decodeURIComponent(url) : url;
+      expect(decode(result.previous)).toEqual(
+        expect.stringContaining('cursor=limit=10&offset=10'),
+      );
+      expect(decode(result.next)).toEqual(
+        expect.stringContaining('cursor=limit=10&offset=30'),
+      );
+    });
+
+    it('returns previous: null on the first page (offset 0)', async () => {
+      const safeAddress = addr();
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: safeAddress },
+      ]);
+      safeRepositoryMock.getSafe.mockResolvedValue(
+        safeBuilder().with('address', safeAddress).build(),
+      );
+      spaceQueueApiMock.getQueuedTransactions.mockResolvedValue(
+        upstreamPage([upstreamTxBuilder('1', safeAddress)], 5),
+      );
+      dataDecoderRepositoryMock.getTransactionDataDecoded.mockResolvedValue(
+        null,
+      );
+      multisigTransactionMapperMock.mapTransaction.mockResolvedValue(
+        {} as never,
+      );
+
+      const result = await service.getTransactionQueue({
+        spaceId: 1,
+        routeUrl: routeUrl(0, 20),
+        paginationData: new PaginationData(20, 0),
+      });
+
+      expect(result.previous).toBeNull();
+      expect(result.next).toBeNull();
+    });
+
+    it('propagates errors raised by the queue API', async () => {
+      spaceSafesRepositoryMock.findBySpaceId.mockResolvedValue([
+        { chainId: '1', address: addr() },
+      ]);
+      const err = new Error('upstream down');
+      spaceQueueApiMock.getQueuedTransactions.mockRejectedValue(err);
+
+      await expect(
+        service.getTransactionQueue({
+          spaceId: 1,
+          routeUrl: routeUrl(),
+          paginationData: new PaginationData(20, 0),
+        }),
+      ).rejects.toBe(err);
+
+      expect(safeRepositoryMock.getSafe).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/spaces/routes/space-transactions.service.ts
+++ b/src/modules/spaces/routes/space-transactions.service.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import type { Address } from 'viem';
+import { getAddress } from 'viem';
+import { IDataDecoderRepository } from '@/modules/data-decoder/domain/v2/data-decoder.repository.interface';
+import type {
+  Confirmation,
+  MultisigTransaction,
+} from '@/modules/safe/domain/entities/multisig-transaction.entity';
+import type { Safe } from '@/modules/safe/domain/entities/safe.entity';
+import type { SafeRepository } from '@/modules/safe/domain/safe.repository';
+import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
+import type { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import type { SpaceQueueTransaction } from '@/modules/spaces/datasources/entities/space-queue-transaction.entity';
+import { ISpaceQueueApi } from '@/modules/spaces/datasources/space-queue-api.service';
+import { ISpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository.interface';
+import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
+import type { QueuedItem } from '@/modules/transactions/routes/entities/queued-item.entity';
+import { TransactionQueuedItem } from '@/modules/transactions/routes/entities/queued-items/transaction-queued-item.entity';
+import { MultisigTransactionMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper';
+import type { Page } from '@/routes/common/entities/page.entity';
+import {
+  buildNextPageURL,
+  buildPreviousPageURL,
+  PaginationData,
+} from '@/routes/common/pagination/pagination.data';
+
+@Injectable()
+export class SpaceTransactionsService {
+  public constructor(
+    @Inject(ISpaceSafesRepository)
+    private readonly spaceSafesRepository: ISpaceSafesRepository,
+    @Inject(ISpaceQueueApi)
+    private readonly spaceQueueApi: ISpaceQueueApi,
+    @Inject(ISafeRepository)
+    private readonly safeRepository: SafeRepository,
+    @Inject(IDataDecoderRepository)
+    private readonly dataDecoderRepository: IDataDecoderRepository,
+    private readonly multisigTransactionMapper: MultisigTransactionMapper,
+  ) {}
+
+  public async getTransactionQueue(args: {
+    spaceId: Space['id'];
+    routeUrl: Readonly<URL>;
+    paginationData: PaginationData;
+  }): Promise<Page<QueuedItem>> {
+    const spaceSafes = await this.spaceSafesRepository.findBySpaceId(
+      args.spaceId,
+    );
+
+    if (spaceSafes.length === 0) {
+      return { count: 0, next: null, previous: null, results: [] };
+    }
+
+    const queuePage = await this.spaceQueueApi.getQueuedTransactions({
+      safes: spaceSafes.map(({ chainId, address }) => ({
+        chainId,
+        address,
+      })),
+      limit: args.paginationData.limit,
+      offset: args.paginationData.offset,
+    });
+
+    const safesByKey = await this.loadSafes(spaceSafes);
+
+    const results = await Promise.all(
+      queuePage.results.map(async (upstreamTx) => {
+        const safe = safesByKey.get(
+          this.makeSafeKey(upstreamTx.chainId, upstreamTx.safe),
+        ) as Safe;
+        const tx = this.toMultisigTransaction(upstreamTx, safe);
+        const dataDecoded =
+          await this.dataDecoderRepository.getTransactionDataDecoded({
+            chainId: upstreamTx.chainId,
+            transaction: tx,
+          });
+        const transaction = await this.multisigTransactionMapper.mapTransaction(
+          upstreamTx.chainId,
+          tx,
+          safe,
+          dataDecoded,
+        );
+        return new TransactionQueuedItem(transaction, ConflictType.None);
+      }),
+    );
+
+    const nextURL = buildNextPageURL(args.routeUrl, queuePage.count);
+    const previousURL = buildPreviousPageURL(args.routeUrl);
+
+    return {
+      count: queuePage.count,
+      next: nextURL?.toString() ?? null,
+      previous: previousURL?.toString() ?? null,
+      results,
+    };
+  }
+
+  private async loadSafes(
+    spaceSafes: Array<{ chainId: string; address: string }>,
+  ): Promise<Map<string, Safe>> {
+    const entries = await Promise.all(
+      spaceSafes.map(async ({ chainId, address }) => {
+        const safe = await this.safeRepository.getSafe({
+          chainId,
+          address: getAddress(address) as Address,
+        });
+        return [this.makeSafeKey(chainId, safe.address), safe] as const;
+      }),
+    );
+    return new Map(entries);
+  }
+
+  private makeSafeKey(chainId: string, address: string): string {
+    return `${chainId}:${address.toLowerCase()}`;
+  }
+
+  private toMultisigTransaction(
+    upstream: SpaceQueueTransaction,
+    safe: Safe,
+  ): MultisigTransaction {
+    const origin = upstream.originName
+      ? JSON.stringify({
+          name: upstream.originName,
+          url: upstream.originUrl,
+        })
+      : null;
+
+    return {
+      safe: upstream.safe,
+      to: upstream.to,
+      value: upstream.value,
+      data: upstream.data,
+      operation: upstream.operation,
+      gasToken: upstream.gasToken,
+      safeTxGas: upstream.safeTxGas,
+      baseGas: upstream.baseGas,
+      gasPrice: upstream.gasPrice,
+      proposer: upstream.proposer,
+      proposedByDelegate: upstream.proposedByDelegate,
+      refundReceiver: upstream.refundReceiver,
+      nonce: upstream.nonce,
+      executionDate: null,
+      submissionDate: upstream.created,
+      modified: upstream.modified,
+      blockNumber: null,
+      transactionHash: upstream.txHash,
+      safeTxHash: upstream.safeTxHash,
+      executor: null,
+      isExecuted: false,
+      isSuccessful: null,
+      ethGasPrice: null,
+      gasUsed: null,
+      fee: null,
+      payment: null,
+      origin,
+      confirmationsRequired: safe.threshold,
+      confirmations: (upstream.confirmations ?? []).map(
+        (c): Confirmation => ({
+          owner: c.owner,
+          submissionDate: c.created,
+          transactionHash: null,
+          signatureType: c.signatureType,
+          signature: c.signature,
+        }),
+      ),
+      signatures: null,
+      trusted: true,
+    };
+  }
+}

--- a/src/modules/spaces/routes/space-transactions.service.ts
+++ b/src/modules/spaces/routes/space-transactions.service.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import type { Address } from 'viem';
-import { getAddress } from 'viem';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import { IDataDecoderRepository } from '@/modules/data-decoder/domain/v2/data-decoder.repository.interface';
 import type {
   Confirmation,
@@ -14,10 +15,12 @@ import type { Space } from '@/modules/spaces/datasources/entities/space.entity.d
 import type { SpaceQueueTransaction } from '@/modules/spaces/datasources/entities/space-queue-transaction.entity';
 import { ISpaceQueueApi } from '@/modules/spaces/datasources/space-queue-api.service';
 import { ISpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository.interface';
+import { assertMember } from '@/modules/spaces/routes/utils/space-assert.utils';
 import { ConflictType } from '@/modules/transactions/routes/entities/conflict-type.entity';
 import type { QueuedItem } from '@/modules/transactions/routes/entities/queued-item.entity';
 import { TransactionQueuedItem } from '@/modules/transactions/routes/entities/queued-items/transaction-queued-item.entity';
 import { MultisigTransactionMapper } from '@/modules/transactions/routes/mappers/multisig-transactions/multisig-transaction.mapper';
+import { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 import type { Page } from '@/routes/common/entities/page.entity';
 import {
   buildNextPageURL,
@@ -36,14 +39,20 @@ export class SpaceTransactionsService {
     private readonly safeRepository: SafeRepository,
     @Inject(IDataDecoderRepository)
     private readonly dataDecoderRepository: IDataDecoderRepository,
+    @Inject(IMembersRepository)
+    private readonly membersRepository: IMembersRepository,
     private readonly multisigTransactionMapper: MultisigTransactionMapper,
   ) {}
 
   public async getTransactionQueue(args: {
     spaceId: Space['id'];
+    authPayload: AuthPayload;
     routeUrl: Readonly<URL>;
     paginationData: PaginationData;
   }): Promise<Page<QueuedItem>> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+    await assertMember(this.membersRepository, args.spaceId, userId);
+
     const spaceSafes = await this.spaceSafesRepository.findBySpaceId(
       args.spaceId,
     );
@@ -51,6 +60,12 @@ export class SpaceTransactionsService {
     if (spaceSafes.length === 0) {
       return { count: 0, next: null, previous: null, results: [] };
     }
+
+    const knownSafeKeys = new Set(
+      spaceSafes.map(({ chainId, address }) =>
+        this.makeSafeKey(chainId, address),
+      ),
+    );
 
     const queuePage = await this.spaceQueueApi.getQueuedTransactions({
       safes: spaceSafes.map(({ chainId, address }) => ({
@@ -61,30 +76,37 @@ export class SpaceTransactionsService {
       offset: args.paginationData.offset,
     });
 
-    const safesByKey = await this.loadSafes(spaceSafes);
+    const pageSafes = queuePage.results
+      .filter((tx) => knownSafeKeys.has(this.makeSafeKey(tx.chainId, tx.safe)))
+      .map((tx) => ({ chainId: tx.chainId, address: tx.safe }));
+    const safesByKey = await this.loadSafes(pageSafes);
 
-    const results = await Promise.all(
-      queuePage.results.map(async (upstreamTx) => {
-        const safe = safesByKey.get(
-          this.makeSafeKey(upstreamTx.chainId, upstreamTx.safe),
-        ) as Safe;
-        const tx = this.toMultisigTransaction(upstreamTx, safe);
-        const dataDecoded =
-          await this.dataDecoderRepository.getTransactionDataDecoded({
-            chainId: upstreamTx.chainId,
-            transaction: tx,
-          });
-        const transaction = await this.multisigTransactionMapper.mapTransaction(
-          upstreamTx.chainId,
-          tx,
-          safe,
-          dataDecoded,
-        );
-        return new TransactionQueuedItem(transaction, ConflictType.None);
-      }),
-    );
+    const results: Array<TransactionQueuedItem> = [];
+    for (const upstreamTx of queuePage.results) {
+      const safe = safesByKey.get(
+        this.makeSafeKey(upstreamTx.chainId, upstreamTx.safe),
+      );
+      if (!safe) {
+        continue;
+      }
+      const tx = this.toMultisigTransaction(upstreamTx, safe);
+      const dataDecoded =
+        await this.dataDecoderRepository.getTransactionDataDecoded({
+          chainId: upstreamTx.chainId,
+          transaction: tx,
+        });
+      const transaction = await this.multisigTransactionMapper.mapTransaction(
+        upstreamTx.chainId,
+        tx,
+        safe,
+        dataDecoded,
+      );
+      results.push(new TransactionQueuedItem(transaction, ConflictType.None));
+    }
 
-    const nextURL = buildNextPageURL(args.routeUrl, queuePage.count);
+    const itemsCount =
+      queuePage.count ?? results.length + args.paginationData.offset;
+    const nextURL = buildNextPageURL(args.routeUrl, itemsCount);
     const previousURL = buildPreviousPageURL(args.routeUrl);
 
     return {
@@ -96,14 +118,18 @@ export class SpaceTransactionsService {
   }
 
   private async loadSafes(
-    spaceSafes: Array<{ chainId: string; address: string }>,
+    pageSafes: Array<{ chainId: string; address: Address }>,
   ): Promise<Map<string, Safe>> {
+    const uniqueByKey = new Map<
+      string,
+      { chainId: string; address: Address }
+    >();
+    for (const { chainId, address } of pageSafes) {
+      uniqueByKey.set(this.makeSafeKey(chainId, address), { chainId, address });
+    }
     const entries = await Promise.all(
-      spaceSafes.map(async ({ chainId, address }) => {
-        const safe = await this.safeRepository.getSafe({
-          chainId,
-          address: getAddress(address) as Address,
-        });
+      Array.from(uniqueByKey.values()).map(async ({ chainId, address }) => {
+        const safe = await this.safeRepository.getSafe({ chainId, address });
         return [this.makeSafeKey(chainId, safe.address), safe] as const;
       }),
     );

--- a/src/modules/spaces/spaces.module.ts
+++ b/src/modules/spaces/spaces.module.ts
@@ -3,12 +3,19 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { AuthModule } from '@/modules/auth/auth.module';
+import { DataDecoderModule } from '@/modules/data-decoder/data-decoder.module';
+import { SafeRepositoryModule } from '@/modules/safe/domain/safe.repository.interface';
 import { AddressBookItem } from '@/modules/spaces/datasources/entities/address-book-item.entity.db';
 import { AddressBookRequest } from '@/modules/spaces/datasources/entities/address-book-request.entity.db';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
 import { UserAddressBookItem } from '@/modules/spaces/datasources/entities/user-address-book-item.entity.db';
+import {
+  ISpaceQueueApi,
+  SpaceQueueApi,
+} from '@/modules/spaces/datasources/space-queue-api.service';
 import { AddressBookItemsRepository } from '@/modules/spaces/domain/address-books/address-book-items.repository';
 import { IAddressBookItemsRepository } from '@/modules/spaces/domain/address-books/address-book-items.repository.interface';
 import { AddressBookRequestsRepository } from '@/modules/spaces/domain/address-books/address-book-requests.repository';
@@ -27,10 +34,13 @@ import { MembersController } from '@/modules/spaces/routes/members.controller';
 import { MembersService } from '@/modules/spaces/routes/members.service';
 import { SpaceSafesController } from '@/modules/spaces/routes/space-safes.controller';
 import { SpaceSafesService } from '@/modules/spaces/routes/space-safes.service';
+import { SpaceTransactionsController } from '@/modules/spaces/routes/space-transactions.controller';
+import { SpaceTransactionsService } from '@/modules/spaces/routes/space-transactions.service';
 import { SpacesController } from '@/modules/spaces/routes/spaces.controller';
 import { SpacesService } from '@/modules/spaces/routes/spaces.service';
 import { UserAddressBookController } from '@/modules/spaces/routes/user-address-book.controller';
 import { UserAddressBookService } from '@/modules/spaces/routes/user-address-book.service';
+import { TransactionsModule } from '@/modules/transactions/transactions.module';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { UsersModule } from '@/modules/users/users.module';
 import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
@@ -49,6 +59,9 @@ import { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.
     ]),
     forwardRef(() => AuthModule),
     forwardRef(() => UsersModule),
+    DataDecoderModule,
+    SafeRepositoryModule,
+    TransactionsModule,
   ],
   controllers: [
     AddressBooksController,
@@ -56,6 +69,7 @@ import { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.
     AddressBookRequestsController,
     SpacesController,
     SpaceSafesController,
+    SpaceTransactionsController,
     MembersController,
   ],
   providers: [
@@ -64,7 +78,13 @@ import { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.
     AddressBookRequestsService,
     SpacesService,
     SpaceSafesService,
+    SpaceTransactionsService,
     MembersService,
+    HttpErrorFactory,
+    {
+      provide: ISpaceQueueApi,
+      useClass: SpaceQueueApi,
+    },
     {
       provide: ISpacesRepository,
       useClass: SpacesRepository,

--- a/src/modules/transactions/transactions.module.ts
+++ b/src/modules/transactions/transactions.module.ts
@@ -130,6 +130,10 @@ import { AddressInfoModule } from '@/routes/common/address-info/address-info.mod
       useClass: TransactionsRepository,
     },
   ],
-  exports: [ITransactionsRepository, TransactionsService],
+  exports: [
+    ITransactionsRepository,
+    MultisigTransactionMapper,
+    TransactionsService,
+  ],
 })
 export class TransactionsModule {}


### PR DESCRIPTION
## Summary
Resolves: [WA-2345](https://linear.app/safe-global/issue/WA-2345/cgw-add-queued-transactions-endpoint)
- Adds `GET /v1/spaces/:spaceId/transactions/queued`, which aggregates pending multisig transactions across all Safes in a space and returns a paginated `QueuedItemPage` ordered by nonce ascending.
- Introduces `SpaceQueueApi` (backed by the new `SAFE_QUEUE_BASE_URI` config, defaulting to `https://safe-queue.safe.global`) to fetch upstream queue data, and reuses the existing `MultisigTransactionMapper` so responses match the regular queue shape.
- Exports `MultisigTransactionMapper` from `TransactionsModule` and wires the new controller/service into `SpacesModule`.

## Test plan
- [ ] `yarn test src/modules/spaces/routes/space-transactions.service.spec.ts`
- [ ] Hit `GET /v1/spaces/:spaceId/transactions/queued` against a space with several Safes and verify pagination + nonce ordering
- [ ] Verify behavior when the space has no associated Safes (empty page)
- [ ] Confirm `SAFE_QUEUE_BASE_URI` override is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)