### PR TITLE
refactor: rename `spaces` to `workspaces` in error messages

### DIFF
--- a/src/modules/spaces/domain/address-books/address-book-items.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/address-books/address-book-items.repository.integration.spec.ts
@@ -227,7 +227,7 @@ describe('AddressBookItemsRepository', () => {
           authPayload,
           spaceId: faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }),
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should throw a NotFoundException if the user is not a member', async () => {
@@ -238,7 +238,7 @@ describe('AddressBookItemsRepository', () => {
           authPayload,
           spaceId,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should throw a NotFoundException if the user declined the membership', async () => {
@@ -249,7 +249,7 @@ describe('AddressBookItemsRepository', () => {
           authPayload,
           spaceId,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should throw a NotFoundException if the user invitation has expired', async () => {
@@ -264,7 +264,7 @@ describe('AddressBookItemsRepository', () => {
           authPayload,
           spaceId,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
   });
 
@@ -368,7 +368,7 @@ describe('AddressBookItemsRepository', () => {
         }),
       ).rejects.toThrow(
         new BadRequestException(
-          `This Space only allows a maximum of ${limit} Address Book Items. You can only add up to 1 more.`,
+          `This Workspace only allows a maximum of ${limit} Address Book Items. You can only add up to 1 more.`,
         ),
       );
     });
@@ -384,7 +384,7 @@ describe('AddressBookItemsRepository', () => {
           spaceId: faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }),
           addressBookItems,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should throw NotFoundException if the user is not an admin', async () => {
@@ -399,7 +399,7 @@ describe('AddressBookItemsRepository', () => {
           spaceId,
           addressBookItems,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should upsert items for an OIDC admin', async () => {
@@ -535,7 +535,7 @@ describe('AddressBookItemsRepository', () => {
           spaceId: faker.number.int({ min: 1, max: DB_MAX_SAFE_INTEGER }),
           address: addressBookItem.address,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should throw NotFoundException if the user is not an ADMIN', async () => {
@@ -549,7 +549,7 @@ describe('AddressBookItemsRepository', () => {
           spaceId,
           address: addressBookItem.address,
         }),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it('should delete an address book item as an OIDC admin', async () => {
@@ -603,7 +603,7 @@ describe('AddressBookItemsRepository', () => {
   ): Promise<AuthPayload> => {
     const { user, authPayload } = await createUser();
     const space = await dbSpacesRepository.findOneBy({ id: spaceId });
-    if (!space) throw new NotFoundException('Space not found.');
+    if (!space) throw new NotFoundException('Workspace not found.');
     await dbMembersRepository.insert({
       user,
       space,
@@ -622,7 +622,7 @@ describe('AddressBookItemsRepository', () => {
   ): Promise<AuthPayload> => {
     const { user, authPayload } = await createUser();
     const space = await dbSpacesRepository.findOneBy({ id: spaceId });
-    if (!space) throw new NotFoundException('Space not found.');
+    if (!space) throw new NotFoundException('Workspace not found.');
     await dbMembersRepository.insert({
       user,
       space,

--- a/src/modules/spaces/domain/address-books/address-book-items.repository.ts
+++ b/src/modules/spaces/domain/address-books/address-book-items.repository.ts
@@ -181,7 +181,7 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
       existingAddressBookItems + args.addressBookItems.length;
     if (totalAddressBookItemsCount > this.maxItems) {
       throw new BadRequestException(
-        `This Space only allows a maximum of ${this.maxItems} Address Book Items. You can only add up to ${this.maxItems - existingAddressBookItems} more.`,
+        `This Workspace only allows a maximum of ${this.maxItems} Address Book Items. You can only add up to ${this.maxItems - existingAddressBookItems} more.`,
       );
     }
   }

--- a/src/modules/spaces/domain/address-books/user-address-book-items.repository.ts
+++ b/src/modules/spaces/domain/address-books/user-address-book-items.repository.ts
@@ -155,7 +155,7 @@ export class UserAddressBookItemsRepository
     });
     if (existingCount + args.newItemsCount > this.maxItems) {
       throw new BadRequestException(
-        `This Space only allows a maximum of ${this.maxItems} private contacts per user. You can only add up to ${this.maxItems - existingCount} more.`,
+        `This Workspace only allows a maximum of ${this.maxItems} private contacts per user. You can only add up to ${this.maxItems - existingCount} more.`,
       );
     }
   }

--- a/src/modules/spaces/domain/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/space-safes.repository.integration.spec.ts
@@ -422,7 +422,7 @@ describe('SpaceSafesRepository', () => {
         }),
       ).rejects.toThrow(
         new BadRequestException(
-          `This Space only allows a maximum of ${maxSafesPerSpace} Safe Accounts. You can only add up to 1 more.`,
+          `This Workspace only allows a maximum of ${maxSafesPerSpace} Safe Accounts. You can only add up to 1 more.`,
         ),
       );
 
@@ -571,7 +571,7 @@ describe('SpaceSafesRepository', () => {
         spaceSafesRepo.findOrFail({
           where: { space: { id: spaceId } },
         }),
-      ).rejects.toThrow(new NotFoundException('Space has no Safes.'));
+      ).rejects.toThrow(new NotFoundException('Workspace has no Safes.'));
     });
   });
 
@@ -659,7 +659,7 @@ describe('SpaceSafesRepository', () => {
         spaceSafesRepo.findOrFail({
           where: { space: { id: spaceId } },
         }),
-      ).rejects.toThrow(new NotFoundException('Space has no Safes.'));
+      ).rejects.toThrow(new NotFoundException('Workspace has no Safes.'));
     });
 
     it('should delete multiple SpaceSafes', async () => {
@@ -691,7 +691,7 @@ describe('SpaceSafesRepository', () => {
         spaceSafesRepo.findOrFail({
           where: { space: { id: spaceId } },
         }),
-      ).rejects.toThrow(new NotFoundException('Space has no Safes.'));
+      ).rejects.toThrow(new NotFoundException('Workspace has no Safes.'));
     });
 
     it('should throw NotFoundException if provided SpaceSafe is not found', async () => {
@@ -719,7 +719,7 @@ describe('SpaceSafesRepository', () => {
             },
           ],
         }),
-      ).rejects.toThrow(new NotFoundException('Space has no Safes.'));
+      ).rejects.toThrow(new NotFoundException('Workspace has no Safes.'));
     });
 
     it('should throw NotFoundException if none of the provided SpaceSafes is found', async () => {
@@ -754,7 +754,7 @@ describe('SpaceSafesRepository', () => {
             },
           ],
         }),
