### PR TITLE
relay: replace RPC calls with safe-tx-service api call when validating safe-tx-hash

### DIFF
--- a/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
+++ b/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
@@ -415,6 +415,40 @@ describe('RelayTransactionHelper', () => {
         }),
       ).resolves.toBe(true);
     });
+
+    it('should match when stored data uses mixed-case hex but decoded data is lowercase', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hex;
+      // erc20 transfer payload — non-empty data so case can actually differ.
+      const recipient = getAddress(faker.finance.ethereumAddress());
+      const execData = execTransactionEncoder()
+        .with('data', erc20TransferEncoder().with('to', recipient).encode())
+        .encode();
+      const decoded = helper.decodeExecTransaction(execData)!;
+      // Tx service may return any hex casing; viem-decoded data is lowercase.
+      // Sanity-check the precondition is non-trivial.
+      expect(decoded.data).toBe(decoded.data.toLowerCase());
+      const stored = buildMatchingStored({
+        safeAddress,
+        decodedTo: decoded.to,
+      })
+        .with('data', decoded.data.toUpperCase().replace('0X', '0x') as Hex)
+        .build();
+      mockSafeRepository.getMultiSigTransaction.mockResolvedValue(stored);
+
+      await expect(
+        helper.isSafeTxHashValid({
+          chainId,
+          safeAddress,
+          decoded,
+          safeTxHash,
+        }),
+      ).resolves.toBe(true);
+    });
   });
 
   describe('decodeExecTransaction', () => {

--- a/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
+++ b/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
-import type { Hex, PublicClient } from 'viem';
-import { getAddress } from 'viem';
+import type { Hex } from 'viem';
+import { getAddress, zeroAddress } from 'viem';
 import { getDeploymentVersionsByChainIds } from '@/__tests__/deployments.helper';
 import configuration from '@/config/entities/configuration';
 import {
@@ -11,7 +11,6 @@ import {
   getSafeL2SingletonDeployments,
   getSafeSingletonDeployments,
 } from '@/domain/common/utils/deployments';
-import type { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
 import type { ILoggingService } from '@/logging/logging.interface';
 import {
   execTransactionFromModuleEncoder,
@@ -42,6 +41,7 @@ import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/p
 import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
 import { RelayTransactionHelper } from '@/modules/relay/domain/relay-transaction-helper';
+import { multisigTransactionBuilder } from '@/modules/safe/domain/entities/__tests__/multisig-transaction.builder';
 import type { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 
 const supportedChainIds = Object.keys(configuration().relay.apiKey);
@@ -74,12 +74,8 @@ const mockLoggingService = jest.mocked({
 const mockSafeRepository = jest.mocked({
   getSafe: jest.fn(),
   getSafesByModule: jest.fn(),
+  getMultiSigTransaction: jest.fn(),
 } as jest.MockedObjectDeep<ISafeRepository>);
-
-const mockBlockchainApiManager = jest.mocked({
-  getApi: jest.fn(),
-  destroyApi: jest.fn(),
-} as jest.MockedObjectDeep<IBlockchainApiManager>);
 
 describe('RelayTransactionHelper', () => {
   let helper: RelayTransactionHelper;
@@ -90,7 +86,6 @@ describe('RelayTransactionHelper', () => {
     helper = new RelayTransactionHelper(
       mockSafeRepository,
       mockLoggingService,
-      mockBlockchainApiManager,
       new Erc20Decoder(),
       new SafeDecoder(),
       new MultiSendDecoder(mockLoggingService),
@@ -243,18 +238,30 @@ describe('RelayTransactionHelper', () => {
   });
 
   describe('isSafeTxHashValid', () => {
-    function makePublicClientMock(args: {
-      nonce: bigint;
-      txHash: Hex;
-    }): jest.MockedObjectDeep<PublicClient> {
-      const readContract = jest
-        .fn()
-        .mockResolvedValueOnce(args.nonce)
-        .mockResolvedValueOnce(args.txHash);
-      return { readContract } as unknown as jest.MockedObjectDeep<PublicClient>;
+    // execTransactionEncoder() defaults: value=0n, data='0x', operation=0,
+    // safeTxGas=baseGas=gasPrice=0n, gasToken=refundReceiver=zeroAddress.
+    // We build a matching stored MultisigTransaction for happy-path tests, with
+    // the `to` field aligned to the decoded payload.
+    function buildMatchingStored(args: {
+      safeAddress: Hex;
+      decodedTo: Hex;
+    }): ReturnType<typeof multisigTransactionBuilder> extends infer B
+      ? B
+      : never {
+      return multisigTransactionBuilder()
+        .with('safe', getAddress(args.safeAddress))
+        .with('to', getAddress(args.decodedTo))
+        .with('value', '0')
+        .with('data', '0x')
+        .with('operation', 0)
+        .with('safeTxGas', 0)
+        .with('baseGas', 0)
+        .with('gasPrice', '0')
+        .with('gasToken', zeroAddress)
+        .with('refundReceiver', zeroAddress);
     }
 
-    it('should return true when on-chain hash matches the provided safeTxHash', async () => {
+    it('should return true when the tx-service stored fields match the decoded execTransaction', async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
       const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
@@ -265,13 +272,11 @@ describe('RelayTransactionHelper', () => {
       const decoded = helper.decodeExecTransaction(
         execTransactionEncoder().encode(),
       )!;
-      const mockPublicClient = makePublicClientMock({
-        nonce: BigInt(0),
-        txHash: safeTxHash,
-      });
-      mockBlockchainApiManager.getApi.mockResolvedValue(
-        mockPublicClient as unknown as PublicClient,
-      );
+      const stored = buildMatchingStored({
+        safeAddress,
+        decodedTo: decoded.to,
+      }).build();
+      mockSafeRepository.getMultiSigTransaction.mockResolvedValue(stored);
 
       await expect(
         helper.isSafeTxHashValid({
@@ -284,7 +289,7 @@ describe('RelayTransactionHelper', () => {
       ).resolves.toBe(true);
     });
 
-    it('should return false when on-chain hash differs from provided safeTxHash', async () => {
+    it('should return false when a stored field differs from the decoded execTransaction', async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
       const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
@@ -292,19 +297,47 @@ describe('RelayTransactionHelper', () => {
         length: 64,
         casing: 'lower',
       }) as Hex;
-      const differentHash = faker.string.hexadecimal({
+      const decoded = helper.decodeExecTransaction(
+        execTransactionEncoder().encode(),
+      )!;
+      const stored = buildMatchingStored({
+        safeAddress,
+        decodedTo: decoded.to,
+      })
+        .with('to', getAddress(faker.finance.ethereumAddress()))
+        .build();
+      mockSafeRepository.getMultiSigTransaction.mockResolvedValue(stored);
+
+      await expect(
+        helper.isSafeTxHashValid({
+          version,
+          chainId,
+          safeAddress,
+          decoded,
+          safeTxHash,
+        }),
+      ).resolves.toBe(false);
+
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('safeTxHash field mismatch'),
+        }),
+      );
+    });
+
+    it('should return false when the tx-service lookup fails', async () => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({
         length: 64,
         casing: 'lower',
       }) as Hex;
       const decoded = helper.decodeExecTransaction(
         execTransactionEncoder().encode(),
       )!;
-      const mockPublicClient = makePublicClientMock({
-        nonce: BigInt(0),
-        txHash: differentHash,
-      });
-      mockBlockchainApiManager.getApi.mockResolvedValue(
-        mockPublicClient as unknown as PublicClient,
+      mockSafeRepository.getMultiSigTransaction.mockRejectedValue(
+        new Error('Not found'),
       );
 
       await expect(
@@ -319,15 +352,16 @@ describe('RelayTransactionHelper', () => {
 
       expect(mockLoggingService.warn).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining('safeTxHash mismatch'),
+          message: expect.stringContaining('tx service lookup failed'),
         }),
       );
     });
 
-    it('should return false when the RPC call fails', async () => {
+    it("should return false when the stored tx's safe address differs from the requested safe", async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
       const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const otherSafe = getAddress(faker.finance.ethereumAddress());
       const safeTxHash = faker.string.hexadecimal({
         length: 64,
         casing: 'lower',
@@ -335,7 +369,11 @@ describe('RelayTransactionHelper', () => {
       const decoded = helper.decodeExecTransaction(
         execTransactionEncoder().encode(),
       )!;
-      mockBlockchainApiManager.getApi.mockRejectedValue(new Error('RPC error'));
+      const stored = buildMatchingStored({
+        safeAddress: otherSafe,
+        decodedTo: decoded.to,
+      }).build();
+      mockSafeRepository.getMultiSigTransaction.mockResolvedValue(stored);
 
       await expect(
         helper.isSafeTxHashValid({
@@ -347,11 +385,49 @@ describe('RelayTransactionHelper', () => {
         }),
       ).resolves.toBe(false);
 
-      expect(mockLoggingService.error).toHaveBeenCalledWith(
+      expect(mockLoggingService.warn).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining('RPC error verifying safeTxHash'),
+          message: expect.stringContaining('safe address mismatch'),
         }),
       );
+    });
+
+    it.each([
+      ['data', { field: 'data' as const, value: null }],
+      ['safeTxGas', { field: 'safeTxGas' as const, value: null }],
+      ['baseGas', { field: 'baseGas' as const, value: null }],
+      ['gasPrice', { field: 'gasPrice' as const, value: null }],
+      ['gasToken', { field: 'gasToken' as const, value: null }],
+      ['refundReceiver', { field: 'refundReceiver' as const, value: null }],
+    ])('should treat stored %s=null as equivalent to the decoded zero/empty default', async (_, override) => {
+      const chainId = faker.helpers.arrayElement(supportedChainIds);
+      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
+      const safeAddress = getAddress(faker.finance.ethereumAddress());
+      const safeTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hex;
+      const decoded = helper.decodeExecTransaction(
+        execTransactionEncoder().encode(),
+      )!;
+      const stored = buildMatchingStored({
+        safeAddress,
+        decodedTo: decoded.to,
+      })
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .with(override.field as any, override.value as any)
+        .build();
+      mockSafeRepository.getMultiSigTransaction.mockResolvedValue(stored);
+
+      await expect(
+        helper.isSafeTxHashValid({
+          version,
+          chainId,
+          safeAddress,
+          decoded,
+          safeTxHash,
+        }),
+      ).resolves.toBe(true);
     });
   });
 

--- a/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
+++ b/src/modules/relay/domain/__tests__/relay-transaction-helper.spec.ts
@@ -59,10 +59,6 @@ const MULTI_SEND_VERSIONS = getDeploymentVersionsByChainIds(
   'MultiSend',
   supportedChainIds,
 );
-const SAFE_VERSIONS = getDeploymentVersionsByChainIds(
-  'Safe',
-  supportedChainIds,
-);
 
 const mockLoggingService = jest.mocked({
   info: jest.fn(),
@@ -263,7 +259,6 @@ describe('RelayTransactionHelper', () => {
 
     it('should return true when the tx-service stored fields match the decoded execTransaction', async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const safeTxHash = faker.string.hexadecimal({
         length: 64,
@@ -280,7 +275,6 @@ describe('RelayTransactionHelper', () => {
 
       await expect(
         helper.isSafeTxHashValid({
-          version,
           chainId,
           safeAddress,
           decoded,
@@ -291,7 +285,6 @@ describe('RelayTransactionHelper', () => {
 
     it('should return false when a stored field differs from the decoded execTransaction', async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const safeTxHash = faker.string.hexadecimal({
         length: 64,
@@ -310,7 +303,6 @@ describe('RelayTransactionHelper', () => {
 
       await expect(
         helper.isSafeTxHashValid({
-          version,
           chainId,
           safeAddress,
           decoded,
@@ -327,7 +319,6 @@ describe('RelayTransactionHelper', () => {
 
     it('should return false when the tx-service lookup fails', async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const safeTxHash = faker.string.hexadecimal({
         length: 64,
@@ -342,7 +333,6 @@ describe('RelayTransactionHelper', () => {
 
       await expect(
         helper.isSafeTxHashValid({
-          version,
           chainId,
           safeAddress,
           decoded,
@@ -359,7 +349,6 @@ describe('RelayTransactionHelper', () => {
 
     it("should return false when the stored tx's safe address differs from the requested safe", async () => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const otherSafe = getAddress(faker.finance.ethereumAddress());
       const safeTxHash = faker.string.hexadecimal({
@@ -377,7 +366,6 @@ describe('RelayTransactionHelper', () => {
 
       await expect(
         helper.isSafeTxHashValid({
-          version,
           chainId,
           safeAddress,
           decoded,
@@ -401,7 +389,6 @@ describe('RelayTransactionHelper', () => {
       ['refundReceiver', { field: 'refundReceiver' as const, value: null }],
     ])('should treat stored %s=null as equivalent to the decoded zero/empty default', async (_, override) => {
       const chainId = faker.helpers.arrayElement(supportedChainIds);
-      const version = faker.helpers.arrayElement(SAFE_VERSIONS[chainId]);
       const safeAddress = getAddress(faker.finance.ethereumAddress());
       const safeTxHash = faker.string.hexadecimal({
         length: 64,
@@ -421,7 +408,6 @@ describe('RelayTransactionHelper', () => {
 
       await expect(
         helper.isSafeTxHashValid({
-          version,
           chainId,
           safeAddress,
           decoded,

--- a/src/modules/relay/domain/limit-addresses.mapper.spec.ts
+++ b/src/modules/relay/domain/limit-addresses.mapper.spec.ts
@@ -97,7 +97,6 @@ describe('LimitAddressesMapper', () => {
     const relayTransactionHelper = new RelayTransactionHelper(
       mockSafeRepository,
       mockLoggingService,
-      { getApi: jest.fn(), destroyApi: jest.fn() } as never,
       new Erc20Decoder(),
       new SafeDecoder(),
       new MultiSendDecoder(mockLoggingService),

--- a/src/modules/relay/domain/relay-transaction-helper.ts
+++ b/src/modules/relay/domain/relay-transaction-helper.ts
@@ -553,7 +553,7 @@ export class RelayTransactionHelper {
     if (BigInt(stored.value) !== decoded.value) {
       mismatches.push('value');
     }
-    if ((stored.data ?? '0x') !== decoded.data) {
+    if ((stored.data ?? '0x').toLowerCase() !== decoded.data.toLowerCase()) {
       mismatches.push('data');
     }
     if (Number(stored.operation) !== decoded.operation) {

--- a/src/modules/relay/domain/relay-transaction-helper.ts
+++ b/src/modules/relay/domain/relay-transaction-helper.ts
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
-import semverSatisfies from 'semver/functions/satisfies';
 import type { Address, Hex } from 'viem';
 import {
   encodeAbiParameters,
   getAddress,
   keccak256,
   parseAbiParameters,
+  zeroAddress,
 } from 'viem';
-import Safe130 from '@/abis/safe/v1.3.0/GnosisSafe.abi';
-import Safe141 from '@/abis/safe/v1.4.1/Safe.abi';
-import Safe150 from '@/abis/safe/v1.5.0/Safe.abi';
 import { LogType } from '@/domain/common/entities/log-type.entity';
 import {
   getMultiSendCallOnlyDeployments,
@@ -20,7 +17,6 @@ import {
   getSafeSingletonDeployments,
   getSignerFactoryDeployments,
 } from '@/domain/common/utils/deployments';
-import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manager.interface';
 import { ILoggingService, LoggingService } from '@/logging/logging.interface';
 import { DelayModifierDecoder } from '@/modules/alerts/domain/contracts/decoders/delay-modifier-decoder.helper';
 import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
@@ -29,10 +25,9 @@ import { Erc20Decoder } from '@/modules/relay/domain/contracts/decoders/erc-20-d
 import { ProxyFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/proxy-factory-decoder.helper';
 import { SignerFactoryDecoder } from '@/modules/relay/domain/contracts/decoders/signer-factory-decoder.helper';
 import { InvalidMultiSendError } from '@/modules/relay/domain/errors/invalid-multisend.error';
+import type { MultisigTransaction } from '@/modules/safe/domain/entities/multisig-transaction.entity';
 import { ISafeRepository } from '@/modules/safe/domain/safe.repository.interface';
 import type { SafeTransaction } from '@/modules/transactions/domain/entities/safe-transaction.entity';
-
-type SafeAbi = typeof Safe130 | typeof Safe141 | typeof Safe150;
 
 @Injectable()
 export class RelayTransactionHelper {
@@ -41,8 +36,6 @@ export class RelayTransactionHelper {
     private readonly safeRepository: ISafeRepository,
     @Inject(LoggingService)
     private readonly loggingService: ILoggingService,
-    @Inject(IBlockchainApiManager)
-    private readonly blockchainApiManager: IBlockchainApiManager,
     private readonly erc20Decoder: Erc20Decoder,
     private readonly safeDecoder: SafeDecoder,
     private readonly multiSendDecoder: MultiSendDecoder,
@@ -50,17 +43,6 @@ export class RelayTransactionHelper {
     private readonly delayModifierDecoder: DelayModifierDecoder,
     private readonly signerFactoryDecoder: SignerFactoryDecoder,
   ) {}
-
-  private getSafeAbi(version: string): SafeAbi {
-    if (semverSatisfies(version, '>=1.5.0')) return Safe150;
-    if (semverSatisfies(version, '>=1.4.1')) return Safe141;
-    if (semverSatisfies(version, '>=1.0.0')) return Safe130;
-    this.loggingService.warn({
-      type: LogType.TxRelayEligibility,
-      message: `getSafeAbi: unrecognised Safe version ${version}, falling back to 1.3.0 ABI`,
-    });
-    return Safe130;
-  }
 
   isValidExecTransactionCall(args: { to: Address; data: Hex }): boolean {
     const decoded = this.decodeExecTransaction(args.data);
@@ -483,6 +465,20 @@ export class RelayTransactionHelper {
     }
   }
 
+  /**
+   * Validates `safeTxHash` against the proposed transaction stored in the Safe Transaction Service.
+   *
+   * Looks up the transaction the service has stored under `safeTxHash`,
+   * asserts it belongs to `safeAddress`, and then performs a field-by-field
+   * equality check between the stored proposal and the `decoded`
+   * `execTransaction` calldata the relay is being asked to submit. Trusts the
+   * tx service to have computed its stored `safeTxHash` correctly at proposal
+   * time — see {@link checkSafeTx} for the comparison rules.
+   *
+   * @returns `true` when the proposal matches the relay payload; `false` on
+   * lookup failure, safe-address mismatch, or any field mismatch. Failures are
+   * logged with {@link LogType.TxRelayEligibility}.
+   */
   async isSafeTxHashValid(args: {
     version: string;
     chainId: string;
@@ -490,51 +486,102 @@ export class RelayTransactionHelper {
     decoded: SafeTransaction;
     safeTxHash: Hex;
   }): Promise<boolean> {
-    const { decoded } = args;
-    const abi = this.getSafeAbi(args.version);
-
+    let stored: MultisigTransaction;
     try {
-      const publicClient = await this.blockchainApiManager.getApi(args.chainId);
-
-      const nonce = await publicClient.readContract({
-        address: args.safeAddress,
-        abi,
-        functionName: 'nonce',
+      stored = await this.safeRepository.getMultiSigTransaction({
+        chainId: args.chainId,
+        safeTransactionHash: args.safeTxHash,
       });
-
-      const onChainHash = await publicClient.readContract({
-        address: args.safeAddress,
-        abi,
-        functionName: 'getTransactionHash',
-        args: [
-          decoded.to,
-          decoded.value,
-          decoded.data,
-          decoded.operation,
-          decoded.safeTxGas,
-          decoded.baseGas,
-          decoded.gasPrice,
-          decoded.gasToken,
-          decoded.refundReceiver,
-          nonce,
-        ],
-      });
-
-      if (onChainHash !== args.safeTxHash) {
-        this.loggingService.warn({
-          type: LogType.TxRelayEligibility,
-          message: `relay-fee safeTxHash mismatch for ${args.safeAddress} on chain ${args.chainId}`,
-        });
-        return false;
-      }
-
-      return true;
     } catch (error) {
-      this.loggingService.error({
+      this.loggingService.warn({
         type: LogType.TxRelayEligibility,
-        message: `relay-fee RPC error verifying safeTxHash for ${args.safeAddress} on chain ${args.chainId}: ${String(error)}`,
+        message: `relay-fee tx service lookup failed for ${args.safeAddress} on chain ${args.chainId} hash=${args.safeTxHash}: ${String(error)}`,
       });
       return false;
     }
+
+    if (getAddress(stored.safe) !== args.safeAddress) {
+      this.loggingService.warn({
+        type: LogType.TxRelayEligibility,
+        message: `relay-fee safe address mismatch for ${args.safeAddress} on chain ${args.chainId} hash=${args.safeTxHash}`,
+      });
+      return false;
+    }
+
+    const mismatches = this.checkSafeTx({
+      stored,
+      decoded: args.decoded,
+    });
+    if (mismatches.length > 0) {
+      this.loggingService.warn({
+        type: LogType.TxRelayEligibility,
+        message: `relay-fee safeTxHash field mismatch for ${args.safeAddress} on chain ${args.chainId} hash=${args.safeTxHash}: ${mismatches.join(',')}`,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Compares a tx-service-stored multisig transaction against the decoded
+   * relay-submitted `execTransaction` payload, returning the names of any
+   * fields that don't match.
+   *
+   * Coerces the two sides into a common form before comparison:
+   * - addresses are checksum-normalized via `getAddress`
+   * - numerics are widened to `bigint` (stored numbers/strings vs decoded `bigint`s)
+   * - nullable stored fields are treated as their zero/empty equivalents:
+   *   `data: null` → `'0x'`, `safeTxGas/baseGas: null` → `0n`,
+   *   `gasPrice: null` → `0n`, `gasToken/refundReceiver: null` → `zeroAddress`
+   *
+   * Does NOT compare `nonce` — it is implicitly committed to by the tx
+   * service's stored `safeTxHash` invariant. Does NOT compare `safe` — caller
+   * is expected to have already asserted that.
+   *
+   * @returns array of mismatched field names; empty when all fields match.
+   */
+  private checkSafeTx(args: {
+    stored: MultisigTransaction;
+    decoded: SafeTransaction;
+  }): Array<string> {
+    const { stored, decoded } = args;
+    const mismatches: Array<string> = [];
+
+    if (getAddress(stored.to) !== getAddress(decoded.to)) {
+      mismatches.push('to');
+    }
+    if (BigInt(stored.value) !== decoded.value) {
+      mismatches.push('value');
+    }
+    if ((stored.data ?? '0x') !== decoded.data) {
+      mismatches.push('data');
+    }
+    if (Number(stored.operation) !== decoded.operation) {
+      mismatches.push('operation');
+    }
+    if (BigInt(stored.safeTxGas ?? 0) !== decoded.safeTxGas) {
+      mismatches.push('safeTxGas');
+    }
+    if (BigInt(stored.baseGas ?? 0) !== decoded.baseGas) {
+      mismatches.push('baseGas');
+    }
+    if (BigInt(stored.gasPrice ?? '0') !== decoded.gasPrice) {
+      mismatches.push('gasPrice');
+    }
+    if (
+      getAddress(stored.gasToken ?? zeroAddress) !==
+      getAddress(decoded.gasToken)
+    ) {
+      mismatches.push('gasToken');
+    }
+    if (
+      getAddress(stored.refundReceiver ?? zeroAddress) !==
+      getAddress(decoded.refundReceiver)
+    ) {
+      mismatches.push('refundReceiver');
+    }
+
+    return mismatches;
   }
 }

--- a/src/modules/relay/domain/relay-transaction-helper.ts
+++ b/src/modules/relay/domain/relay-transaction-helper.ts
@@ -480,7 +480,6 @@ export class RelayTransactionHelper {
    * logged with {@link LogType.TxRelayEligibility}.
    */
   async isSafeTxHashValid(args: {
-    version: string;
     chainId: string;
     safeAddress: Address;
     decoded: SafeTransaction;

--- a/src/modules/relay/domain/relay.domain.module.ts
+++ b/src/modules/relay/domain/relay.domain.module.ts
@@ -2,7 +2,6 @@
 import { Module } from '@nestjs/common';
 import { FeeServiceApiModule } from '@/datasources/fee-service-api/fee-service-api.module';
 import { BalancesModule } from '@/modules/balances/balances.module';
-import { BlockchainModule } from '@/modules/blockchain/blockchain.module';
 import { RelayApiModule } from '@/modules/relay/datasources/relay-api.module';
 import { IRelayManager } from '@/modules/relay/domain/interfaces/relay-manager.interface';
 import { LimitAddressesMapper } from '@/modules/relay/domain/limit-addresses.mapper';
@@ -22,7 +21,6 @@ import { SafeRepositoryModule } from '@/modules/safe/domain/safe.repository.inte
     SafeRepositoryModule,
     BalancesModule,
     FeeServiceApiModule,
-    BlockchainModule,
   ],
   providers: [
     RelayTransactionHelper,

--- a/src/modules/relay/domain/relayers/__tests__/relay-fee.relayer.spec.ts
+++ b/src/modules/relay/domain/relayers/__tests__/relay-fee.relayer.spec.ts
@@ -194,7 +194,6 @@ describe('RelayFeeRelayer', () => {
       expect(result).toEqual({ taskId });
       expect(mockRelayTransactionHelper.isSafeTxHashValid).toHaveBeenCalledWith(
         {
-          version: '1.3.0',
           chainId: enabledChainId,
           safeAddress,
           decoded: fakeDecoded,

--- a/src/modules/relay/domain/relayers/relay-fee.relayer.ts
+++ b/src/modules/relay/domain/relayers/relay-fee.relayer.ts
@@ -115,7 +115,6 @@ export class RelayFeeRelayer implements IRelayer {
       // Verify the safeTxHash matches the decoded payload and that the fee
       // service permits relaying this specific transaction.
       await this.validateExecTransaction({
-        version,
         chainId,
         to,
         decoded,
@@ -161,20 +160,18 @@ export class RelayFeeRelayer implements IRelayer {
   }
 
   private async validateExecTransaction(args: {
-    version: string;
     chainId: string;
     to: Address;
     decoded: SafeTransaction;
     safeTxHash: Hex | undefined;
   }): Promise<void> {
-    const { version, chainId, to, decoded, safeTxHash } = args;
+    const { chainId, to, decoded, safeTxHash } = args;
 
     if (!safeTxHash) {
       throw new RelayTxDeniedError(undefined);
     }
 
     const isValid = await this.relayTransactionHelper.isSafeTxHashValid({
-      version,
       chainId,
       safeAddress: to,
       decoded,


### PR DESCRIPTION
- This change is required because CGW has no infura key setup which is causing RPC calls to fail and relay checks to fail.
- The new approach directly compares the decoded transaction payload to the stored proposal.
- Removed the dependency on `IBlockchainApiManager` and all related blockchain RPC calls from `RelayTransactionHelper`
- Added a new private method `checkSafeTx` to `RelayTransactionHelper`
- Changes in tests