### PR TITLE
fix(hooks): invalidate nested Safe tx cache on parent approveHash execution

### DIFF
--- a/src/modules/hooks/domain/helpers/event-cache.helper.module.ts
+++ b/src/modules/hooks/domain/helpers/event-cache.helper.module.ts
@@ -4,6 +4,8 @@ import { BalancesModule } from '@/modules/balances/balances.module';
 import { BlockchainModule } from '@/modules/blockchain/blockchain.module';
 import { ChainsModule } from '@/modules/chains/chains.module';
 import { CollectiblesModule } from '@/modules/collectibles/collectibles.module';
+import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
+import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import { DelegatesV2RepositoryModule } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
 import { EarnModule } from '@/modules/earn/earn.module';
 import { EventCacheHelper } from '@/modules/hooks/domain/helpers/event-cache.helper';
@@ -27,7 +29,7 @@ import { TransactionsModule } from '@/modules/transactions/transactions.module';
     StakingModule,
     TransactionsModule,
   ],
-  providers: [EventCacheHelper],
+  providers: [EventCacheHelper, SafeDecoder, MultiSendDecoder],
   exports: [EventCacheHelper],
 })
 export class EventCacheHelperModule {}

--- a/src/modules/hooks/domain/helpers/event-cache.helper.ts
+++ b/src/modules/hooks/domain/helpers/event-cache.helper.ts
@@ -333,11 +333,10 @@ export class EventCacheHelper {
       }),
     ];
 
