### PR TITLE
feat(spaces): support email invites alongside wallet invites

### DIFF
--- a/src/modules/spaces/routes/entities/__tests__/invite-user.dto.builder.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-user.dto.builder.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import { nameBuilder } from '@/domain/common/entities/name.builder';
+import {
+  InviteType,
+  type InviteUserInput,
+} from '@/modules/spaces/routes/entities/invite-users.dto.entity';
+import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
+
+type WalletInviteUserInput = Extract<
+  InviteUserInput,
+  { type: typeof InviteType.Wallet }
+>;
+
+type EmailInviteUserInput = Extract<
+  InviteUserInput,
+  { type: typeof InviteType.Email }
+>;
+
+export function walletInviteUserDtoBuilder(): IBuilder<WalletInviteUserInput> {
+  return new Builder<WalletInviteUserInput>()
+    .with('type', InviteType.Wallet)
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('role', 'MEMBER')
+    .with('name', nameBuilder());
+}
+
+export function emailInviteUserDtoBuilder(): IBuilder<EmailInviteUserInput> {
+  return new Builder<EmailInviteUserInput>()
+    .with('type', InviteType.Email)
+    .with('email', EmailAddressSchema.parse(faker.internet.email()))
+    .with('role', 'MEMBER')
+    .with('name', nameBuilder());
+}

--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -43,8 +43,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should infer type=wallet for legacy clients sending address without type', () => {
-    const legacy = walletInviteItem();
-    delete legacy.type;
+    const { type: _type, ...legacy } = walletInviteItem();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [legacy] });
 
@@ -53,8 +52,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject an email-shaped item that omits `type`', () => {
-    const legacy = emailInviteItem();
-    delete legacy.type;
+    const { type: _type, ...legacy } = emailInviteItem();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [legacy] });
 
@@ -95,8 +93,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject an item missing the role field', () => {
-    const wallet = walletInviteItem();
-    delete wallet.role;
+    const { role: _role, ...wallet } = walletInviteItem();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
 
@@ -104,8 +101,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject a wallet item missing the address', () => {
-    const wallet = walletInviteItem();
-    delete wallet.address;
+    const { address: _address, ...wallet } = walletInviteItem();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
 
@@ -121,8 +117,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject an email item missing the email', () => {
-    const email = emailInviteItem();
-    delete email.email;
+    const { email: _email, ...email } = emailInviteItem();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [email] });
 
@@ -147,17 +142,40 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject an item missing the name field', () => {
-    const wallet = walletInviteItem();
-    delete wallet.name;
+    const { name: _name, ...wallet } = walletInviteItem();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
 
     expect(result.success).toBe(false);
   });
 
-  it('should reject a name exceeding 255 characters', () => {
+  it('should reject a name exceeding 30 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), name: 'a'.repeat(256) }],
+      users: [{ ...walletInviteItem(), name: 'a'.repeat(31) }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a name shorter than 3 characters', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), name: 'ab' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a whitespace-only name', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), name: '   ' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a name with invalid characters', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), name: '<>@!' }],
     });
 
     expect(result.success).toBe(false);

--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -1,26 +1,16 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
 import { getAddress } from 'viem';
+import {
+  emailInviteUserDtoBuilder,
+  walletInviteUserDtoBuilder,
+} from '@/modules/spaces/routes/entities/__tests__/invite-user.dto.builder';
 import { InviteUsersDtoSchema } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
-
-const walletInviteItem = (): Record<string, unknown> => ({
-  type: 'wallet',
-  address: getAddress(faker.finance.ethereumAddress()),
-  role: 'MEMBER',
-  name: faker.person.firstName(),
-});
-
-const emailInviteItem = (): Record<string, unknown> => ({
-  type: 'email',
-  email: faker.internet.email(),
-  role: 'MEMBER',
-  name: faker.person.firstName(),
-});
 
 describe('InviteUsersDtoSchema', () => {
   it('should validate a wallet invite with explicit type', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [walletInviteItem()],
+      users: [walletInviteUserDtoBuilder().build()],
     });
 
     expect(result.success).toBe(true);
@@ -28,7 +18,7 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should validate an email invite with explicit type', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [emailInviteItem()],
+      users: [emailInviteUserDtoBuilder().build()],
     });
 
     expect(result.success).toBe(true);
@@ -36,14 +26,17 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should validate a mixed batch of wallet and email invites', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [walletInviteItem(), emailInviteItem()],
+      users: [
+        walletInviteUserDtoBuilder().build(),
+        emailInviteUserDtoBuilder().build(),
+      ],
     });
 
     expect(result.success).toBe(true);
   });
 
   it('should infer type=wallet for legacy clients sending address without type', () => {
-    const { type: _type, ...legacy } = walletInviteItem();
+    const { type: _type, ...legacy } = walletInviteUserDtoBuilder().build();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [legacy] });
 
@@ -52,7 +45,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject an email-shaped item that omits `type`', () => {
-    const { type: _type, ...legacy } = emailInviteItem();
+    const { type: _type, ...legacy } = emailInviteUserDtoBuilder().build();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [legacy] });
 
@@ -61,7 +54,12 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should normalize email to lowercase via EmailAddressSchema', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...emailInviteItem(), email: 'Mixed.Case@Example.COM' }],
+      users: [
+        {
+          ...emailInviteUserDtoBuilder().build(),
+          email: 'Mixed.Case@Example.COM',
+        },
+      ],
     });
 
     expect(result.success).toBe(true);
@@ -72,7 +70,9 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject an invalid email format', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...emailInviteItem(), email: 'not-an-email' }],
+      users: [
+        { ...emailInviteUserDtoBuilder().build(), email: 'not-an-email' },
+      ],
     });
 
     expect(result.success).toBe(false);
@@ -93,7 +93,7 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject an item missing the role field', () => {
-    const { role: _role, ...wallet } = walletInviteItem();
+    const { role: _role, ...wallet } = walletInviteUserDtoBuilder().build();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
 
@@ -101,7 +101,8 @@ describe('InviteUsersDtoSchema', () => {
   });
 
   it('should reject a wallet item missing the address', () => {
-    const { address: _address, ...wallet } = walletInviteItem();
+    const { address: _address, ...wallet } =
+      walletInviteUserDtoBuilder().build();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
 
@@ -110,14 +111,16 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject a wallet item with an invalid address', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), address: 'not-an-address' }],
+      users: [
+        { ...walletInviteUserDtoBuilder().build(), address: 'not-an-address' },
+      ],
     });
 
     expect(result.success).toBe(false);
   });
 
   it('should reject an email item missing the email', () => {
-    const { email: _email, ...email } = emailInviteItem();
+    const { email: _email, ...email } = emailInviteUserDtoBuilder().build();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [email] });
 
@@ -127,7 +130,7 @@ describe('InviteUsersDtoSchema', () => {
   it('should reject an email exceeding 255 characters', () => {
     const longEmail = `${'a'.repeat(251)}@b.co`;
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...emailInviteItem(), email: longEmail }],
+      users: [{ ...emailInviteUserDtoBuilder().build(), email: longEmail }],
     });
 
     expect(result.success).toBe(false);
@@ -135,14 +138,14 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject an unknown type value', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), type: 'admin' }],
+      users: [{ ...walletInviteUserDtoBuilder().build(), type: 'admin' }],
     });
 
     expect(result.success).toBe(false);
   });
 
   it('should reject an item missing the name field', () => {
-    const { name: _name, ...wallet } = walletInviteItem();
+    const { name: _name, ...wallet } = walletInviteUserDtoBuilder().build();
 
     const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
 
@@ -151,7 +154,9 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject a name exceeding 30 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), name: 'a'.repeat(31) }],
+      users: [
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(31) },
+      ],
     });
 
     expect(result.success).toBe(false);
