### PR TITLE
feat: add dev container setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,9 +2,11 @@
 
 # Dev container image for safe-client-gateway.
 # Production image is unchanged and lives at the repo-root Dockerfile.
-# Note: Microsoft only publishes major-version tags for this image, so the
-# Node version floats within 24.x; production currently uses 24.11.0.
-FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm
+# Microsoft only publishes major-version tags for this image, so we pin by
+# digest to keep dev environments reproducible. Production currently uses
+# Node 24.11.0; refresh the digest periodically (or via Renovate/Dependabot)
+# to pick up the latest 24.x patch.
+FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm@sha256:14484cf5f183867fbdddd69db1991ee9a82fc50ff378f40344dcc31824eb834e
 
 # Microsoft's image runs as the `node` user by default; switch to root
 # for system installs and to enable Corepack.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+# Dev container image for safe-client-gateway.
+# Production image is unchanged and lives at the repo-root Dockerfile.
+# Note: Microsoft only publishes major-version tags for this image, so the
+# Node version floats within 24.x; production currently uses 24.11.0.
+FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm
+
+# Microsoft's image runs as the `node` user by default; switch to root
+# for system installs and to enable Corepack.
+USER root
+
+# Install postgres-client for inspecting db / db-test from inside the container.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Activate Corepack so Yarn 4.14.1 (pinned in .yarnrc.yml) resolves the
+# project-managed release on first install.
+RUN corepack enable
+
+USER node

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
 # Dev container image for safe-client-gateway.
 # Production image is unchanged and lives at the repo-root Dockerfile.
 # Note: Microsoft only publishes major-version tags for this image, so the

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/safe-client-gateway",
   "remoteUser": "node",
-  "forwardPorts": [3000],
+  "forwardPorts": [3030],
   "postCreateCommand": ".devcontainer/post-create.sh",
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Safe Client Gateway",
+  "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/safe-client-gateway",
+  "remoteUser": "node",
+  "forwardPorts": [3000],
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "biomejs.biome",
+        "Anthropic.claude-code",
+        "openai.chatgpt"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "biomejs.biome",
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
   "remoteUser": "node",
   "forwardPorts": [3030],
   "postCreateCommand": ".devcontainer/post-create.sh",
+  "postAttachCommand": ".devcontainer/post-attach.sh",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -15,7 +16,8 @@
       ],
       "settings": {
         "editor.defaultFormatter": "biomejs.biome",
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "claudeCode.initialPermissionMode": "auto"
       }
     }
   }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,110 @@
