### PR TITLE
fix(spaces): relax invite name validation to max 255 chars

### DIFF
--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -152,38 +152,32 @@ describe('InviteUsersDtoSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('should reject a name exceeding 30 characters', () => {
+  it('should accept a name of up to 255 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [
-        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(31) },
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(255) },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject a name exceeding 255 characters', () => {
+    const result = InviteUsersDtoSchema.safeParse({
+      users: [
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(256) },
       ],
     });
 
     expect(result.success).toBe(false);
   });
 
-  it('should reject a name shorter than 3 characters', () => {
-    const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteUserDtoBuilder().build(), name: 'ab' }],
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it('should reject a whitespace-only name', () => {
-    const result = InviteUsersDtoSchema.safeParse({
-      users: [{ ...walletInviteUserDtoBuilder().build(), name: '   ' }],
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it('should reject a name with invalid characters', () => {
+  it('should accept a name with special characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [{ ...walletInviteUserDtoBuilder().build(), name: '<>@!' }],
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it('should reject an invalid role value', () => {

--- a/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
@@ -1,21 +1,12 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
-import {
-  makeNameSchema,
-  NAME_MAX_LENGTH,
-  NAME_MIN_LENGTH,
-} from '@/domain/common/schemas/name.schema';
 
 export const AcceptInviteDtoSchema = z.object({
-  name: makeNameSchema(),
+  name: z.string().max(255),
 });
 
 export class AcceptInviteDto implements z.infer<typeof AcceptInviteDtoSchema> {
-  @ApiProperty({
-    type: String,
-    minLength: NAME_MIN_LENGTH,
-    maxLength: NAME_MAX_LENGTH,
-  })
+  @ApiProperty({ type: String, maxLength: 255 })
   public readonly name!: string;
 }

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -2,11 +2,6 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
-import {
-  makeNameSchema,
-  NAME_MAX_LENGTH,
-  NAME_MIN_LENGTH,
-} from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { MemberRole } from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -22,7 +17,7 @@ export const InviteType = {
 
 const SharedInviteFields = {
   role: z.enum(getStringEnumKeys(MemberRole)),
-  name: makeNameSchema(),
+  name: z.string().max(255),
 };
 
 const WalletInviteUserSchema = z
@@ -71,11 +66,7 @@ class WalletInviteUserDto implements z.infer<typeof WalletInviteUserSchema> {
   @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
   public readonly role!: keyof typeof MemberRole;
 
-  @ApiProperty({
-    type: String,
-    minLength: NAME_MIN_LENGTH,
-    maxLength: NAME_MAX_LENGTH,
-  })
+  @ApiProperty({ type: String, maxLength: 255 })
   public readonly name!: string;
 }
 
@@ -89,11 +80,7 @@ class EmailInviteUserDto implements z.infer<typeof EmailInviteUserSchema> {
   @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
   public readonly role!: keyof typeof MemberRole;
 
-  @ApiProperty({
-    type: String,
-    minLength: NAME_MIN_LENGTH,
-    maxLength: NAME_MAX_LENGTH,
-  })
+  @ApiProperty({ type: String, maxLength: 255 })
   public readonly name!: string;
 }
 


### PR DESCRIPTION
## Summary

- #3104 switched invite `name` validation from `z.string().max(255)` to `NameSchema` (min 3 / max 30 chars, restricted charset), which rejects invite names that were previously accepted — a regression for existing clients.
- Restores the original `z.string().max(255)` validation in `InviteUsersDtoSchema` and `AcceptInviteDtoSchema`, and updates the Swagger `@ApiProperty` metadata to match (`maxLength: 255`, no `minLength`).
- Adapts the DTO schema tests: strict-name rejection tests replaced with tests pinning the relaxed behavior (accepts 255 chars and special characters, rejects > 255).

## Related

- #3104