-    // Nested Safe: if this executed tx approves a child Safe transaction
-    // (approveHash, optionally wrapped in multiSend), the tx-service only signals
-    // a change to the parent tx. Decode the calldata and also invalidate the
-    // referenced child transaction(s) and their Safe's queue, otherwise the child
-    // keeps serving stale state until its cache expires. See WA-2032.
+    // Nested Safe: cascade invalidation to children referenced by approveHash
+    // calls in the executed calldata. We invalidate regardless of event.failed
+    // (a failed approveHash didn't change child state, but re-fetching is cheap
+    // and always-correct). See WA-2032 and getApprovedNestedTransactions.
     for (const child of this.getApprovedNestedTransactions(event)) {
       promises.push(
         this.safeRepository.clearMultisigTransactions({
@@ -360,8 +359,8 @@ export class EventCacheHelper {
    *
    * In nested-Safe setups a parent Safe approves a child transaction by executing
    * `approveHash(childSafeTxHash)` on the child Safe contract, optionally batched
-   * inside a `multiSend`. The child Safe is the `to` of the `approveHash` call and
-   * the child `safeTxHash` is the decoded argument.
+   * inside one or more `multiSend` calls. The child Safe is the `to` of the
+   * `approveHash` call and the child `safeTxHash` is the decoded argument.
    *
    * @param event - the executed multisig transaction event
    * @returns child Safe address + safeTxHash pairs to invalidate (empty if none)
@@ -375,24 +374,29 @@ export class EventCacheHelper {
     if (!event.data) {
       return [];
     }
+    return this.collectApprovedHashes(event.data, event.to);
+  }
 
-    // Direct approveHash executed on the child Safe (event.to).
-    const approvedHash = this.decodeApprovedHash(event.data);
+  /**
+   * Recursively walks `data` (a call to `callee`) and collects every
+   * `approveHash` invocation, unwrapping `multiSend` batches of arbitrary depth.
+   * For each approveHash found, the child Safe is the immediate `callee` of that
+   * call (i.e. the inner call's `to` inside a multiSend, or the outer `to` at
+   * the top level).
+   */
+  private collectApprovedHashes(
+    data: Hex,
+    callee: Address,
+  ): Array<{ safeAddress: Address; safeTxHash: Hex }> {
+    const approvedHash = this.decodeApprovedHash(data);
     if (approvedHash) {
-      return [{ safeAddress: event.to, safeTxHash: approvedHash }];
+      return [{ safeAddress: callee, safeTxHash: approvedHash }];
     }
 
-    // approveHash wrapped in a multiSend batch: the child Safe is each inner
-    // call's `to`, so we cannot rely on event.to here.
-    if (this.multiSendDecoder.helpers.isMultiSend(event.data)) {
+    if (this.multiSendDecoder.helpers.isMultiSend(data)) {
       return this.multiSendDecoder
-        .mapMultiSendTransactions(event.data)
-        .flatMap((transaction) => {
-          const hash = this.decodeApprovedHash(transaction.data);
-          return hash
-            ? [{ safeAddress: transaction.to, safeTxHash: hash }]
-            : [];
-        });
+        .mapMultiSendTransactions(data)
+        .flatMap((inner) => this.collectApprovedHashes(inner.data, inner.to));
     }
 
     return [];
@@ -400,8 +404,12 @@ export class EventCacheHelper {
 
   /**
    * Returns the approved child `safeTxHash` if `data` is an `approveHash` call,
-   * otherwise null. Malformed calldata is treated as "not an approveHash" so it
-   * never breaks the surrounding cache invalidation.
+   * otherwise null.
+   *
+   * `isApproveHash` only matches the 4-byte selector, so the decode try/catch is
+   * the real trust boundary: any non-`approveHash` call that happens to share
+   * the selector (or truncated calldata) fails to decode and is treated as
+   * "not an approveHash", so cache invalidation never breaks on malformed input.
    */
   private decodeApprovedHash(data: Hex): Hex | null {
     if (!this.safeDecoder.helpers.isApproveHash(data)) {

--- a/src/modules/hooks/domain/helpers/event-cache.helper.ts
+++ b/src/modules/hooks/domain/helpers/event-cache.helper.ts
@@ -4,6 +4,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import type { MemoizedFunction } from 'lodash';
 import memoize from 'lodash/memoize';
+import type { Address, Hex } from 'viem';
 import { CacheRouter } from '@/datasources/cache/cache.router';
 import {
   CacheService,
@@ -18,6 +19,8 @@ import { IBalancesRepository } from '@/modules/balances/domain/balances.reposito
 import { IBlockchainRepository } from '@/modules/blockchain/domain/blockchain.repository.interface';
 import { IChainsRepository } from '@/modules/chains/domain/chains.repository.interface';
 import { ICollectiblesRepository } from '@/modules/collectibles/domain/collectibles.repository.interface';
+import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
+import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import { IDelegatesV2Repository } from '@/modules/delegate/domain/v2/delegates.v2.repository.interface';
 import { EarnRepository } from '@/modules/earn/domain/earn.repository';
 import type { Event } from '@/modules/hooks/routes/entities/event.entity';
@@ -66,6 +69,8 @@ export class EventCacheHelper {
     private readonly loggingService: ILoggingService,
     @Inject(CacheService)
     private readonly cacheService: ICacheService,
+    private readonly safeDecoder: SafeDecoder,
+    private readonly multiSendDecoder: MultiSendDecoder,
   ) {
     this.isSupportedChainMemo = memoize(
       this.chainsRepository.isSupportedChain.bind(this.chainsRepository),
@@ -293,7 +298,7 @@ export class EventCacheHelper {
     // - the transaction executed – clear multisig transaction
     // - the safe configuration - clear safe info
     // - the stakes of a safe
-    return [
+    const promises = [
       this.collectiblesRepository.clearCollectibles({
         chainId: event.chainId,
         safeAddress: event.address,
@@ -327,6 +332,87 @@ export class EventCacheHelper {
         safeAddress: event.address,
       }),
     ];
+
+    // Nested Safe: if this executed tx approves a child Safe transaction
+    // (approveHash, optionally wrapped in multiSend), the tx-service only signals
+    // a change to the parent tx. Decode the calldata and also invalidate the
+    // referenced child transaction(s) and their Safe's queue, otherwise the child
+    // keeps serving stale state until its cache expires. See WA-2032.
+    for (const child of this.getApprovedNestedTransactions(event)) {
+      promises.push(
+        this.safeRepository.clearMultisigTransactions({
+          chainId: event.chainId,
+          safeAddress: child.safeAddress,
+        }),
+        this.safeRepository.clearMultisigTransaction({
+          chainId: event.chainId,
+          safeTransactionHash: child.safeTxHash,
+        }),
+      );
+    }
+
+    return promises;
+  }
+
+  /**
+   * Extracts the nested (child) Safe transactions approved by an executed parent
+   * transaction.
+   *
+   * In nested-Safe setups a parent Safe approves a child transaction by executing
+   * `approveHash(childSafeTxHash)` on the child Safe contract, optionally batched
+   * inside a `multiSend`. The child Safe is the `to` of the `approveHash` call and
+   * the child `safeTxHash` is the decoded argument.
+   *
+   * @param event - the executed multisig transaction event
+   * @returns child Safe address + safeTxHash pairs to invalidate (empty if none)
+   */
+  private getApprovedNestedTransactions(
+    event: Extract<
+      Event,
+      { type: TransactionEventType.EXECUTED_MULTISIG_TRANSACTION }
+    >,
+  ): Array<{ safeAddress: Address; safeTxHash: Hex }> {
+    if (!event.data) {
+      return [];
+    }
+
+    // Direct approveHash executed on the child Safe (event.to).
+    const approvedHash = this.decodeApprovedHash(event.data);
+    if (approvedHash) {
+      return [{ safeAddress: event.to, safeTxHash: approvedHash }];
+    }
+
+    // approveHash wrapped in a multiSend batch: the child Safe is each inner
+    // call's `to`, so we cannot rely on event.to here.
+    if (this.multiSendDecoder.helpers.isMultiSend(event.data)) {
+      return this.multiSendDecoder
+        .mapMultiSendTransactions(event.data)
+        .flatMap((transaction) => {
+          const hash = this.decodeApprovedHash(transaction.data);
+          return hash
+            ? [{ safeAddress: transaction.to, safeTxHash: hash }]
+            : [];
+        });
+    }
+
+    return [];
+  }
+
+  /**
+   * Returns the approved child `safeTxHash` if `data` is an `approveHash` call,
+   * otherwise null. Malformed calldata is treated as "not an approveHash" so it
+   * never breaks the surrounding cache invalidation.
+   */
+  private decodeApprovedHash(data: Hex): Hex | null {
+    if (!this.safeDecoder.helpers.isApproveHash(data)) {
+      return null;
+    }
+    try {
+      const decoded = this.safeDecoder.decodeFunctionData({ data });
+      return decoded.functionName === 'approveHash' ? decoded.args[0] : null;
+    } catch {
+      return null;
+    }
   }
 
   private onTransactionEventNewConfirmation(

--- a/src/modules/hooks/domain/hooks.repository.spec.ts
+++ b/src/modules/hooks/domain/hooks.repository.spec.ts
@@ -8,6 +8,8 @@ import type { BlockchainRepository } from '@/modules/blockchain/domain/blockchai
 import type { ChainsRepository } from '@/modules/chains/domain/chains.repository';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
 import type { CollectiblesRepository } from '@/modules/collectibles/domain/collectibles.repository';
+import { MultiSendDecoder } from '@/modules/contracts/domain/decoders/multi-send-decoder.helper';
+import { SafeDecoder } from '@/modules/contracts/domain/decoders/safe-decoder.helper';
 import type { DelegatesV2Repository } from '@/modules/delegate/domain/v2/delegates.v2.repository';
 import type { EarnRepository } from '@/modules/earn/domain/earn.repository';
 import { EventCacheHelper } from '@/modules/hooks/domain/helpers/event-cache.helper';
@@ -119,6 +121,8 @@ describe('HooksRepository (Unit)', () => {
       mockTransactionsRepository,
       mockLoggingService,
       fakeCacheService,
+      new SafeDecoder(),
+      new MultiSendDecoder(mockLoggingService),
     );
     mockPushNotificationService.enqueueEvent.mockResolvedValue();
     hooksRepository = new HooksRepository(

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -453,6 +453,228 @@ describe('Hook Events for Cache', () => {
         cachedValue,
       );
     });
+
+    it('does not clear nested children for events with no data', async () => {
+      const chainId = faker.string.numeric();
+      const childTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      });
+      const childCacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${childTxHash}`,
+        faker.string.alpha(),
+      );
+      const cachedValue = faker.string.alpha();
+      await fakeCacheService.hSet(
+        childCacheDir,
+        cachedValue,
+        faker.number.int({ min: 1 }),
+      );
+      mockSupportedChain(chainId);
+
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: getAddress(faker.finance.ethereumAddress()),
+        chainId,
+        to: getAddress(faker.finance.ethereumAddress()),
+        safeTxHash: faker.string.hexadecimal({ length: 64 }),
+        txHash: faker.string.hexadecimal({ length: 64 }),
+        failed: 'false',
+        // data omitted — schema preprocesses null/undefined to undefined
+      };
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      await expect(fakeCacheService.hGet(childCacheDir)).resolves.toBe(
+        cachedValue,
+      );
+    });
+
+    it('clears only the approveHash children when multiSend mixes approveHash with other calls', async () => {
+      const chainId = faker.string.numeric();
+      const multiSendAddress = getAddress(faker.finance.ethereumAddress());
+      const approvedChildSafe = getAddress(faker.finance.ethereumAddress());
+      const approvedChildHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hash;
+      const unrelatedSafe = getAddress(faker.finance.ethereumAddress());
+
+      const approvedChildCacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${approvedChildHash}`,
+        faker.string.alpha(),
+      );
+      const unrelatedSafeQueueCacheDir = new CacheDir(
+        `${chainId}_multisig_transactions_${unrelatedSafe}`,
+        faker.string.alpha(),
+      );
+      const unrelatedCachedValue = faker.string.alpha();
+      await fakeCacheService.hSet(
+        approvedChildCacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      await fakeCacheService.hSet(
+        unrelatedSafeQueueCacheDir,
+        unrelatedCachedValue,
+        faker.number.int({ min: 1 }),
+      );
+      mockSupportedChain(chainId);
+
+      const multiSendData = multiSendTransactionsEncoder([
+        {
+          operation: 0,
+          to: approvedChildSafe,
+          value: BigInt(0),
+          data: encodeFunctionData({
+            abi: Safe130,
+            functionName: 'approveHash',
+            args: [approvedChildHash],
+          }),
+        },
+        {
+          // A non-approveHash inner call targeting unrelatedSafe: must NOT
+          // cause its queue cache to be cleared.
+          operation: 0,
+          to: unrelatedSafe,
+          value: BigInt(0),
+          data: '0xabcdef01' as Hex,
+        },
+      ]);
+
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: getAddress(faker.finance.ethereumAddress()),
+        chainId,
+        to: multiSendAddress,
+        safeTxHash: faker.string.hexadecimal({ length: 64 }),
+        txHash: faker.string.hexadecimal({ length: 64 }),
+        failed: 'false',
+        data: encodeFunctionData({
+          abi: [
+            {
+              inputs: [{ name: 'transactions', type: 'bytes' }],
+              name: 'multiSend',
+              outputs: [],
+              stateMutability: 'payable',
+              type: 'function',
+            },
+          ],
+          functionName: 'multiSend',
+          args: [multiSendData],
+        }),
+      };
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      await expect(
+        fakeCacheService.hGet(approvedChildCacheDir),
+      ).resolves.toBeNull();
+      await expect(
+        fakeCacheService.hGet(unrelatedSafeQueueCacheDir),
+      ).resolves.toBe(unrelatedCachedValue);
+    });
+
+    it('recurses into nested multiSend batches to find approveHash calls', async () => {
+      const chainId = faker.string.numeric();
+      const outerMultiSendAddress = getAddress(faker.finance.ethereumAddress());
+      const innerMultiSendAddress = getAddress(faker.finance.ethereumAddress());
+      const childSafe = getAddress(faker.finance.ethereumAddress());
+      const childTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hash;
+      const childTxCacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${childTxHash}`,
+        faker.string.alpha(),
+      );
+      const childQueueCacheDir = new CacheDir(
+        `${chainId}_multisig_transactions_${childSafe}`,
+        faker.string.alpha(),
+      );
+      await fakeCacheService.hSet(
+        childTxCacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      await fakeCacheService.hSet(
+        childQueueCacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      mockSupportedChain(chainId);
+
+      const multiSendAbi = [
+        {
+          inputs: [{ name: 'transactions', type: 'bytes' }],
+          name: 'multiSend',
+          outputs: [],
+          stateMutability: 'payable',
+          type: 'function',
+        },
+      ] as const;
+
+      const innerMultiSendData = encodeFunctionData({
+        abi: multiSendAbi,
+        functionName: 'multiSend',
+        args: [
+          multiSendTransactionsEncoder([
+            {
+              operation: 0,
+              to: childSafe,
+              value: BigInt(0),
+              data: encodeFunctionData({
+                abi: Safe130,
+                functionName: 'approveHash',
+                args: [childTxHash],
+              }),
+            },
+          ]),
+        ],
+      });
+
+      const outerData = encodeFunctionData({
+        abi: multiSendAbi,
+        functionName: 'multiSend',
+        args: [
+          multiSendTransactionsEncoder([
+            {
+              operation: 0,
+              to: innerMultiSendAddress,
+              value: BigInt(0),
+              data: innerMultiSendData,
+            },
+          ]),
+        ],
+      });
+
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: getAddress(faker.finance.ethereumAddress()),
+        chainId,
+        to: outerMultiSendAddress,
+        safeTxHash: faker.string.hexadecimal({ length: 64 }),
+        txHash: faker.string.hexadecimal({ length: 64 }),
+        failed: 'false',
+        data: outerData,
+      };
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      await expect(fakeCacheService.hGet(childTxCacheDir)).resolves.toBeNull();
+      await expect(
+        fakeCacheService.hGet(childQueueCacheDir),
+      ).resolves.toBeNull();
+    });
   });
 
   it.each([

--- a/src/modules/hooks/routes/hooks-cache.integration.spec.ts
+++ b/src/modules/hooks/routes/hooks-cache.integration.spec.ts
@@ -3,8 +3,9 @@ import type { Server } from 'node:net';
 import { faker } from '@faker-js/faker';
 import type { INestApplication } from '@nestjs/common';
 import type { ConsumeMessage } from 'amqplib';
-import { getAddress } from 'viem';
+import { encodeFunctionData, getAddress, type Hash, type Hex } from 'viem';
 import { createTestModule } from '@/__tests__/testing-module';
+import Safe130 from '@/abis/safe/v1.3.0/GnosisSafe.abi';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import configuration from '@/config/entities/__tests__/configuration';
 import type { FakeCacheService } from '@/datasources/cache/__tests__/fake.cache.service';
@@ -17,6 +18,7 @@ import { IBlockchainApiManager } from '@/domain/interfaces/blockchain-api.manage
 import { IStakingApiManager } from '@/domain/interfaces/staking-api.manager.interface';
 import { ITransactionApiManager } from '@/domain/interfaces/transaction-api.manager.interface';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { multiSendTransactionsEncoder } from '@/modules/contracts/domain/__tests__/encoders/multi-send-encoder.builder';
 import {
   deletedDelegateEventBuilder,
   newDelegateEventBuilder,
@@ -255,6 +257,202 @@ describe('Hook Events for Cache', () => {
     await cb({ content: Buffer.from(JSON.stringify(data)) } as ConsumeMessage);
 
     await expect(fakeCacheService.hGet(cacheDir)).resolves.toBeNull();
+  });
+
+  describe('nested Safe approveHash invalidation', () => {
+    const approveHashData = (hashToApprove: Hash): Hex =>
+      encodeFunctionData({
+        abi: Safe130,
+        functionName: 'approveHash',
+        args: [hashToApprove],
+      });
+
+    const mockSupportedChain = (chainId: string): void => {
+      networkService.get.mockImplementation(({ url }) => {
+        if (url === `${safeConfigUrl}/api/v1/chains/${chainId}`) {
+          return Promise.resolve({
+            data: rawify(chainBuilder().with('chainId', chainId).build()),
+            status: 200,
+          });
+        }
+        return Promise.reject(new Error(`Could not match ${url}`));
+      });
+    };
+
+    it('EXECUTED_MULTISIG_TRANSACTION with approveHash clears the nested (child) Safe tx and queue', async () => {
+      const chainId = faker.string.numeric();
+      const parentSafe = getAddress(faker.finance.ethereumAddress());
+      const childSafe = getAddress(faker.finance.ethereumAddress());
+      const childTxHash = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hash;
+      const childTxCacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${childTxHash}`,
+        faker.string.alpha(),
+      );
+      const childQueueCacheDir = new CacheDir(
+        `${chainId}_multisig_transactions_${childSafe}`,
+        faker.string.alpha(),
+      );
+      await fakeCacheService.hSet(
+        childTxCacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      await fakeCacheService.hSet(
+        childQueueCacheDir,
+        faker.string.alpha(),
+        faker.number.int({ min: 1 }),
+      );
+      mockSupportedChain(chainId);
+
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: parentSafe,
+        chainId,
+        to: childSafe, // approveHash is executed on the child Safe
+        safeTxHash: faker.string.hexadecimal({ length: 64 }),
+        txHash: faker.string.hexadecimal({ length: 64 }),
+        failed: 'false',
+        data: approveHashData(childTxHash),
+      };
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      await expect(fakeCacheService.hGet(childTxCacheDir)).resolves.toBeNull();
+      await expect(
+        fakeCacheService.hGet(childQueueCacheDir),
+      ).resolves.toBeNull();
+    });
+
+    it('clears nested Safe txs for approveHash calls wrapped in a multiSend', async () => {
+      const chainId = faker.string.numeric();
+      const parentSafe = getAddress(faker.finance.ethereumAddress());
+      const multiSendAddress = getAddress(faker.finance.ethereumAddress());
+      const childSafeA = getAddress(faker.finance.ethereumAddress());
+      const childSafeB = getAddress(faker.finance.ethereumAddress());
+      const childTxHashA = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hash;
+      const childTxHashB = faker.string.hexadecimal({
+        length: 64,
+        casing: 'lower',
+      }) as Hash;
+      const childCacheDirs = [
+        new CacheDir(
+          `${chainId}_multisig_transaction_${childTxHashA}`,
+          faker.string.alpha(),
+        ),
+        new CacheDir(
+          `${chainId}_multisig_transactions_${childSafeA}`,
+          faker.string.alpha(),
+        ),
+        new CacheDir(
+          `${chainId}_multisig_transaction_${childTxHashB}`,
+          faker.string.alpha(),
+        ),
+        new CacheDir(
+          `${chainId}_multisig_transactions_${childSafeB}`,
+          faker.string.alpha(),
+        ),
+      ];
+      for (const cacheDir of childCacheDirs) {
+        await fakeCacheService.hSet(
+          cacheDir,
+          faker.string.alpha(),
+          faker.number.int({ min: 1 }),
+        );
+      }
+      mockSupportedChain(chainId);
+
+      const multiSendData = multiSendTransactionsEncoder([
+        {
+          operation: 0,
+          to: childSafeA,
+          value: BigInt(0),
+          data: approveHashData(childTxHashA),
+        },
+        {
+          operation: 0,
+          to: childSafeB,
+          value: BigInt(0),
+          data: approveHashData(childTxHashB),
+        },
+      ]);
+
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: parentSafe,
+        chainId,
+        to: multiSendAddress,
+        safeTxHash: faker.string.hexadecimal({ length: 64 }),
+        txHash: faker.string.hexadecimal({ length: 64 }),
+        failed: 'false',
+        data: encodeFunctionData({
+          abi: [
+            {
+              inputs: [{ name: 'transactions', type: 'bytes' }],
+              name: 'multiSend',
+              outputs: [],
+              stateMutability: 'payable',
+              type: 'function',
+            },
+          ],
+          functionName: 'multiSend',
+          args: [multiSendData],
+        }),
+      };
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      for (const cacheDir of childCacheDirs) {
+        await expect(fakeCacheService.hGet(cacheDir)).resolves.toBeNull();
+      }
+    });
+
+    it('does not clear unrelated transactions for non-approveHash executed txs', async () => {
+      const chainId = faker.string.numeric();
+      const unrelatedTxHash = faker.string.hexadecimal({ length: 64 });
+      const unrelatedCacheDir = new CacheDir(
+        `${chainId}_multisig_transaction_${unrelatedTxHash}`,
+        faker.string.alpha(),
+      );
+      const cachedValue = faker.string.alpha();
+      await fakeCacheService.hSet(
+        unrelatedCacheDir,
+        cachedValue,
+        faker.number.int({ min: 1 }),
+      );
+      mockSupportedChain(chainId);
+
+      const data = {
+        type: 'EXECUTED_MULTISIG_TRANSACTION',
+        address: getAddress(faker.finance.ethereumAddress()),
+        chainId,
+        to: getAddress(faker.finance.ethereumAddress()),
+        safeTxHash: faker.string.hexadecimal({ length: 64 }),
+        txHash: faker.string.hexadecimal({ length: 64 }),
+        failed: 'false',
+        data: '0xaaaaaaaa', // not approveHash, not multiSend
+      };
+
+      const cb = getSubscriptionCallback(queuesApiService);
+      await cb({
+        content: Buffer.from(JSON.stringify(data)),
+      } as ConsumeMessage);
+
+      await expect(fakeCacheService.hGet(unrelatedCacheDir)).resolves.toBe(
+        cachedValue,
+      );
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Summary

Resolves [WA-2032](https://linear.app/safe-global/issue/WA-2032). In nested-Safe setups a child transaction is confirmed/executed when a parent Safe executes `approveHash(childSafeTxHash)` on the child Safe. The tx-service emits `EXECUTED_MULTISIG_TRANSACTION` for the parent's `approveHash` tx, but CGW only invalidated the parent caches — leaving the child tx and the child Safe's queue stale until TTL (the "tx disappears / wrong state after signing" bug, reproduced on production).

## Changes

- Decode the executed tx's calldata with `SafeDecoder`; when it's an `approveHash` (directly or wrapped in a `multiSend`), also clear the child tx (`clearMultisigTransaction`) and the child Safe's list (`clearMultisigTransactions`). Child Safe = the `approveHash` call's `to`.
- Wire `SafeDecoder` + `MultiSendDecoder` into `EventCacheHelperModule`.
- Integration tests for direct `approveHash`, `multiSend`-wrapped `approveHash`, and a non-`approveHash` no-op.