+# Override file for the dev container.
+# Used together with the root docker-compose.yml via the file list in
+# .devcontainer/devcontainer.json.
+services:
+  devcontainer:
+    build:
+      # Paths in this file are resolved against the Compose project directory
+      # (the dir of the first -f file), which is the repo root.
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      # Workspace bind mount; ':cached' improves macOS file-system perf.
+      - .:/workspaces/safe-client-gateway:cached
+      # Persist Claude Code auth/config across container rebuilds.
+      # If the host directory does not exist Docker creates an empty one.
+      - ${HOME}/.claude-docker:/home/node/.claude
+    environment:
+      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+      - ALERTS_PROVIDER_ACCOUNT
+      - ALERTS_PROVIDER_API_BASE_URI
+      - ALERTS_PROVIDER_API_KEY
+      - ALERTS_PROVIDER_PROJECT
+      - ALERTS_PROVIDER_SIGNING_KEY
+      - ALLOW_CORS
+      - AUTH_POST_LOGIN_REDIRECT_URI
+      - AUTH_TOKEN
+      - AWS_ACCESS_KEY_ID
+      - AWS_KMS_ENCRYPTION_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - BLOCKLIST_ENCRYPTED_DATA
+      - BLOCKLIST_SECRET_KEY
+      - BLOCKLIST_SECRET_SALT
+      - BRIDGE_API_KEY
+      - CAPTCHA_ENABLED
+      - CGW_ENV
+      - CIRCUIT_BREAKER_ENABLED
+      - CSV_AWS_ACCESS_KEY_ID
+      - CSV_AWS_SECRET_ACCESS_KEY
+      - EMAIL_API_APPLICATION_CODE
+      - EMAIL_API_FROM_EMAIL
+      - EMAIL_API_KEY
+      - FF_AUTH
+      - FF_CONFIG_HOOKS_DEBUG_LOGS
+      - FF_COUNTERFACTUAL_BALANCES
+      - FF_DEBUG_LOGS
+      - FF_EMAIL
+      - FF_ETH_SIGN
+      - FF_FILTER_VALUE_PARSING
+      - FF_HASH_VERIFICATION_API
+      - FF_HASH_VERIFICATION_PROPOSAL
+      - FF_HOOK_HTTP_POST_EVENT
+      - FF_IMPROVED_ADDRESS_POISONING
+      - FF_LIFITRANSACTIONS_MAPPING
+      - FF_MESSAGE_VERIFICATION
+      - FF_SIGNATURE_VERIFICATION_API
+      - FF_SIGNATURE_VERIFICATION_PROPOSAL
+      - FF_TRUSTED_DELEGATE_CALL
+      - FF_TRUSTED_FOR_DELEGATE_CALL_CONTRACTS_LIST
+      - FF_USERS
+      - FF_VAULT_TRANSACTIONS_MAPPING
+      - FF_ZERION_BALANCES_CHAIN_IDS
+      - FF_ZERION_ENABLED
+      - FF_ZERION_POSITIONS_DISABLED
+      - FINGERPRINT_ENCRYPTION_KEY
+      - INFURA_API_KEY
+      - JWT_ISSUER
+      - JWT_SECRET
+      - LOG_LEVEL
+      - LOG_PRETTY_COLORIZE
+      - POSTGRES_HOST
+      - POSTGRES_PORT
+      - POSTGRES_SSL_ENABLED
+      - POSTGRES_SSL_REJECT_UNAUTHORIZED
+      - PUSH_NOTIFICATIONS_API_PROJECT
+      - PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL
+      - PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY
+      - QUEUE_SERVICE_BASE_URI
+      - REDIS_HOST
+      - RELAY_DAILY_LIMIT_CHAIN_IDS
+      - RELAY_NO_FEE_CAMPAIGN_MAINNET_RELAY_RULES
+      - RELAY_NO_FEE_CAMPAIGN_MAINNET_SAFE_TOKEN_ADDRESS
+      - RELAY_NO_FEE_CAMPAIGN_SEPOLIA_RELAY_RULES
+      - RELAY_PROVIDER_API_KEY_ARBITRUM_ONE
+      - RELAY_PROVIDER_API_KEY_AVALANCHE
+      - RELAY_PROVIDER_API_KEY_BASE
+      - RELAY_PROVIDER_API_KEY_BLAST
+      - RELAY_PROVIDER_API_KEY_BSC
+      - RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN
+      - RELAY_PROVIDER_API_KEY_LINEA
+      - RELAY_PROVIDER_API_KEY_OPTIMISM
+      - RELAY_PROVIDER_API_KEY_POLYGON
+      - RELAY_PROVIDER_API_KEY_POLYGON_ZKEVM
+      - RELAY_PROVIDER_API_KEY_SEPOLIA
+      - RELAY_PROVIDER_API_KEY_UNICHAIN
+      - SAFE_CONFIG_BASE_URI
+      - SAFE_DATA_DECODER_BASE_URI
+      - STAKING_API_KEY
+      - STAKING_TESTNET_API_KEY
+      - TEST_ENV
+      - TEST_ENV_2
+      # - TEST_ENV_3
+      - TX_SERVICE_API_KEY
+    # Keep the container alive for VS Code to attach to.
+    command: sleep infinity
+    working_dir: /workspaces/safe-client-gateway
+    depends_on:
+      - db
+      - db-test
+      - redis
+      - rabbitmq

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
 # Override file for the dev container.
 # Used together with the root docker-compose.yml via the file list in
 # .devcontainer/devcontainer.json.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,9 +15,16 @@ services:
       - .:/workspaces/safe-client-gateway:cached
       # Persist Claude Code auth/config across container rebuilds.
       # If the host directory does not exist Docker creates an empty one.
