### PR TITLE
chore: drop --max-turns cap from Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,6 +87,5 @@ jobs:
 
           claude_args: |
             --model claude-opus-4-7
-            --max-turns 10
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           trigger_phrase: "@claude review"


### PR DESCRIPTION
## Summary

The `--max-turns 10` cap in the Claude code review workflow caused reviews of large dependency-bump PRs (e.g. #2608, viem 2.23.5 → 2.48.11) to abort with `Reached maximum number of turns (10)` before the review could finish. A turn-based cap is also a poor cost guard since turn cost is unpredictable. The existing `timeout-minutes: 5` job timeout already bounds runtime/cost, so the explicit cap is redundant.

## Changes
- Remove `--max-turns 10` from `claude_args` in `.github/workflows/claude-code-review.yml`.