@@ -159,7 +164,7 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject a name shorter than 3 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), name: 'ab' }],
+      users: [{ ...walletInviteUserDtoBuilder().build(), name: 'ab' }],
     });
 
     expect(result.success).toBe(false);
@@ -167,7 +172,7 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject a whitespace-only name', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), name: '   ' }],
+      users: [{ ...walletInviteUserDtoBuilder().build(), name: '   ' }],
     });
 
     expect(result.success).toBe(false);
@@ -175,7 +180,7 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject a name with invalid characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), name: '<>@!' }],
+      users: [{ ...walletInviteUserDtoBuilder().build(), name: '<>@!' }],
     });
 
     expect(result.success).toBe(false);
@@ -183,7 +188,7 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject an invalid role value', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), role: 'OWNER' }],
+      users: [{ ...walletInviteUserDtoBuilder().build(), role: 'OWNER' }],
     });
 
     expect(result.success).toBe(false);
@@ -203,7 +208,12 @@ describe('InviteUsersDtoSchema', () => {
 
   it('should reject a wallet item that also carries an email field (strict)', () => {
     const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteItem(), email: faker.internet.email() }],
+      users: [
+        {
+          ...walletInviteUserDtoBuilder().build(),
+          email: faker.internet.email(),
+        },
+      ],
     });
 
     expect(result.success).toBe(false);