-      - ${HOME}/.claude-docker:/home/node/.claude
+      # ${HOME:?...} fails fast with a clear error if HOME is unset (e.g. CI).
+      - ${HOME:?HOME must be set to mount the Claude config volume}/.claude-docker:/home/node/.claude
+      # SSH agent forwarding:
+      #   - Docker Desktop (macOS/Windows): SSH_AUTH_SOCK is unset on the host,
+      #     so the default /run/host-services/ssh-auth.sock magic path is used.
+      #   - Linux: export SSH_AUTH_SOCK on the host (usually already set by your
+      #     agent) and Compose bind-mounts it into the container.
+      - ${SSH_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/ssh-agent
     environment:
-      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+      - SSH_AUTH_SOCK=/ssh-agent
       - ALERTS_PROVIDER_ACCOUNT
       - ALERTS_PROVIDER_API_BASE_URI
       - ALERTS_PROVIDER_API_KEY
@@ -98,9 +105,6 @@ services:
       - SAFE_DATA_DECODER_BASE_URI
       - STAKING_API_KEY
       - STAKING_TESTNET_API_KEY
-      - TEST_ENV
-      - TEST_ENV_2
-      # - TEST_ENV_3
       - TX_SERVICE_API_KEY
     # Keep the container alive for VS Code to attach to.
     command: sleep infinity

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ${SSH_AUTH_SOCK:-/run/host-services/ssh-auth.sock}:/ssh-agent
     environment:
       - SSH_AUTH_SOCK=/ssh-agent
+      - APPLICATION_PORT=3030
       - ALERTS_PROVIDER_ACCOUNT
       - ALERTS_PROVIDER_API_BASE_URI
       - ALERTS_PROVIDER_API_KEY

--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-MIT
+
+# Runs every time VS Code attaches to the devcontainer.
+# By this point the Anthropic.claude-code extension is installed, so its
+# bundled `claude` CLI is available on PATH and we can use it to manage
+# plugins. Everything below is idempotent so re-runs on every attach are
+# safe and cheap.
+set -euo pipefail
+
+if ! command -v claude >/dev/null 2>&1; then
+  # The Anthropic.claude-code VS Code extension ships a bundled `claude`
+  # binary but does not add it to PATH. Resolve the newest installed
+  # version (path includes version + arch, so glob-and-sort).
+  CLAUDE_BIN=$(ls -1d /home/node/.vscode-server/extensions/anthropic.claude-code-*/resources/native-binary/claude 2>/dev/null | sort -V | tail -1)
+  if [ -n "$CLAUDE_BIN" ] && [ -x "$CLAUDE_BIN" ]; then
+    export PATH="$(dirname "$CLAUDE_BIN"):$PATH"
+  fi
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[devcontainer] 'claude' CLI not found on PATH — skipping plugin install."
+  echo "[devcontainer] Open the Anthropic.claude-code extension once, then reload to retry."
+  exit 0
+fi
+
+# Install Anthropic's official marketplace and the superpowers plugin.
+# Both commands are no-ops when already present.
+claude plugin marketplace add anthropics/claude-plugins-official || true
+claude plugin install superpowers@claude-plugins-official || true

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: FSL-1.1-MIT
+
 # Runs once after the devcontainer is created.
 # Keep this idempotent so re-running it is safe.
 set -euo pipefail

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Runs once after the devcontainer is created.
+# Keep this idempotent so re-running it is safe.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "[devcontainer] Activating Corepack..."
+corepack enable
+
+echo "[devcontainer] Installing dependencies..."
+yarn install --immutable
+
+echo "[devcontainer] Setup complete."

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "Anthropic.claude-code",
+    "openai.chatgpt"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[typescript]": {
-    "typescript.preferences.importModuleSpecifier": "non-relative"
-  }
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "js/ts.preferences.importModuleSpecifier": "non-relative",
+  "remote.autoForwardPortsFallback": 0
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ The project requires some ABIs that are generated after install. In order to man
 yarn generate-abis
 ```
 
+### Development with Dev Containers
+
+If you have Docker and the [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed, you can develop the project without installing Node, Yarn, or any of the backing services on your host:
+
+1. Open the repository in VS Code.
+2. Run **Dev Containers: Reopen in Container** from the command palette.
+
+On first build the container will:
+
+- Install dependencies with `yarn install --immutable`.
+- Generate a `.env` file from `.env.sample.json` if one does not already exist.
+
+The following services start automatically alongside the dev container: Postgres (`db`), Postgres test DB (`db-test`), Redis (`redis`), and RabbitMQ (`rabbitmq`). The `web`, `nginx`, and `pgadmin` services from `docker-compose.yml` are NOT auto-started; if you need them, run them from the host with:
+
+```bash
+docker compose up <service>
+```
+
+VS Code installs Biome, Jest, and EditorConfig extensions automatically inside the container. You will also be prompted to install the recommended AI extensions (Claude Code, ChatGPT) — accept or dismiss as you prefer.
+
 ## Setup your env
 
 We recommend using what is available in the .env.sample file:

--- a/README.md
+++ b/README.md
@@ -46,10 +46,7 @@ If you have Docker and the [VS Code Dev Containers extension](https://marketplac
 1. Open the repository in VS Code.
 2. Run **Dev Containers: Reopen in Container** from the command palette.
 
-On first build the container will:
-
-- Install dependencies with `yarn install --immutable`.
-- Generate a `.env` file from `.env.sample.json` if one does not already exist.
+On first build the container will install dependencies with `yarn install --immutable` (which also generates the required ABIs via the `postinstall` hook).
 
 The following services start automatically alongside the dev container: Postgres (`db`), Postgres test DB (`db-test`), Redis (`redis`), and RabbitMQ (`rabbitmq`). The `web`, `nginx`, and `pgadmin` services from `docker-compose.yml` are NOT auto-started; if you need them, run them from the host with:
 
@@ -57,7 +54,9 @@ The following services start automatically alongside the dev container: Postgres
 docker compose up <service>
 ```
 