-      ).rejects.toThrow(new NotFoundException('Space has no Safes.'));
+      ).rejects.toThrow(new NotFoundException('Workspace has no Safes.'));
     });
 
     it('should delete found SpaceSafes and ignore not found', async () => {

--- a/src/modules/spaces/domain/space-safes.repository.ts
+++ b/src/modules/spaces/domain/space-safes.repository.ts
@@ -46,7 +46,7 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
     const existingSafes = await this.findBySpaceId(args.spaceId);
     if (existingSafes.length + safesToInsert.length > this.maxSafesPerSpace) {
       throw new BadRequestException(
-        `This Space only allows a maximum of ${this.maxSafesPerSpace} Safe Accounts. You can only add up to ${this.maxSafesPerSpace - existingSafes.length} more.`,
+        `This Workspace only allows a maximum of ${this.maxSafesPerSpace} Safe Accounts. You can only add up to ${this.maxSafesPerSpace - existingSafes.length} more.`,
       );
     }
 
@@ -80,7 +80,7 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
     const spaceSafes = await this.find(args);
 
     if (spaceSafes.length === 0) {
-      throw new NotFoundException('Space has no Safes.');
+      throw new NotFoundException('Workspace has no Safes.');
     }
 
     return spaceSafes;

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -465,7 +465,7 @@ describe('SpacesRepository', () => {
 
       await expect(
         spacesRepository.findOneOrFail({ where: { id: spaceId } }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
   });
 
@@ -559,7 +559,7 @@ describe('SpacesRepository', () => {
 
       await expect(
         spacesRepository.findOrFail({ where: { id: spaceId } }),
-      ).rejects.toThrow('Spaces not found.');
+      ).rejects.toThrow('Workspaces not found.');
     });
   });
 
@@ -657,7 +657,7 @@ describe('SpacesRepository', () => {
 
       await expect(
         spacesRepository.findOneByUserIdOrFail({ userId }),
-      ).rejects.toThrow(`Space not found. UserId = ${userId}`);
+      ).rejects.toThrow(`Workspace not found. UserId = ${userId}`);
     });
   });
 