@@ -213,7 +223,7 @@ describe('InviteUsersDtoSchema', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [
         {
-          ...emailInviteItem(),
+          ...emailInviteUserDtoBuilder().build(),
           address: getAddress(faker.finance.ethereumAddress()),
         },
       ],

--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { InviteUsersDtoSchema } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
+
+const walletInviteItem = (): Record<string, unknown> => ({
+  type: 'wallet',
+  address: getAddress(faker.finance.ethereumAddress()),
+  role: 'MEMBER',
+  name: faker.person.firstName(),
+});
+
+const emailInviteItem = (): Record<string, unknown> => ({
+  type: 'email',
+  email: faker.internet.email(),
+  role: 'MEMBER',
+  name: faker.person.firstName(),
+});
+
+describe('InviteUsersDtoSchema', () => {
+  it('should validate a wallet invite with explicit type', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [walletInviteItem()],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate an email invite with explicit type', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [emailInviteItem()],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate a mixed batch of wallet and email invites', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [walletInviteItem(), emailInviteItem()],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should infer type=wallet for legacy clients sending address without type', () => {
+    const legacy = walletInviteItem();
+    delete legacy.type;
+
+    const result = InviteUsersDtoSchema.safeParse({ users: [legacy] });
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.users[0].type).toBe('wallet');
+  });
+
+  it('should reject an email-shaped item that omits `type`', () => {
+    const legacy = emailInviteItem();
+    delete legacy.type;
+
+    const result = InviteUsersDtoSchema.safeParse({ users: [legacy] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should normalize email to lowercase via EmailAddressSchema', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...emailInviteItem(), email: 'Mixed.Case@Example.COM' }],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success && result.data.users[0].type === 'email') {
+      expect(result.data.users[0].email).toBe('mixed.case@example.com');
+    }
+  });
+
+  it('should reject an invalid email format', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...emailInviteItem(), email: 'not-an-email' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an empty users array', () => {
+    const result = InviteUsersDtoSchema.safeParse({ users: [] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an item with neither address nor email', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ role: 'MEMBER', name: faker.person.firstName() }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an item missing the role field', () => {
+    const wallet = walletInviteItem();
+    delete wallet.role;
+
+    const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a wallet item missing the address', () => {
+    const wallet = walletInviteItem();
+    delete wallet.address;
+
+    const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a wallet item with an invalid address', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), address: 'not-an-address' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an email item missing the email', () => {
+    const email = emailInviteItem();
+    delete email.email;
+
+    const result = InviteUsersDtoSchema.safeParse({ users: [email] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an email exceeding 255 characters', () => {
+    const longEmail = `${'a'.repeat(251)}@b.co`;
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...emailInviteItem(), email: longEmail }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an unknown type value', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), type: 'admin' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an item missing the name field', () => {
+    const wallet = walletInviteItem();
+    delete wallet.name;
+
+    const result = InviteUsersDtoSchema.safeParse({ users: [wallet] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a name exceeding 255 characters', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), name: 'a'.repeat(256) }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an invalid role value', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), role: 'OWNER' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a body missing the users field', () => {
+    const result = InviteUsersDtoSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a body where users is not an array', () => {
+    const result = InviteUsersDtoSchema.safeParse({ users: 'not-an-array' });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a wallet item that also carries an email field (strict)', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [{ ...walletInviteItem(), email: faker.internet.email() }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an email item that also carries an address field (strict)', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [
+        {
+          ...emailInviteItem(),
+          address: getAddress(faker.finance.ethereumAddress()),
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
@@ -2,12 +2,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
 import {
+  makeNameSchema,
   NAME_MAX_LENGTH,
   NAME_MIN_LENGTH,
 } from '@/domain/common/schemas/name.schema';
 
 export const AcceptInviteDtoSchema = z.object({
-  name: z.string().max(255),
+  name: makeNameSchema(),
 });
 
 export class AcceptInviteDto implements z.infer<typeof AcceptInviteDtoSchema> {

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
 import {
@@ -9,24 +9,66 @@ import {
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { MemberRole } from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import {
+  type EmailAddress,
+  EmailAddressSchema,
+} from '@/validation/entities/schemas/email-address.schema';
 
-const InviteUserDtoSchema = z
-  .array(
-    z.object({
-      address: AddressSchema,
-      role: z.enum(getStringEnumKeys(MemberRole)),
-      name: z.string().max(255),
-    }),
-  )
-  .min(1);
+export const InviteType = {
+  Wallet: 'wallet',
+  Email: 'email',
+} as const;
+
+const SharedInviteFields = {
+  role: z.enum(getStringEnumKeys(MemberRole)),
+  name: z.string().max(NAME_MAX_LENGTH),
+};
+
+const WalletInviteUserSchema = z
+  .object({
+    type: z.literal(InviteType.Wallet),
+    address: AddressSchema,
+    ...SharedInviteFields,
+  })
+  .strict();
+
+const EmailInviteUserSchema = z
+  .object({
+    type: z.literal(InviteType.Email),
+    email: EmailAddressSchema,
+    ...SharedInviteFields,
+  })
+  .strict();
+
+export const InviteUserSchema = z.discriminatedUnion('type', [
+  WalletInviteUserSchema,
+  EmailInviteUserSchema,
+]);
+
+export type InviteUserInput = z.infer<typeof InviteUserSchema>;
+
+// Defaults missing `type` to wallet so legacy clients keep working.
+// TODO: remove once wallet-1 wa-2052 ships.
+const InviteUserSchemaWithWalletDefault = z.preprocess((raw) => {
+  if (raw && typeof raw === 'object' && !('type' in raw)) {
+    return { ...raw, type: InviteType.Wallet };
+  }
+  return raw;
+}, InviteUserSchema);
 
 export const InviteUsersDtoSchema = z.object({
-  users: InviteUserDtoSchema,
+  users: z.array(InviteUserSchemaWithWalletDefault).min(1),
 });
 
-export class InviteUserDto {
+export class WalletInviteUserDto {
+  @ApiProperty({ enum: [InviteType.Wallet] })
+  public readonly type!: typeof InviteType.Wallet;
+
   @ApiProperty()
   public readonly address!: Address;
+
+  @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
+  public readonly role!: keyof typeof MemberRole;
 
   @ApiProperty({
     type: String,
@@ -34,17 +76,36 @@ export class InviteUserDto {
     maxLength: NAME_MAX_LENGTH,
   })
   public readonly name!: string;
-
-  @ApiProperty({
-    enum: getStringEnumKeys(MemberRole),
-  })
-  public readonly role!: keyof typeof MemberRole;
 }
 
+export class EmailInviteUserDto {
+  @ApiProperty({ enum: [InviteType.Email] })
+  public readonly type!: typeof InviteType.Email;
+
+  @ApiProperty({ type: String, format: 'email', maxLength: 255 })
+  public readonly email!: EmailAddress;
+
+  @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
+  public readonly role!: keyof typeof MemberRole;
+
+  @ApiProperty({
+    type: String,
+    minLength: NAME_MIN_LENGTH,
+    maxLength: NAME_MAX_LENGTH,
+  })
+  public readonly name!: string;
+}
+
+@ApiExtraModels(WalletInviteUserDto, EmailInviteUserDto)
 export class InviteUsersDto implements z.infer<typeof InviteUsersDtoSchema> {
   @ApiProperty({
-    type: InviteUserDto,
-    isArray: true,
+    type: 'array',
+    items: {
+      oneOf: [
+        { $ref: getSchemaPath(WalletInviteUserDto) },
+        { $ref: getSchemaPath(EmailInviteUserDto) },
+      ],
+    },
   })
-  public readonly users!: Array<InviteUserDto>;
+  public readonly users!: Array<InviteUserInput>;
 }

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -3,6 +3,7 @@ import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
 import {
+  makeNameSchema,
   NAME_MAX_LENGTH,
   NAME_MIN_LENGTH,
 } from '@/domain/common/schemas/name.schema';
@@ -21,7 +22,7 @@ export const InviteType = {
 
 const SharedInviteFields = {
   role: z.enum(getStringEnumKeys(MemberRole)),
-  name: z.string().max(NAME_MAX_LENGTH),
+  name: makeNameSchema(),
 };
 
 const WalletInviteUserSchema = z

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -61,7 +61,7 @@ export const InviteUsersDtoSchema = z.object({
   users: z.array(InviteUserSchemaWithWalletDefault).min(1),
 });
 
-export class WalletInviteUserDto {
+class WalletInviteUserDto implements z.infer<typeof WalletInviteUserSchema> {
   @ApiProperty({ enum: [InviteType.Wallet] })
   public readonly type!: typeof InviteType.Wallet;
 
@@ -79,7 +79,7 @@ export class WalletInviteUserDto {
   public readonly name!: string;
 }
 
-export class EmailInviteUserDto {
+class EmailInviteUserDto implements z.infer<typeof EmailInviteUserSchema> {
   @ApiProperty({ enum: [InviteType.Email] })
   public readonly type!: typeof InviteType.Email;
 

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -981,7 +981,7 @@ describe('MembersRepository', () => {
         name: nameBuilder(),
         role: 'ADMIN',
         status: 'ACTIVE',
-        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        invitedBy: null,
       });
       const inviteEmail = EmailAddressSchema.parse(faker.internet.email());
       const inviteName = nameBuilder();
@@ -1023,7 +1023,7 @@ describe('MembersRepository', () => {
         name: nameBuilder(),
         role: 'ADMIN',
         status: 'ACTIVE',
-        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        invitedBy: null,
       });
       const existingEmail = EmailAddressSchema.parse(faker.internet.email());
       const existingInsert = await dbUserRepo.insert({

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -672,7 +672,7 @@ describe('MembersRepository', () => {
         name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
-        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        invitedBy: null,
       });
       const users = faker.helpers.multiple(
         () => {
@@ -727,7 +727,7 @@ describe('MembersRepository', () => {
         name: adminName,
         role: 'ADMIN',
         status: 'ACTIVE',
-        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        invitedBy: null,
       });
       const users = faker.helpers.multiple(
         () => {

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -4,7 +4,6 @@ import { faker } from '@faker-js/faker';
 import { ForbiddenException, GoneException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { DataSource, In } from 'typeorm';
-import type { Address } from 'viem';
 import { getAddress } from 'viem';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
@@ -24,6 +23,10 @@ import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
 import { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
 import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
+import {
+  InviteType,
+  type InviteUserInput,
+} from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
 import {
@@ -35,6 +38,7 @@ import { MembersRepository } from '@/modules/users/domain/members.repository';
 import { UsersRepository } from '@/modules/users/domain/users.repository';
 import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
+import { EmailAddressSchema } from '@/validation/entities/schemas/email-address.schema';
 
 const mockLoggingService = {
   debug: jest.fn(),
@@ -674,6 +678,7 @@ describe('MembersRepository', () => {
       const users = faker.helpers.multiple(
         () => {
           return {
+            type: InviteType.Wallet,
             address: getAddress(faker.finance.ethereumAddress()),
             role: faker.helpers.arrayElement(MemberRoleKeys),
             name: faker.person.firstName(),
@@ -728,6 +733,7 @@ describe('MembersRepository', () => {
       const users = faker.helpers.multiple(
         () => {
           return {
+            type: InviteType.Wallet,
             address: getAddress(faker.finance.ethereumAddress()),
             role: faker.helpers.arrayElement(MemberRoleKeys),
             name: faker.person.firstName(),
@@ -791,6 +797,7 @@ describe('MembersRepository', () => {
         spaceId,
         users: [
           {
+            type: InviteType.Wallet,
             address: memberWallet,
             role: memberRole,
             name: memberName,
@@ -874,6 +881,7 @@ describe('MembersRepository', () => {
           spaceId,
           users: [
             {
+              type: InviteType.Wallet,
               address: inviteeAddress,
               role: 'ADMIN',
               name: updatedInviteeName,
@@ -947,6 +955,7 @@ describe('MembersRepository', () => {
           spaceId,
           users: [
             {
+              type: InviteType.Wallet,
               address: activeMemberAddress,
               role: 'ADMIN',
               name: faker.person.firstName(),
@@ -959,6 +968,90 @@ describe('MembersRepository', () => {
       );
     });
 
+    it('should invite by email, creating a PENDING placeholder user', async () => {
+      const inviteExpiresAt = faker.date.future();
+      const { user: owner, authPayload } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: owner,
+        space: space.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+      });
+      const inviteEmail = EmailAddressSchema.parse(faker.internet.email());
+      const inviteName = nameBuilder();
+
+      const invitations = await membersRepository.inviteUsers({
+        authPayload,
+        spaceId,
+        users: [
+          {
+            type: InviteType.Email,
+            email: inviteEmail,
+            role: 'MEMBER',
+            name: inviteName,
+          },
+        ],
+        inviteExpiresAt,
+      });
+
+      expect(invitations).toHaveLength(1);
+      const placeholder = await dbUserRepo.findOneOrFail({
+        where: { id: invitations[0].userId },
+      });
+      expect(placeholder.status).toBe('PENDING');
+      expect(placeholder.email).toBe(inviteEmail);
+      expect(placeholder.extUserId).toBeNull();
+    });
+
+    it('should reuse the existing user when invited by email matches an ACTIVE account', async () => {
+      const inviteExpiresAt = faker.date.future();
+      const { user: owner, authPayload } = await createSiweUser();
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: owner,
+        space: space.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+      });
+      const existingEmail = EmailAddressSchema.parse(faker.internet.email());
+      const existingInsert = await dbUserRepo.insert({
+        status: 'ACTIVE',
+        email: existingEmail,
+        extUserId: faker.string.uuid(),
+      });
+      const existingUserId = existingInsert.generatedMaps[0].id;
+
+      const invitations = await membersRepository.inviteUsers({
+        authPayload,
+        spaceId,
+        users: [
+          {
+            type: InviteType.Email,
+            email: existingEmail,
+            role: 'MEMBER',
+            name: nameBuilder(),
+          },
+        ],
+        inviteExpiresAt,
+      });
+
+      expect(invitations).toHaveLength(1);
+      expect(invitations[0].userId).toBe(existingUserId);
+    });
+
     it('should throw an error if the space does not exist', async () => {
       const inviteExpiresAt = faker.date.future();
       const { authPayload } = await createSiweUser();
@@ -966,11 +1059,7 @@ describe('MembersRepository', () => {
         min: 69420,
         max: DB_MAX_SAFE_INTEGER,
       });
-      const users: Array<{
-        address: Address;
-        role: keyof typeof MemberRole;
-        name: string;
-      }> = [];
+      const users: Array<InviteUserInput> = [];
 
       await expect(
         membersRepository.inviteUsers({

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -133,7 +133,6 @@ describe('MembersRepository', () => {
       postgresDatabaseService,
       new UsersRepository(postgresDatabaseService, walletsRepo),
       new SpacesRepository(postgresDatabaseService, mockConfigurationService),
-      walletsRepo,
     );
   });
 

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -5,9 +5,9 @@ import type {
   FindOptionsRelations,
   FindOptionsWhere,
 } from 'typeorm';
-import type { Address } from 'viem';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import type { InviteUserInput } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import type { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import type { Invitation } from '@/modules/users/domain/entities/invitation.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
@@ -45,11 +45,7 @@ export interface IMembersRepository {
   inviteUsers(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    users: Array<{
-      address: Address;
-      role: Member['role'];
-      name: Member['name'];
-    }>;
+    users: Array<InviteUserInput>;
     inviteExpiresAt: Date;
   }): Promise<Array<Invitation>>;
 

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -10,27 +10,25 @@ import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__test
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { spaceBuilder } from '@/modules/spaces/domain/entities/__tests__/space.entity.db.builder';
 import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
+import { InviteType } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import { MembersRepository } from '@/modules/users/domain/members.repository';
 import type { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { walletBuilder } from '@/modules/wallets/datasources/entities/__tests__/wallets.entity.db.builder';
-import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
 
 describe('MembersRepository', () => {
   const usersRepository = {
     create: jest.fn(),
+    findOrCreateByWalletAddress: jest.fn(),
     updateStatus: jest.fn(),
   } as jest.MockedObjectDeep<IUsersRepository>;
   const spacesRepository = {
     findOneOrFail: jest.fn(),
   } as jest.MockedObjectDeep<ISpacesRepository>;
-  const walletsRepository = {
-    find: jest.fn(),
-  } as jest.MockedObjectDeep<IWalletsRepository>;
 
   let entityManager: jest.Mocked<
-    Pick<EntityManager, 'findOne' | 'insert' | 'update'>
+    Pick<EntityManager, 'find' | 'findOne' | 'insert' | 'update'>
   >;
   let postgresDatabaseService: jest.MockedObjectDeep<PostgresDatabaseService>;
   let target: MembersRepository;
@@ -45,6 +43,7 @@ describe('MembersRepository', () => {
 
     inviteExpiresAt = faker.date.future();
     entityManager = {
+      find: jest.fn(),
       findOne: jest.fn(),
       insert: jest.fn(),
       update: jest.fn(),
@@ -60,7 +59,6 @@ describe('MembersRepository', () => {
       postgresDatabaseService,
       usersRepository,
       spacesRepository,
-      walletsRepository,
     );
   });
 
@@ -68,11 +66,12 @@ describe('MembersRepository', () => {
     it('should insert a member invite when the user is not already in the space', async () => {
       const wallet = walletBuilder().build();
       const userToInvite = {
+        type: InviteType.Wallet,
         address: wallet.address,
         role: 'MEMBER' as const,
         name: nameBuilder(),
       };
-      walletsRepository.find.mockResolvedValue([wallet]);
+      entityManager.find.mockResolvedValue([wallet]);
       entityManager.findOne.mockResolvedValue(null);
 
       await expect(
@@ -116,11 +115,12 @@ describe('MembersRepository', () => {
         .build();
       const wallet = walletBuilder().with('user', existingMember.user).build();
       const userToInvite = {
+        type: InviteType.Wallet,
         address: wallet.address,
         role: 'ADMIN' as const,
         name: nameBuilder(),
       };
-      walletsRepository.find.mockResolvedValue([wallet]);
+      entityManager.find.mockResolvedValue([wallet]);
       entityManager.findOne.mockResolvedValue(existingMember);
 
       await target.inviteUsers({
@@ -167,11 +167,12 @@ describe('MembersRepository', () => {
         .build();
       const wallet = walletBuilder().with('user', existingMember.user).build();
       const userToInvite = {
+        type: InviteType.Wallet,
         address: wallet.address,
         role: 'ADMIN' as const,
         name: nameBuilder(),
       };
-      walletsRepository.find.mockResolvedValue([wallet]);
+      entityManager.find.mockResolvedValue([wallet]);
       entityManager.findOne.mockResolvedValue(existingMember);
 
       await expect(
@@ -193,11 +194,12 @@ describe('MembersRepository', () => {
     it('should translate insert unique constraint races to a domain error', async () => {
       const wallet = walletBuilder().build();
       const userToInvite = {
+        type: InviteType.Wallet,
         address: wallet.address,
         role: 'MEMBER' as const,
         name: nameBuilder(),
       };
-      walletsRepository.find.mockResolvedValue([wallet]);
+      entityManager.find.mockResolvedValue([wallet]);
       entityManager.findOne.mockResolvedValue(null);
       entityManager.insert.mockRejectedValue(
         new QueryFailedError(

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -13,6 +13,8 @@ import type {
   FindOptionsRelations,
   FindOptionsWhere,
 } from 'typeorm';
+import { In } from 'typeorm';
+import type { Address } from 'viem';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
@@ -31,6 +33,7 @@ import type { User } from '@/modules/users/domain/entities/user.entity';
 import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { activeOrPendingMemberWhere } from '@/modules/users/domain/utils/members.utils';
+import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
 
 @Injectable()
 export class MembersRepository implements IMembersRepository {
@@ -119,18 +122,36 @@ export class MembersRepository implements IMembersRepository {
     });
 
     const invitations: Array<Invitation> = [];
+    const walletAddresses = args.users.flatMap((user) =>
+      user.type === InviteType.Wallet ? [user.address] : [],
+    );
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const walletUserIds = new Map<Address, User['id']>();
+      if (walletAddresses.length > 0) {
+        // Batch existing wallet lookups while keeping user creation atomic.
+        const wallets = await entityManager.find(Wallet, {
+          where: { address: In(walletAddresses) },
+          relations: { user: true },
+        });
+
+        for (const wallet of wallets) {
+          walletUserIds.set(wallet.address, wallet.user.id);
+        }
+      }
+
       for (const userToInvite of args.users) {
         let userIdToInvite: User['id'];
         switch (userToInvite.type) {
           case InviteType.Wallet: {
             userIdToInvite =
-              await this.usersRepository.findOrCreateByWalletAddress(
+              walletUserIds.get(userToInvite.address) ??
+              (await this.usersRepository.findOrCreateByWalletAddress(
                 userToInvite.address,
                 'PENDING',
                 entityManager,
-              );
+              ));
+            walletUserIds.set(userToInvite.address, userIdToInvite);
             break;
           }
           case InviteType.Email: {

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -13,8 +13,6 @@ import type {
   FindOptionsRelations,
   FindOptionsWhere,
 } from 'typeorm';
-import { In } from 'typeorm';
-import { type Address, isAddressEqual } from 'viem';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
@@ -33,7 +31,6 @@ import type { User } from '@/modules/users/domain/entities/user.entity';
 import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 import { IUsersRepository } from '@/modules/users/domain/users.repository.interface';
 import { activeOrPendingMemberWhere } from '@/modules/users/domain/utils/members.utils';
-import { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
 
 @Injectable()
 export class MembersRepository implements IMembersRepository {
@@ -43,8 +40,6 @@ export class MembersRepository implements IMembersRepository {
     private readonly usersRepository: IUsersRepository,
     @Inject(ISpacesRepository)
     private readonly spacesRepository: ISpacesRepository,
-    @Inject(IWalletsRepository)
-    private readonly walletsRepository: IWalletsRepository,
   ) {}
 
   public async findOneOrFail(
@@ -123,15 +118,6 @@ export class MembersRepository implements IMembersRepository {
       where: { id: args.spaceId },
     });
 
-    const invitedAddresses = args.users.flatMap((u) =>
-      u.type === InviteType.Wallet ? [u.address] : [],
-    );
-    const invitedWallets = invitedAddresses.length
-      ? await this.walletsRepository.find({
-          where: { address: In(invitedAddresses) },
-          relations: { user: true },
-        })
-      : [];
     const invitations: Array<Invitation> = [];
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
@@ -139,15 +125,11 @@ export class MembersRepository implements IMembersRepository {
         let userIdToInvite: User['id'];
         switch (userToInvite.type) {
           case InviteType.Wallet: {
-            const wallet = invitedWallets.find((w) =>
-              isAddressEqual(w.address, userToInvite.address),
-            );
-            userIdToInvite = wallet
-              ? wallet.user.id
-              : await this.createUserAndWallet({
-                  entityManager,
-                  address: userToInvite.address,
-                });
+            userIdToInvite =
+              await this.usersRepository.findOrCreateByWalletAddress(
+                userToInvite.address,
+                'PENDING',
+              );
             break;
           }
           case InviteType.Email: {
@@ -246,19 +228,6 @@ export class MembersRepository implements IMembersRepository {
     }
 
     throw duplicateInviteError();
-  }
-
-  private async createUserAndWallet(args: {
-    entityManager: EntityManager;
-    address: Address;
-  }): Promise<User['id']> {
-    const { address, entityManager } = args;
-    const userId = await this.usersRepository.create('PENDING', entityManager);
-    await this.walletsRepository.create(
-      { walletAddress: address, userId },
-      entityManager,
-    );
-    return userId;
   }
 
   public async acceptInvite(args: {

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -155,11 +155,10 @@ export class MembersRepository implements IMembersRepository {
             break;
           }
           case InviteType.Email: {
-            userIdToInvite =
-              await this.usersRepository.findOrCreatePendingByEmail(
-                userToInvite.email,
-                entityManager,
-              );
+            userIdToInvite = await this.usersRepository.findOrCreateByEmail(
+              userToInvite.email,
+              entityManager,
+            );
             break;
           }
         }

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -129,6 +129,7 @@ export class MembersRepository implements IMembersRepository {
               await this.usersRepository.findOrCreateByWalletAddress(
                 userToInvite.address,
                 'PENDING',
+                entityManager,
               );
             break;
           }

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -22,6 +22,10 @@ import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.en
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
+import {
+  InviteType,
+  type InviteUserInput,
+} from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import type { Invitation } from '@/modules/users/domain/entities/invitation.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
@@ -110,11 +114,7 @@ export class MembersRepository implements IMembersRepository {
   public async inviteUsers(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
-    users: Array<{
-      name: Member['name'];
-      address: Address;
-      role: Member['role'];
-    }>;
+    users: Array<InviteUserInput>;
     inviteExpiresAt: Date;
   }): Promise<Array<Invitation>> {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
@@ -123,25 +123,42 @@ export class MembersRepository implements IMembersRepository {
       where: { id: args.spaceId },
     });
 
-    const invitedAddresses = args.users.map((user) => user.address);
-    const invitedWallets = await this.walletsRepository.find({
-      where: { address: In(invitedAddresses) },
-      relations: { user: true },
-    });
+    const invitedAddresses = args.users.flatMap((u) =>
+      u.type === InviteType.Wallet ? [u.address] : [],
+    );
+    const invitedWallets = invitedAddresses.length
+      ? await this.walletsRepository.find({
+          where: { address: In(invitedAddresses) },
+          relations: { user: true },
+        })
+      : [];
     const invitations: Array<Invitation> = [];
 
     await this.postgresDatabaseService.transaction(async (entityManager) => {
       for (const userToInvite of args.users) {
-        // Find existing User via Wallet or create new User and Wallet.
-        const wallet = invitedWallets.find((wallet) => {
-          return isAddressEqual(wallet.address, userToInvite.address);
-        });
-        const userIdToInvite = wallet
-          ? wallet.user.id
-          : await this.createUserAndWallet({
-              entityManager,
-              address: userToInvite.address,
-            });
+        let userIdToInvite: User['id'];
+        switch (userToInvite.type) {
+          case InviteType.Wallet: {
+            const wallet = invitedWallets.find((w) =>
+              isAddressEqual(w.address, userToInvite.address),
+            );
+            userIdToInvite = wallet
+              ? wallet.user.id
+              : await this.createUserAndWallet({
+                  entityManager,
+                  address: userToInvite.address,
+                });
+            break;
+          }
+          case InviteType.Email: {
+            userIdToInvite =
+              await this.usersRepository.findOrCreatePendingByEmail(
+                userToInvite.email,
+                entityManager,
+              );
+            break;
+          }
+        }
 
         await this.insertOrUpdateInvite({
           entityManager,
@@ -170,11 +187,7 @@ export class MembersRepository implements IMembersRepository {
     entityManager: EntityManager;
     space: Space;
     userId: User['id'];
-    userToInvite: {
-      name: Member['name'];
-      address: Address;
-      role: Member['role'];
-    };
+    userToInvite: InviteUserInput;
     invitedBy: number | null;
     inviteExpiresAt: Date;
   }): Promise<void> {
@@ -186,11 +199,13 @@ export class MembersRepository implements IMembersRepository {
       invitedBy,
       inviteExpiresAt,
     } = args;
-    const { name, role, address } = userToInvite;
+    const { name, role } = userToInvite;
 
     const duplicateInviteError = (): UniqueConstraintError =>
       new UniqueConstraintError(
-        `${address} is already in this space or has a pending invite.`,
+        userToInvite.type === InviteType.Wallet
+          ? `${userToInvite.address} is already in this space or has a pending invite.`
+          : 'This invitee is already in this space or has a pending invite.',
       );
 
     const existingMember = await entityManager.findOne(DbMember, {

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -996,6 +996,70 @@ describe('UsersRepository', () => {
         ),
       ).rejects.toThrow(UnauthorizedException);
     });
+
+    it('should claim a PENDING email-invite placeholder and flip it to ACTIVE', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const email = fakeEmailAddress();
+      const extUserId = faker.string.uuid();
+      const placeholderInsert = await dbUserRepository.insert({
+        status: 'PENDING',
+        email,
+      });
+      const placeholderId = placeholderInsert.identifiers[0].id as number;
+
+      const resolvedId = await usersRepository.findOrCreateByExtUserIdAndEmail(
+        extUserId,
+        email,
+      );
+
+      expect(resolvedId).toBe(placeholderId);
+      const claimed = await dbUserRepository.findOneOrFail({
+        where: { id: placeholderId },
+      });
+      expect(claimed.status).toBe('ACTIVE');
+      expect(claimed.extUserId).toBe(extUserId);
+      expect(claimed.email).toBe(email);
+    });
+  });
+
+  describe('findOrCreatePendingByEmail', () => {
+    it('should insert a PENDING user when no row with the email exists', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const email = fakeEmailAddress();
+
+      const userId = await usersRepository.findOrCreatePendingByEmail(email);
+
+      const user = await dbUserRepository.findOneOrFail({
+        where: { id: userId },
+      });
+      expect(user.status).toBe('PENDING');
+      expect(user.email).toBe(email);
+      expect(user.extUserId).toBeNull();
+    });
+
+    it('should be idempotent and return the existing user id on repeated calls', async () => {
+      const email = fakeEmailAddress();
+
+      const first = await usersRepository.findOrCreatePendingByEmail(email);
+      const second = await usersRepository.findOrCreatePendingByEmail(email);
+
+      expect(first).toBe(second);
+    });
+
+    it('should return the existing user id when a user with this email is already ACTIVE', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const email = fakeEmailAddress();
+      const insertResult = await dbUserRepository.insert({
+        status: 'ACTIVE',
+        email,
+        extUserId: faker.string.uuid(),
+      });
+      const existingId = insertResult.identifiers[0].id as number;
+
+      await expect(
+        usersRepository.findOrCreatePendingByEmail(email),
+      ).resolves.toBe(existingId);
+    });
   });
 
   describe('update', () => {

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -1047,12 +1047,12 @@ describe('UsersRepository', () => {
     });
   });
 
-  describe('findOrCreatePendingByEmail', () => {
+  describe('findOrCreateByEmail', () => {
     it('should insert a PENDING user when no row with the email exists', async () => {
       const dbUserRepository = dataSource.getRepository(User);
       const email = fakeEmailAddress();
 
-      const userId = await usersRepository.findOrCreatePendingByEmail(email);
+      const userId = await usersRepository.findOrCreateByEmail(email);
 
       const user = await dbUserRepository.findOneOrFail({
         where: { id: userId },
@@ -1065,8 +1065,8 @@ describe('UsersRepository', () => {
     it('should be idempotent and return the existing user id on repeated calls', async () => {
       const email = fakeEmailAddress();
 
-      const first = await usersRepository.findOrCreatePendingByEmail(email);
-      const second = await usersRepository.findOrCreatePendingByEmail(email);
+      const first = await usersRepository.findOrCreateByEmail(email);
+      const second = await usersRepository.findOrCreateByEmail(email);
 
       expect(first).toBe(second);
     });
@@ -1081,9 +1081,9 @@ describe('UsersRepository', () => {
       });
       const existingId = insertResult.identifiers[0].id as number;
 
-      await expect(
-        usersRepository.findOrCreatePendingByEmail(email),
-      ).resolves.toBe(existingId);
+      await expect(usersRepository.findOrCreateByEmail(email)).resolves.toBe(
+        existingId,
+      );
     });
   });
 

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -877,6 +877,31 @@ describe('UsersRepository', () => {
       });
     });
 
+    it('should create a PENDING user when requested', async () => {
+      const dbUserRepository = dataSource.getRepository(User);
+      const dbWalletRepository = dataSource.getRepository(Wallet);
+      const address = getAddress(faker.finance.ethereumAddress());
+
+      const userId = await usersRepository.findOrCreateByWalletAddress(
+        address,
+        'PENDING',
+      );
+
+      await expect(
+        dbUserRepository.findOneOrFail({ where: { id: userId } }),
+      ).resolves.toEqual(expect.objectContaining({ status: 'PENDING' }));
+      await expect(
+        dbWalletRepository.findOneOrFail({
+          where: { address },
+          relations: { user: true },
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          user: expect.objectContaining({ id: userId, status: 'PENDING' }),
+        }),
+      );
+    });
+
     it('should checksum the wallet address when creating', async () => {
       const dbWalletRepository = dataSource.getRepository(Wallet);
       const nonChecksummedAddress = faker.finance

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -61,7 +61,10 @@ export interface IUsersRepository {
 
   findByWalletAddress(address: Address): Promise<User | undefined>;
 
-  findOrCreateByWalletAddress(address: Address): Promise<User['id']>;
+  findOrCreateByWalletAddress(
+    address: Address,
+    status?: keyof typeof UserStatus,
+  ): Promise<User['id']>;
 
   findOrCreatePendingByEmail(
     email: EmailAddress,

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -67,7 +67,7 @@ export interface IUsersRepository {
     entityManager?: EntityManager,
   ): Promise<User['id']>;
 
-  findOrCreatePendingByEmail(
+  findOrCreateByEmail(
     email: EmailAddress,
     entityManager?: EntityManager,
   ): Promise<User['id']>;

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -63,6 +63,11 @@ export interface IUsersRepository {
 
   findOrCreateByWalletAddress(address: Address): Promise<User['id']>;
 
+  findOrCreatePendingByEmail(
+    email: EmailAddress,
+    entityManager?: EntityManager,
+  ): Promise<User['id']>;
+
   findOrCreateByExtUserIdAndEmail(
     extUserId: string,
     email: EmailAddress,

--- a/src/modules/users/domain/users.repository.interface.ts
+++ b/src/modules/users/domain/users.repository.interface.ts
@@ -64,6 +64,7 @@ export interface IUsersRepository {
   findOrCreateByWalletAddress(
     address: Address,
     status?: keyof typeof UserStatus,
+    entityManager?: EntityManager,
   ): Promise<User['id']>;
 
   findOrCreatePendingByEmail(

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -24,6 +24,7 @@ describe('UsersRepository', () => {
     find: jest.Mock;
     findOne: jest.Mock;
     findOneOrFail: jest.Mock;
+    update: jest.Mock;
     createQueryBuilder: jest.Mock;
   };
   let emailUpdateExecute: jest.Mock;
@@ -46,6 +47,7 @@ describe('UsersRepository', () => {
       find: jest.fn(),
       findOne: jest.fn(),
       findOneOrFail: jest.fn(),
+      update: jest.fn(),
       createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
     };
 
@@ -128,9 +130,10 @@ describe('UsersRepository', () => {
       const userId = faker.number.int({ min: 1 });
       const extUserId = faker.string.uuid();
       const email = fakeEmailAddress();
-      // First lookup finds no record, so we attempt the insert; the insert loses
-      // the race and the re-fetch returns the row the concurrent request wrote.
+      // Lookups: extUserId → null, email → null (no placeholder to claim),
+      // then INSERT loses the race and re-fetch by extUserId finds the row.
       userRepository.findOne
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({ id: userId, email });
       postgresDatabaseService.transaction.mockRejectedValue(
@@ -141,13 +144,14 @@ describe('UsersRepository', () => {
         target.findOrCreateByExtUserIdAndEmail(extUserId, email),
       ).resolves.toBe(userId);
 
-      expect(userRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(userRepository.findOne).toHaveBeenCalledTimes(3);
     });
 
     it('should reject when the racing row has a conflicting email', async () => {
       const userId = faker.number.int({ min: 1 });
       const extUserId = faker.string.uuid();
       userRepository.findOne
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({ id: userId, email: fakeEmailAddress() });
       postgresDatabaseService.transaction.mockRejectedValue(
@@ -157,6 +161,67 @@ describe('UsersRepository', () => {
       await expect(
         target.findOrCreateByExtUserIdAndEmail(extUserId, fakeEmailAddress()),
       ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should claim a PENDING email-invite placeholder and flip it to ACTIVE', async () => {
+      const placeholderId = faker.number.int({ min: 1 });
+      const extUserId = faker.string.uuid();
+      const email = fakeEmailAddress();
+      userRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        id: placeholderId,
+        status: 'PENDING',
+        extUserId: null,
+      });
+      userRepository.update.mockResolvedValue({ affected: 1 });
+
+      await expect(
+        target.findOrCreateByExtUserIdAndEmail(extUserId, email),
+      ).resolves.toBe(placeholderId);
+
+      expect(userRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: placeholderId,
+          status: 'PENDING',
+          extUserId: expect.anything(),
+        }),
+        { extUserId, status: 'ACTIVE' },
+      );
+      expect(postgresDatabaseService.transaction).not.toHaveBeenCalled();
+    });
+
+    it('should throw when the email belongs to an already-active user', async () => {
+      const linkedUserId = faker.number.int({ min: 1 });
+      const extUserId = faker.string.uuid();
+      userRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        id: linkedUserId,
+        status: 'ACTIVE',
+        extUserId: faker.string.uuid(),
+      });
+
+      await expect(
+        target.findOrCreateByExtUserIdAndEmail(extUserId, fakeEmailAddress()),
+      ).rejects.toThrow(UserEmailAlreadyInUseError);
+      expect(userRepository.update).not.toHaveBeenCalled();
+      expect(postgresDatabaseService.transaction).not.toHaveBeenCalled();
+    });
+
+    it('should fall through to INSERT (and surface UserEmailAlreadyInUseError) when the claim UPDATE loses the race', async () => {
+      const placeholderId = faker.number.int({ min: 1 });
+      const extUserId = faker.string.uuid();
+      userRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        id: placeholderId,
+        status: 'PENDING',
+        extUserId: null,
+      });
+      userRepository.update.mockResolvedValue({ affected: 0 });
+      postgresDatabaseService.transaction.mockRejectedValue(
+        uniqueConstraintError('idx_users_email'),
+      );
+
+      await expect(
+        target.findOrCreateByExtUserIdAndEmail(extUserId, fakeEmailAddress()),
+      ).rejects.toThrow(UserEmailAlreadyInUseError);
+      expect(postgresDatabaseService.transaction).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -2,7 +2,9 @@
 import { faker } from '@faker-js/faker';
 import { UnauthorizedException } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
+import { getAddress } from 'viem';
 import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { User as DbUser } from '@/modules/users/datasources/entities/users.entity.db';
 import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-email-already-in-use.error';
 import { UsersRepository } from '@/modules/users/domain/users.repository';
 import type { IWalletsRepository } from '@/modules/wallets/domain/wallets.repository.interface';
@@ -57,6 +59,86 @@ describe('UsersRepository', () => {
     } as jest.MockedObjectDeep<PostgresDatabaseService>;
 
     target = new UsersRepository(postgresDatabaseService, walletsRepository);
+  });
+
+  describe('findOrCreateByWalletAddress', () => {
+    const mockEntityManager = (args?: {
+      walletInsertIdentifiers?: Array<Record<string, unknown>>;
+      createdUserId?: number;
+      racedUserId?: number;
+    }) => {
+      const queryBuilder = {
+        insert: jest.fn().mockReturnThis(),
+        into: jest.fn().mockReturnThis(),
+        values: jest.fn().mockReturnThis(),
+        orIgnore: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({
+          identifiers: args?.walletInsertIdentifiers ?? [{ id: 1 }],
+        }),
+      };
+
+      return {
+        findOne: jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(
+            args?.racedUserId
+              ? {
+                  user: {
+                    id: args.racedUserId,
+                  },
+                }
+              : null,
+          ),
+        insert: jest.fn().mockResolvedValue({
+          identifiers: [{ id: args?.createdUserId ?? 1 }],
+        }),
+        createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+        delete: jest.fn(),
+      };
+    };
+
+    it('should use the provided entity manager instead of opening a transaction', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const createdUserId = faker.number.int({ min: 1 });
+      const entityManager = mockEntityManager({ createdUserId });
+
+      await expect(
+        target.findOrCreateByWalletAddress(
+          address,
+          'PENDING',
+          // The test only needs the EntityManager methods used by the helper.
+          entityManager as never,
+        ),
+      ).resolves.toBe(createdUserId);
+
+      expect(postgresDatabaseService.transaction).not.toHaveBeenCalled();
+      expect(entityManager.insert).toHaveBeenCalledWith(DbUser, {
+        status: 'PENDING',
+      });
+      expect(entityManager.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete the created user and return the racing wallet user when wallet insert is ignored', async () => {
+      const address = getAddress(faker.finance.ethereumAddress());
+      const createdUserId = faker.number.int({ min: 1 });
+      const racedUserId = faker.number.int({ min: createdUserId + 1 });
+      const entityManager = mockEntityManager({
+        createdUserId,
+        racedUserId,
+        walletInsertIdentifiers: [],
+      });
+
+      await expect(
+        target.findOrCreateByWalletAddress(
+          address,
+          'PENDING',
+          entityManager as never,
+        ),
+      ).resolves.toBe(racedUserId);
+
+      expect(entityManager.delete).toHaveBeenCalledWith(DbUser, createdUserId);
+    });
   });
 
   describe('findOrCreateByExtUserIdAndEmail', () => {

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -211,6 +211,7 @@ export class UsersRepository implements IUsersRepository {
         return existing.user.id;
       }
 
+      // `status` only applies when creating a user for a new wallet.
       const userId = await this.create(status, manager);
       const insert = await manager
         .createQueryBuilder()
@@ -250,7 +251,7 @@ export class UsersRepository implements IUsersRepository {
    * Used by the email-invite path: the placeholder will be claimed by the
    * eventual OIDC sign-in via {@link findOrCreateByExtUserIdAndEmail}.
    */
-  public findOrCreatePendingByEmail(
+  public findOrCreateByEmail(
     email: EmailAddress,
     entityManager?: EntityManager,
   ): Promise<User['id']> {

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -372,8 +372,6 @@ export class UsersRepository implements IUsersRepository {
       { extUserId, status: 'ACTIVE' },
     );
 
-    // Lost a race to a concurrent claim; let the caller fall through to
-    // INSERT, where idx_users_email will surface UserEmailAlreadyInUseError.
     return result.affected === 1 ? candidate.id : null;
   }
 
@@ -427,8 +425,6 @@ export class UsersRepository implements IUsersRepository {
         .where('id = :userId', { userId })
         .andWhere('email IS NULL')
         .execute();
-      // Zero affected rows means another request backfilled this user after
-      // reconcileEmail saw email=null; that is idempotent for this path.
     } catch (error) {
       if (this.isUniqueConstraintViolation(error, 'idx_users_email')) {
         throw new UserEmailAlreadyInUseError();

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -197,6 +197,7 @@ export class UsersRepository implements IUsersRepository {
 
   public async findOrCreateByWalletAddress(
     address: Address,
+    status: keyof typeof UserStatus = 'ACTIVE',
   ): Promise<User['id']> {
     const existing = await this.findByWalletAddress(address);
     if (existing) {
@@ -206,7 +207,7 @@ export class UsersRepository implements IUsersRepository {
     try {
       return await this.postgresDatabaseService.transaction(
         async (entityManager: EntityManager) => {
-          const userId = await this.create('ACTIVE', entityManager);
+          const userId = await this.create(status, entityManager);
 
           await this.walletsRepository.create(
             { userId, walletAddress: address },
@@ -413,6 +414,8 @@ export class UsersRepository implements IUsersRepository {
         .where('id = :userId', { userId })
         .andWhere('email IS NULL')
         .execute();
+      // If another request already backfilled the same email, the guarded
+      // update affects zero rows; that is idempotent for this reconcile path.
     } catch (error) {
       if (this.isUniqueConstraintViolation(error, 'idx_users_email')) {
         throw new UserEmailAlreadyInUseError();

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -7,7 +7,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import type { FindOptionsRelations, FindOptionsWhere } from 'typeorm';
-import { EntityManager, In } from 'typeorm';
+import { EntityManager, In, IsNull } from 'typeorm';
 import type { Address } from 'viem';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
@@ -232,16 +232,53 @@ export class UsersRepository implements IUsersRepository {
   }
 
   /**
+   * Returns the id of an existing user with this email, or creates and
+   * returns a PENDING placeholder. Idempotent — repeated calls with the
+   * same email yield the same id.
+   *
+   * Used by the email-invite path: the placeholder will be claimed by the
+   * eventual OIDC sign-in via {@link findOrCreateByExtUserIdAndEmail}.
+   */
+  public findOrCreatePendingByEmail(
+    email: EmailAddress,
+    entityManager?: EntityManager,
+  ): Promise<User['id']> {
+    const upsertThenSelect = async (
+      manager: EntityManager,
+    ): Promise<User['id']> => {
+      await manager
+        .createQueryBuilder()
+        .insert()
+        .into(DbUser)
+        .values({ status: 'PENDING', email })
+        .orIgnore()
+        .execute();
+
+      const user = await manager.findOneOrFail(DbUser, {
+        where: { email },
+        select: { id: true },
+      });
+      return user.id;
+    };
+
+    if (entityManager) {
+      return upsertThenSelect(entityManager);
+    }
+    return this.postgresDatabaseService.transaction(upsertThenSelect);
+  }
+
+  /**
    * Finds or creates an OIDC user identified by their external user ID.
    *
-   * If a user with the given `extUserId` already exists, their email is
-   * reconciled against `email`: a missing email is persisted, while a
-   * conflicting one is rejected. Otherwise a new user is created with the
-   * email stored at insert time.
+   * Resolution order:
+   *  1. existing user with this `extUserId` → reconcile email
+   *  2. PENDING placeholder created by a prior email invite → claim by
+   *     setting `extUserId` and flipping to ACTIVE
+   *  3. otherwise INSERT a fresh ACTIVE user with email at insert time
    *
    * @param extUserId - The external (OIDC provider) user identifier.
    * @param email - The verified email address to associate with the user.
-   * @returns The ID of the existing or newly created user.
+   * @returns The ID of the existing, claimed, or newly created user.
    * @throws {UnauthorizedException} If the email does not match the one
    * already registered for the account.
    * @throws {UserEmailAlreadyInUseError} If the email is already in use by
@@ -254,6 +291,11 @@ export class UsersRepository implements IUsersRepository {
     const existing = await this.findByExtUserId(extUserId);
     if (existing) {
       return this.reconcileEmail(existing, email);
+    }
+
+    const claimed = await this.claimPendingByEmail(extUserId, email);
+    if (claimed !== null) {
+      return claimed;
     }
 
     try {
@@ -282,6 +324,43 @@ export class UsersRepository implements IUsersRepository {
       }
       throw error;
     }
+  }
+
+  /**
+   * Atomically claims a PENDING email-invite placeholder for this OIDC
+   * caller. Returns the claimed user id, or null if no matching
+   * placeholder exists (caller should fall through to INSERT). Throws
+   * {@link UserEmailAlreadyInUseError} when a user with this email exists
+   * but isn't a claimable placeholder (already ACTIVE, or already linked
+   * to a different extUserId).
+   */
+  private async claimPendingByEmail(
+    extUserId: string,
+    email: EmailAddress,
+  ): Promise<User['id'] | null> {
+    const userRepository =
+      await this.postgresDatabaseService.getRepository(DbUser);
+    const candidate = await userRepository.findOne({
+      where: { email },
+      select: { id: true, status: true, extUserId: true },
+    });
+
+    if (!candidate) {
+      return null;
+    }
+
+    if (candidate.status !== 'PENDING' || candidate.extUserId !== null) {
+      throw new UserEmailAlreadyInUseError();
+    }
+
+    const result = await userRepository.update(
+      { id: candidate.id, status: 'PENDING', extUserId: IsNull() },
+      { extUserId, status: 'ACTIVE' },
+    );
+
+    // Lost a race to a concurrent claim; let the caller fall through to
+    // INSERT, where idx_users_email will surface UserEmailAlreadyInUseError.
+    return result.affected === 1 ? candidate.id : null;
   }
 
   private async findByExtUserId(

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -195,41 +195,51 @@ export class UsersRepository implements IUsersRepository {
     return wallet?.user;
   }
 
-  public async findOrCreateByWalletAddress(
+  public findOrCreateByWalletAddress(
     address: Address,
     status: keyof typeof UserStatus = 'ACTIVE',
+    entityManager?: EntityManager,
   ): Promise<User['id']> {
-    const existing = await this.findByWalletAddress(address);
-    if (existing) {
-      return existing.id;
-    }
-
-    try {
-      return await this.postgresDatabaseService.transaction(
-        async (entityManager: EntityManager) => {
-          const userId = await this.create(status, entityManager);
-
-          await this.walletsRepository.create(
-            { userId, walletAddress: address },
-            entityManager,
-          );
-
-          return userId;
-        },
-      );
-    } catch (error) {
-      // Handle race condition: a concurrent call may have created the
-      // wallet between our find and insert, causing a unique constraint
-      // violation. Retry the lookup in that case.
-      if (
-        error instanceof Error &&
-        error.message.includes('UQ_wallet_address')
-      ) {
-        const user = await this.findByWalletAddressOrFail(address);
-        return user.id;
+    const findOrCreate = async (
+      manager: EntityManager,
+    ): Promise<User['id']> => {
+      const existing = await manager.findOne(Wallet, {
+        where: { address },
+        relations: { user: true },
+      });
+      if (existing) {
+        return existing.user.id;
       }
-      throw error;
+
+      const userId = await this.create(status, manager);
+      const insert = await manager
+        .createQueryBuilder()
+        .insert()
+        .into(Wallet)
+        .values({ user: { id: userId }, address })
+        .orIgnore()
+        .execute();
+
+      if (insert.identifiers.length > 0) {
+        return userId;
+      }
+
+      await manager.delete(DbUser, userId);
+      const raced = await manager.findOne(Wallet, {
+        where: { address },
+        relations: { user: true },
+      });
+      if (!raced) {
+        throw new NotFoundException(`Wallet not found. Address=${address}`);
+      }
+      return raced.user.id;
+    };
+
+    if (entityManager) {
+      return findOrCreate(entityManager);
     }
+
+    return this.postgresDatabaseService.transaction(findOrCreate);
   }
 
   /**
@@ -289,6 +299,8 @@ export class UsersRepository implements IUsersRepository {
     extUserId: string,
     email: EmailAddress,
   ): Promise<User['id']> {
+    // This lookup/claim/insert sequence relies on unique indexes to settle
+    // races instead of SERIALIZABLE isolation; see the catches below.
     const existing = await this.findByExtUserId(extUserId);
     if (existing) {
       return this.reconcileEmail(existing, email);
@@ -414,8 +426,8 @@ export class UsersRepository implements IUsersRepository {
         .where('id = :userId', { userId })
         .andWhere('email IS NULL')
         .execute();
-      // If another request already backfilled the same email, the guarded
-      // update affects zero rows; that is idempotent for this reconcile path.
+      // Zero affected rows means another request backfilled this user after
+      // reconcileEmail saw email=null; that is idempotent for this path.
     } catch (error) {
       if (this.isUniqueConstraintViolation(error, 'idx_users_email')) {
         throw new UserEmailAlreadyInUseError();


### PR DESCRIPTION
Resolves: https://linear.app/safe-global/issue/WA-2327/add-email-invite-endpoint

Adds email as an invite identifier on the space invite endpoint, alongside the existing wallet identifier.

## Summary

- New `EmailInviteUserDto` and `WalletInviteUserDto` make the two invite shapes distinct at the API level; the request body is a discriminated array on `type`.
- Backward-compat preprocess defaults a missing `type` to `wallet` so existing wallet-only clients keep working during the wallet-1 migration.
- New `UsersRepository.findOrCreatePendingByEmail`: race-safe `INSERT … ON CONFLICT DO NOTHING` + `SELECT`, accepts an optional outer `EntityManager` so the placeholder lives inside the invite transaction.
- Per-item dispatch in `MembersRepository.inviteUsers`: wallet items keep the existing find-wallet-or-create-user-and-wallet path; email items resolve their user id via the new repo method.
- OIDC sign-in resolution gains a new step (`linkPendingInviteeByEmail`): when a PENDING placeholder matches the verified email of the signing-in user, claim it by setting `extUserId` and flipping the user's status to `ACTIVE`. Race-safe via `WHERE extUserId IS NULL` + affected check + re-read.

## Details

- **Two DTO types** with a discriminated union on `type` — chosen over a single permissive DTO so each item is unambiguously one shape at the API level, and to leave room for future invite identifier types without reshaping the endpoint.
- **Builds on #3101 (require verified email for OIDC sign-in)**. That PR's invariant — emails reaching the repo are verified — is what lets the new claim step here trust the email claim. Without that guard, OIDC sign-in with an unverified email could create a second `User` row alongside the placeholder, leaving them un-reconcilable without merge code; this PR avoids needing to write any such reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)