-VS Code installs Biome, Jest, and EditorConfig extensions automatically inside the container. You will also be prompted to install the recommended AI extensions (Claude Code, ChatGPT) — accept or dismiss as you prefer.
+Note: both `db` and `db-test` run with SSL enabled, so before you reopen in container — or any time you run `docker compose up db`/`db-test` from the host — make sure the self-signed key has owner-only permissions (see [Running the services](#running-the-services)).
+
+VS Code installs the Biome, Claude Code, and ChatGPT extensions automatically inside the container.
 
 ## Setup your env
 
@@ -130,6 +129,17 @@ yarn env:validate
 yarn env:validate:silent
 ```
 
+## Running the services
+
+Both the `db` and `db-test` Postgres containers run with SSL enabled using a self-signed certificate stored in `db_config/test/`. Postgres refuses to start if the private key is group- or world-readable, so before launching either container (whether from the host or via the dev container) restrict the key to the owner:
+
+```shell
+# disallow any access to world or group
+chmod 0600 db_config/test/server.key
+```
+
+This only needs to be done once per checkout (and again after a fresh `git clone`).
+
 ## Running the app
 
 1. Start Redis instance. By default, it will start on port `6379` of `localhost`.
@@ -166,15 +176,8 @@ yarn run start:prod
 
 The unit test suite contains tests that require a database connection.
 This project provides a `db-test` container which also validates the support for SSL connections.
-To start the container, make sure that the key for the self-signed certificate
-has the right permissions.
 
-```shell
-# disallow any access to world or group
-chmod 0600 db_config/test/server.key
-```
-
-With the right permissions set on the `server.key` file we can now start the `db-test` container:
+Make sure the self-signed certificate key has the right permissions (see [Running the services](#running-the-services)), then start the `db-test` container:
 
 ```shell
 # start the db-test container

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ yarn generate-abis
 
 ### Development with Dev Containers
 
-If you have Docker and the [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed, you can develop the project without installing Node, Yarn, or any of the backing services on your host:
+If you have Docker and the [VS Code/Cursor Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed, you can develop the project without installing Node, Yarn, or any of the backing services on your host:
 
-1. Open the repository in VS Code.
+1. Open the repository in VS Code/Cursor.
 2. Run **Dev Containers: Reopen in Container** from the command palette.
 
 On first build the container will install dependencies with `yarn install --immutable` (which also generates the required ABIs via the `postinstall` hook).
@@ -56,7 +56,7 @@ docker compose up <service>
 
 Note: both `db` and `db-test` run with SSL enabled, so before you reopen in container — or any time you run `docker compose up db`/`db-test` from the host — make sure the self-signed key has owner-only permissions (see [Running the services](#running-the-services)).
 
-VS Code installs the Biome, Claude Code, and ChatGPT extensions automatically inside the container.
+VS Code/Cursor installs the Biome, Claude Code, and ChatGPT extensions automatically inside the container.
 
 ## Setup your env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,20 @@ services:
     image: postgres:14.8-alpine
     volumes:
       - ./data/db:/var/lib/postgresql/data
+      - ./db_config/test/server.crt:/var/lib/postgresql/server.crt:ro
+      - ./db_config/test/server.key:/var/lib/postgresql/server.key:ro
+      - ./db_config/test/pg_hba.conf:/etc/pg_hba.conf
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-safe-client-gateway}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
       - '${POSTGRES_PORT:-5432}:5432'
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/var/lib/postgresql/server.crt
+      -c ssl_key_file=/var/lib/postgresql/server.key
+      -c hba_file=/etc/pg_hba.conf
 
   db-test:
     image: postgres:14.8-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: FSL-1.1-MIT
+
 services:
   redis:
     image: redis/redis-stack:7.2.0-v10


### PR DESCRIPTION
## Summary
Enable VS Code Dev Containers for the project so contributors can develop without installing Node, Yarn, or backing services on the host. Switch the workspace default formatter to Biome and document the dev container flow in the README.

## Changes

- **`.devcontainer/`** — new directory wiring up the dev container:
- `Dockerfile` — based on `mcr.microsoft.com/devcontainers/typescript-node:24-bookworm`; installs `postgresql-client` and enables Corepack so the pinned Yarn 4.14.1 resolves on first install.
- `docker-compose.yml` — Compose override that builds the `devcontainer` service against the repo root, bind-mounts the workspace (`:cached` for macOS), persists Claude Code auth at `~/.claude-docker`, forwards the host SSH agent socket, passes all gateway env vars through, and `depends_on` `db`, `db-test`,
  `redis`, and `rabbitmq`. `web`, `nginx`, and `pgadmin` are deliberately not auto-started.
- `devcontainer.json` — wires both compose files, forwards port `3000`, runs `post-create.sh`, sets `node` as the remote user, and pre-installs Biome, Claude Code, and ChatGPT extensions with Biome as default formatter / format-on-save.
- `post-create.sh` — idempotent setup: `corepack enable` + `yarn install --immutable`.
- **`docker-compose.yml`** — enables SSL on the `db` service by mounting cert/key/`pg_hba.conf` from `db_config/test/` and passing `-c ssl=on` flags, matching the existing `db-test` configuration so local dev mirrors the TLS-enabled connection used in tests.
- **`.vscode/settings.json`** — switches default formatter from Prettier to Biome, enables `formatOnSave`, replaces the deprecated `[typescript]` block with the global `js/ts.preferences.importModuleSpecifier: "non-relative"`, and disables the auto-forward-ports fallback prompt.
- **`.vscode/extensions.json`** — new recommendations file (Biome, Claude Code, ChatGPT) so contributors get the same extension prompt outside the container.
- **`README.md`** — new "Development with Dev Containers" section documenting the workflow and which services do/don't auto-start.