--- a/src/modules/spaces/domain/spaces.repository.ts
+++ b/src/modules/spaces/domain/spaces.repository.ts
@@ -55,7 +55,7 @@ export class SpacesRepository implements ISpacesRepository {
     const isLimited = await this.isLimited(args.userId);
     if (isLimited) {
       throw new ForbiddenException(
-        'User has reached the maximum number of Spaces.',
+        'User has reached the maximum number of Workspaces.',
       );
     }
 
@@ -90,7 +90,7 @@ export class SpacesRepository implements ISpacesRepository {
     const space = await this.findOne(args);
 
     if (!space) {
-      throw new NotFoundException('Space not found.');
+      throw new NotFoundException('Workspace not found.');
     }
 
     return space;
@@ -113,7 +113,7 @@ export class SpacesRepository implements ISpacesRepository {
     const spaces = await this.find(args);
 
     if (spaces.length === 0) {
-      throw new NotFoundException('Spaces not found.');
+      throw new NotFoundException('Workspaces not found.');
     }
 
     return spaces;
@@ -136,7 +136,9 @@ export class SpacesRepository implements ISpacesRepository {
     const spaces = await this.findByUserId(args);
 
     if (spaces.length === 0) {
-      throw new NotFoundException(`Spaces not found. UserId = ${args.userId}`);
+      throw new NotFoundException(
+        `Workspaces not found. UserId = ${args.userId}`,
+      );
     }
 
     return spaces;
@@ -174,7 +176,9 @@ export class SpacesRepository implements ISpacesRepository {
     const space = await this.findOneByUserId(args);
 
     if (!space) {
-      throw new NotFoundException(`Space not found. UserId = ${args.userId}`);
+      throw new NotFoundException(
+        `Workspace not found. UserId = ${args.userId}`,
+      );
     }
 
     return space;

--- a/src/modules/spaces/routes/address-books.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/address-books.controller.e2e-spec.ts
@@ -199,7 +199,7 @@ describe('AddressBooksController', () => {
         .expect(404)
         .expect({
           statusCode: 404,
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
         });
     });
@@ -213,7 +213,7 @@ describe('AddressBooksController', () => {
         .expect(404)
         .expect({
           statusCode: 404,
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
         });
     });
@@ -519,7 +519,7 @@ describe('AddressBooksController', () => {
         .expect(400)
         .expect({
           message:
-            'This Space only allows a maximum of 1 Address Book Items. You can only add up to 0 more.',
+            'This Workspace only allows a maximum of 1 Address Book Items. You can only add up to 0 more.',
           error: 'Bad Request',
           statusCode: 400,
         });
@@ -551,7 +551,7 @@ describe('AddressBooksController', () => {
         .expect(400)
         .expect({
           message:
-            'This Space only allows a maximum of 1 Address Book Items. You can only add up to 1 more.',
+            'This Workspace only allows a maximum of 1 Address Book Items. You can only add up to 1 more.',
           error: 'Bad Request',
           statusCode: 400,
         });
@@ -703,7 +703,7 @@ describe('AddressBooksController', () => {
         .expect(404)
         .expect({
           statusCode: 404,
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
         });
     });
@@ -739,7 +739,7 @@ describe('AddressBooksController', () => {
         .expect(404)
         .expect({
           statusCode: 404,
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
         });
     });

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -319,7 +319,7 @@ describe('MembersController', () => {
         })
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -589,7 +589,7 @@ describe('MembersController', () => {
         })
         .expect(409)
         .expect({
-          message: `${memberAddress} is already in this space or has a pending invite.`,
+          message: `${memberAddress} is already in this workspace or has a pending invite.`,
           error: 'Conflict',
           statusCode: 409,
         });
@@ -788,7 +788,7 @@ describe('MembersController', () => {
         })
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -842,7 +842,7 @@ describe('MembersController', () => {
         })
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -899,7 +899,7 @@ describe('MembersController', () => {
         })
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -1088,7 +1088,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -1139,7 +1139,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${nonMemberAuthPayload}`])
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -1190,7 +1190,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${inviteeAccessToken}`])
         .expect(404)
         .expect({
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
           statusCode: 404,
         });
@@ -1499,7 +1499,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(401)
         .expect({
-          message: 'The user is not an active member of the space.',
+          message: 'The user is not an active member of the workspace.',
           error: 'Unauthorized',
           statusCode: 401,
         });

--- a/src/modules/spaces/routes/spaces.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/spaces.controller.e2e-spec.ts
@@ -191,7 +191,7 @@ describe('SpacesController', () => {
         .send({ name: nameBuilder() })
         .expect(403)
         .expect({
-          message: 'User has reached the maximum number of Spaces.',
+          message: 'User has reached the maximum number of Workspaces.',
           error: 'Forbidden',
           statusCode: 403,
         });
@@ -616,7 +616,7 @@ describe('SpacesController', () => {
         .expect(404)
         .expect({
           statusCode: 404,
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
         });
     });
@@ -637,7 +637,7 @@ describe('SpacesController', () => {
         .expect(404)
         .expect({
           statusCode: 404,
-          message: 'Space not found.',
+          message: 'Workspace not found.',
           error: 'Not Found',
         });
     });

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -536,7 +536,7 @@ describe('SpacesService', () => {
 
       await expect(
         service.getActiveOrInvitedSpace(999999, authPayload),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it.each([
@@ -549,7 +549,7 @@ describe('SpacesService', () => {
 
       await expect(
         service.getActiveOrInvitedSpace(1, authPayload),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
     });
 
     it.each([
@@ -565,7 +565,7 @@ describe('SpacesService', () => {
 
       await expect(
         service.getActiveOrInvitedSpace(spaceId, authPayload),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
       expect(spacesRepositoryMock.find).not.toHaveBeenCalled();
     });
 
@@ -581,7 +581,7 @@ describe('SpacesService', () => {
 
       await expect(
         service.getActiveOrInvitedSpace(spaceId, authPayload),
-      ).rejects.toThrow(new NotFoundException('Space not found.'));
+      ).rejects.toThrow(new NotFoundException('Workspace not found.'));
 
       expect(membersRepositoryMock.find).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -55,7 +55,7 @@ export class SpacesService {
   ): Promise<GetSpaceResponse> {
     const [space] = await this.findSpaces(authPayload, id);
     if (!space) {
-      throw new NotFoundException('Space not found.');
+      throw new NotFoundException('Workspace not found.');
     }
     return space;
   }

--- a/src/modules/spaces/routes/utils/__tests__/space-assert.utils.spec.ts
+++ b/src/modules/spaces/routes/utils/__tests__/space-assert.utils.spec.ts
@@ -57,7 +57,7 @@ describe('space-assert.utils', () => {
           faker.number.int(),
         ),
       ).rejects.toThrow(
-        new ForbiddenException('User is not an admin of this space'),
+        new ForbiddenException('User is not an admin of this workspace'),
       );
     });
   });
@@ -98,7 +98,7 @@ describe('space-assert.utils', () => {
           faker.number.int(),
         ),
       ).rejects.toThrow(
-        new ForbiddenException('User is not a member of this space'),
+        new ForbiddenException('User is not a member of this workspace'),
       );
     });
   });

--- a/src/modules/spaces/routes/utils/space-assert.utils.ts
+++ b/src/modules/spaces/routes/utils/space-assert.utils.ts
@@ -33,7 +33,7 @@ export async function assertAdmin(
   userId: number,
 ): Promise<void> {
   if (!(await isAdmin(spacesRepository, spaceId, userId))) {
-    throw new ForbiddenException('User is not an admin of this space');
+    throw new ForbiddenException('User is not an admin of this workspace');
   }
 }
 
@@ -50,6 +50,6 @@ export async function assertMember(
   );
 
   if (!member) {
-    throw new ForbiddenException('User is not a member of this space');
+    throw new ForbiddenException('User is not a member of this workspace');
   }
 }

--- a/src/modules/surveys/routes/surveys.service.ts
+++ b/src/modules/surveys/routes/surveys.service.ts
@@ -190,7 +190,7 @@ export class SurveysService {
     });
     if (!member) {
       throw new ForbiddenException(
-        'User is not an active admin of this space.',
+        'User is not an active admin of this workspace.',
       );
     }
     return userId;

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -963,7 +963,7 @@ describe('MembersRepository', () => {
           inviteExpiresAt: faker.date.future(),
         }),
       ).rejects.toThrow(
-        `${activeMemberAddress} is already in this space or has a pending invite.`,
+        `${activeMemberAddress} is already in this workspace or has a pending invite.`,
       );
     });
 
@@ -1067,7 +1067,7 @@ describe('MembersRepository', () => {
           users,
           inviteExpiresAt,
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
   });
 
@@ -1325,7 +1325,7 @@ describe('MembersRepository', () => {
             name: adminName,
           },
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if not authenticated', async () => {
@@ -1362,7 +1362,7 @@ describe('MembersRepository', () => {
             name: memberName,
           },
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if the space does not exist', async () => {
@@ -1381,7 +1381,7 @@ describe('MembersRepository', () => {
             name: memberName,
           },
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if the user is already a member of the space', async () => {
@@ -1420,7 +1420,7 @@ describe('MembersRepository', () => {
           spaceId,
           payload: { name: memberName },
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if the user is not INVITED to the space', async () => {
@@ -1468,7 +1468,7 @@ describe('MembersRepository', () => {
             name: memberName,
           },
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw GoneException if the invite has expired', async () => {
@@ -1700,7 +1700,7 @@ describe('MembersRepository', () => {
           authPayload: nonMemberAuthPayload,
           spaceId,
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if not authenticated', async () => {
@@ -1729,7 +1729,7 @@ describe('MembersRepository', () => {
           authPayload: new AuthPayload(authPayloadDto),
           spaceId,
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if the space does not exist', async () => {
@@ -1744,7 +1744,7 @@ describe('MembersRepository', () => {
           authPayload,
           spaceId,
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if the user is already a member of the space', async () => {
@@ -1782,7 +1782,7 @@ describe('MembersRepository', () => {
           authPayload: memberAuthPayload,
           spaceId,
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw an error if the user is not INVITED to the space', async () => {
@@ -1827,7 +1827,7 @@ describe('MembersRepository', () => {
           authPayload,
           spaceId,
         }),
-      ).rejects.toThrow('Space not found.');
+      ).rejects.toThrow('Workspace not found.');
     });
 
     it('should throw GoneException if the invite has expired', async () => {
@@ -2015,7 +2015,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2039,7 +2039,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2068,7 +2068,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2098,7 +2098,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2128,7 +2128,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2205,7 +2205,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2235,7 +2235,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2265,7 +2265,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });
@@ -2286,7 +2286,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new ForbiddenException(
-          'The user is not an active member of the space.',
+          'The user is not an active member of the workspace.',
         ),
       );
     });

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -184,7 +184,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new UniqueConstraintError(
-          `${wallet.address} is already in this space or has a pending invite.`,
+          `${wallet.address} is already in this workspace or has a pending invite.`,
         ),
       );
       expect(entityManager.insert).not.toHaveBeenCalled();
@@ -218,7 +218,7 @@ describe('MembersRepository', () => {
         }),
       ).rejects.toThrow(
         new UniqueConstraintError(
-          `${wallet.address} is already in this space or has a pending invite.`,
+          `${wallet.address} is already in this workspace or has a pending invite.`,
         ),
       );
       expect(entityManager.insert).toHaveBeenCalled();

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -207,8 +207,8 @@ export class MembersRepository implements IMembersRepository {
     const duplicateInviteError = (): UniqueConstraintError =>
       new UniqueConstraintError(
         userToInvite.type === InviteType.Wallet
-          ? `${userToInvite.address} is already in this space or has a pending invite.`
-          : 'This invitee is already in this space or has a pending invite.',
+          ? `${userToInvite.address} is already in this workspace or has a pending invite.`
+          : 'This invitee is already in this workspace or has a pending invite.',
       );
 
     const existingMember = await entityManager.findOne(DbMember, {
@@ -511,7 +511,7 @@ export class MembersRepository implements IMembersRepository {
     });
     if (!member) {
       throw new ForbiddenException(
-        'The user is not an active member of the space.',
+        'The user is not an active member of the workspace.',
       );
     }
     return member;


### PR DESCRIPTION
## Summary

Renames the user-facing term "space"/"spaces" to "workspace"/"workspaces" in all error messages returned to the frontend. The frontend now refers to these as "workspaces", so the error messages the API returns in response bodies should match.

Resolves: [WA-2420](https://linear.app/safe-global/issue/WA-2420/cgw-change-status-message-texts-space-workspace)

Scope is limited to the error message strings actually thrown and returned to clients. Code identifiers (`SpaceSafe`, `spaceId`, the `spaces.*` config keys, entity/class/file names), route paths (`/v1/spaces`), and Swagger `@ApiResponse` description strings are intentionally left unchanged, as is the `name.schema.ts` validation text where "spaces" means literal whitespace characters.

## Changes

Updated error messages (`Space`→`Workspace`, `Spaces`→`Workspaces`, `space`→`workspace`):

- `spaces.repository.ts` — "maximum number of Workspaces", "Workspace not found.", "Workspaces not found.", "Workspace/Workspaces not found. UserId = …"
- `space-safes.repository.ts` — "This Workspace only allows … Safe Accounts…", "Workspace has no Safes."
- `address-books/user-address-book-items.repository.ts` — "This Workspace only allows … private contacts…"
- `address-books/address-book-items.repository.ts` — "This Workspace only allows … Address Book Items…"
- `routes/utils/space-assert.utils.ts` — "User is not an admin/member of this workspace"
- `routes/spaces.service.ts` — "Workspace not found."
- `users/domain/members.repository.ts` — "already in this workspace or has a pending invite.", "not an active member of the workspace."
- `surveys/routes/surveys.service.ts` — "not an active admin of this workspace."

Updated the corresponding unit, integration, and e2e test assertions to match the new message text.

## Out of scope

- Swagger/OpenAPI `@ApiResponse` `description:` strings (API docs, not response-body messages)
- Code identifiers, config keys, route paths, entity/class/file names
- "spaces" referring to literal whitespace in `name.schema.ts`
- Test `it(...)`/`describe(...)` descriptions
