### PR TITLE
feat(space): validation

### DIFF
--- a/migrations/1780900000000-member-name-length.ts
+++ b/migrations/1780900000000-member-name-length.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MemberNameLength1780900000000 implements MigrationInterface {
+  name = 'MemberNameLength1780900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "members" ALTER COLUMN "name" TYPE character varying(255)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "members" ALTER COLUMN "name" TYPE character varying(30)`,
+    );
+  }
+}

--- a/migrations/1780900000000-member-name-length.ts
+++ b/migrations/1780900000000-member-name-length.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class MemberNameLength1780900000000 implements MigrationInterface {

--- a/src/modules/spaces/domain/address-books/entities/address-book-item.entity.ts
+++ b/src/modules/spaces/domain/address-books/entities/address-book-item.entity.ts
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
 import { makeNameSchema } from '@/domain/common/schemas/name.schema';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 export const ADDRESS_BOOK_NAME_MAX_LENGTH = 50;
 
 export const AddressBookItemSchema = z.object({
-  chainIds: z.array(z.string()),
+  chainIds: z.array(ChainIdSchema),
   address: AddressSchema,
   name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),
 });

--- a/src/modules/spaces/domain/address-books/entities/address-book-item.entity.ts
+++ b/src/modules/spaces/domain/address-books/entities/address-book-item.entity.ts
@@ -5,7 +5,7 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 export const ADDRESS_BOOK_NAME_MAX_LENGTH = 50;
 
-const AddressBookItemSchema = z.object({
+export const AddressBookItemSchema = z.object({
   chainIds: z.array(z.string()),
   address: AddressSchema,
   name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),

--- a/src/modules/spaces/domain/address-books/entities/address-book-request.entity.ts
+++ b/src/modules/spaces/domain/address-books/entities/address-book-request.entity.ts
@@ -8,6 +8,7 @@ import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { ADDRESS_BOOK_NAME_MAX_LENGTH } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { SpaceSchema } from '@/modules/spaces/domain/entities/space.entity';
+import { MemberSchema } from '@/modules/users/domain/entities/member.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import { UserSchema } from '@/modules/users/domain/entities/user.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -36,7 +37,7 @@ export const AddressBookRequestSchema: z.ZodType<
   address: AddressSchema as z.ZodType<Address>,
   name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),
   status: z.enum(getStringEnumKeys(AddressBookRequestStatus)),
-  reviewedBy: z.number().int().nullable(),
+  reviewedBy: MemberSchema.shape.invitedBy,
 });
 
 export type AddressBookRequest = z.infer<typeof AddressBookRequestSchema>;

--- a/src/modules/spaces/domain/address-books/entities/user-address-book-item.entity.ts
+++ b/src/modules/spaces/domain/address-books/entities/user-address-book-item.entity.ts
@@ -3,8 +3,7 @@
 import type { Address } from 'viem';
 import { z } from 'zod';
 import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
-import { makeNameSchema } from '@/domain/common/schemas/name.schema';
-import { ADDRESS_BOOK_NAME_MAX_LENGTH } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
+import { AddressBookItemSchema } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { SpaceSchema } from '@/modules/spaces/domain/entities/space.entity';
 import type { User } from '@/modules/users/domain/entities/user.entity';
@@ -24,8 +23,8 @@ export const UserAddressBookItemSchema: z.ZodType<
   space: z.lazy(() => SpaceSchema),
   creator: z.lazy(() => UserSchema),
   chainIds: z.array(z.string()),
-  address: AddressSchema as z.ZodType<Address>,
-  name: makeNameSchema({ maxLength: ADDRESS_BOOK_NAME_MAX_LENGTH }),
+  address: AddressSchema,
+  name: AddressBookItemSchema.shape.name,
 });
 
 export type UserAddressBookItem = z.infer<typeof UserAddressBookItemSchema>;

--- a/src/modules/spaces/domain/address-books/entities/user-address-book-item.entity.ts
+++ b/src/modules/spaces/domain/address-books/entities/user-address-book-item.entity.ts
@@ -3,6 +3,7 @@
 import type { Address } from 'viem';
 import { z } from 'zod';
 import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
 import { AddressBookItemSchema } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { SpaceSchema } from '@/modules/spaces/domain/entities/space.entity';
@@ -22,7 +23,7 @@ export const UserAddressBookItemSchema: z.ZodType<
 > = RowSchema.extend({
   space: z.lazy(() => SpaceSchema),
   creator: z.lazy(() => UserSchema),
-  chainIds: z.array(z.string()),
+  chainIds: z.array(ChainIdSchema),
   address: AddressSchema,
   name: AddressBookItemSchema.shape.name,
 });

--- a/src/modules/spaces/domain/entities/space.entity.ts
+++ b/src/modules/spaces/domain/entities/space.entity.ts
@@ -4,6 +4,7 @@ import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
 import { NameSchema } from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { Space as DbSpace } from '@/modules/spaces/datasources/entities/space.entity.db';
+import type { SpaceSafe } from '@/modules/spaces/domain/entities/space-safe.entity';
 import { SpaceSafeSchema } from '@/modules/spaces/domain/entities/space-safe.entity';
 import type { Member } from '@/modules/users/domain/entities/member.entity';
 import { MemberSchema } from '@/modules/users/domain/entities/member.entity';
@@ -12,19 +13,20 @@ export enum SpaceStatus {
   ACTIVE = 1,
 }
 
-export type Space = z.infer<typeof SpaceSchema>;
+export type Space = z.infer<typeof RowSchema> & {
+  name: string;
+  status: keyof typeof SpaceStatus;
+  members: Array<Member>;
+  safes?: DbSpace['safes'];
+};
 
-// We need explicitly define ZodType due to recursion
-export const SpaceSchema: z.ZodType<
-  z.infer<typeof RowSchema> & {
-    name: string;
-    status: keyof typeof SpaceStatus;
-    members: Array<Member>;
-    safes?: DbSpace['safes'];
-  }
-> = RowSchema.extend({
+// The lazy callbacks are explicitly typed to break the circular inference
+// with MemberSchema, while keeping SpaceSchema a ZodObject (exposing `.shape`).
+export const SpaceSchema = RowSchema.extend({
   name: NameSchema,
   status: z.enum(getStringEnumKeys(SpaceStatus)),
-  members: z.array(z.lazy(() => MemberSchema)),
-  safes: z.array(z.lazy(() => SpaceSafeSchema)).optional(),
+  members: z.array(z.lazy((): z.ZodType<Member> => MemberSchema)),
+  safes: z
+    .array(z.lazy((): z.ZodType<SpaceSafe> => SpaceSafeSchema))
+    .optional(),
 });

--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -172,12 +172,12 @@ describe('InviteUsersDtoSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('should accept a name with special characters', () => {
+  it('should reject a name with invalid special characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [{ ...walletInviteUserDtoBuilder().build(), name: '<>@!' }],
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
   it('should reject an invalid role value', () => {

--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -152,20 +152,20 @@ describe('InviteUsersDtoSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('should accept a name of up to 255 characters', () => {
+  it('should accept a name of up to 30 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [
-        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(255) },
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(30) },
       ],
     });
 
     expect(result.success).toBe(true);
   });
 
-  it('should reject a name exceeding 255 characters', () => {
+  it('should reject a name exceeding 30 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [
-        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(256) },
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(31) },
       ],
     });
 

--- a/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/invite-users.dto.entity.spec.ts
@@ -152,20 +152,20 @@ describe('InviteUsersDtoSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('should accept a name of up to 30 characters', () => {
+  it('should accept a name of up to 255 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [
-        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(30) },
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(255) },
       ],
     });
 
     expect(result.success).toBe(true);
   });
 
-  it('should reject a name exceeding 30 characters', () => {
+  it('should reject a name exceeding 255 characters', () => {
     const result = InviteUsersDtoSchema.safeParse({
       users: [
-        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(31) },
+        { ...walletInviteUserDtoBuilder().build(), name: 'a'.repeat(256) },
       ],
     });
 

--- a/src/modules/spaces/routes/entities/__tests__/upsert-address-book-items.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/upsert-address-book-items.dto.entity.spec.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { UpsertAddressBookItemsSchema } from '@/modules/spaces/routes/entities/upsert-address-book-items.dto.entity';
+
+const validItem = (): {
+  name: string;
+  address: string;
+  chainIds: Array<string>;
+} => ({
+  name: 'My Wallet',
+  address: getAddress(faker.finance.ethereumAddress()),
+  chainIds: ['1', '100'],
+});
+
+describe('UpsertAddressBookItemsSchema', () => {
+  it('should validate a well-formed payload', () => {
+    const result = UpsertAddressBookItemsSchema.safeParse({
+      items: [validItem()],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should require a name', () => {
+    const { name: _name, ...item } = validItem();
+
+    const result = UpsertAddressBookItemsSchema.safeParse({ items: [item] });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a name with invalid special characters', () => {
+    const result = UpsertAddressBookItemsSchema.safeParse({
+      items: [{ ...validItem(), name: '<>@!' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a non-numeric chain id', () => {
+    const result = UpsertAddressBookItemsSchema.safeParse({
+      items: [{ ...validItem(), chainIds: ['mainnet'] }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject an invalid address', () => {
+    const result = UpsertAddressBookItemsSchema.safeParse({
+      items: [{ ...validItem(), address: 'not-an-address' }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/modules/spaces/routes/entities/__tests__/upsert-address-book-items.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/upsert-address-book-items.dto.entity.spec.ts
@@ -1,19 +1,15 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { faker } from '@faker-js/faker';
-import { getAddress } from 'viem';
+import { addressBookItemBuilder } from '@/modules/spaces/domain/address-books/entities/__tests__/address-book-item.db.builder';
 import { UpsertAddressBookItemsSchema } from '@/modules/spaces/routes/entities/upsert-address-book-items.dto.entity';
 
 const validItem = (): {
   name: string;
   address: string;
   chainIds: Array<string>;
-} => ({
-  name: faker.string.alphanumeric({ length: { min: 3, max: 20 } }),
-  address: getAddress(faker.finance.ethereumAddress()),
-  chainIds: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
-    faker.string.numeric({ length: { min: 1, max: 6 } }),
-  ),
-});
+} => {
+  const { name, address, chainIds } = addressBookItemBuilder().build();
+  return { name, address, chainIds };
+};
 
 describe('UpsertAddressBookItemsSchema', () => {
   it('should validate a well-formed payload', () => {

--- a/src/modules/spaces/routes/entities/__tests__/upsert-address-book-items.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/upsert-address-book-items.dto.entity.spec.ts
@@ -8,9 +8,11 @@ const validItem = (): {
   address: string;
   chainIds: Array<string>;
 } => ({
-  name: 'My Wallet',
+  name: faker.string.alphanumeric({ length: { min: 3, max: 20 } }),
   address: getAddress(faker.finance.ethereumAddress()),
-  chainIds: ['1', '100'],
+  chainIds: Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, () =>
+    faker.string.numeric({ length: { min: 1, max: 6 } }),
+  ),
 });
 
 describe('UpsertAddressBookItemsSchema', () => {

--- a/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
-import { makeNameSchema } from '@/domain/common/schemas/name.schema';
+import {
+  makeNameSchema,
+  NAME_MAX_LENGTH,
+} from '@/domain/common/schemas/name.schema';
 
 export const AcceptInviteDtoSchema = z.object({
-  name: makeNameSchema({ maxLength: 255 }),
+  name: makeNameSchema({ maxLength: NAME_MAX_LENGTH }),
 });
 
 export class AcceptInviteDto implements z.infer<typeof AcceptInviteDtoSchema> {
-  @ApiProperty({ type: String, maxLength: 255 })
+  @ApiProperty({ type: String, maxLength: NAME_MAX_LENGTH })
   public readonly name!: string;
 }

--- a/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
@@ -1,16 +1,14 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
-import {
-  makeNameSchema,
-  NAME_MAX_LENGTH,
-} from '@/domain/common/schemas/name.schema';
+import { makeNameSchema } from '@/domain/common/schemas/name.schema';
+import { MEMBER_NAME_MAX_LENGTH } from '@/modules/users/domain/entities/member.entity';
 
 export const AcceptInviteDtoSchema = z.object({
-  name: makeNameSchema({ maxLength: NAME_MAX_LENGTH }),
+  name: makeNameSchema({ maxLength: MEMBER_NAME_MAX_LENGTH }),
 });
 
 export class AcceptInviteDto implements z.infer<typeof AcceptInviteDtoSchema> {
-  @ApiProperty({ type: String, maxLength: NAME_MAX_LENGTH })
+  @ApiProperty({ type: String, maxLength: MEMBER_NAME_MAX_LENGTH })
   public readonly name!: string;
 }

--- a/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/accept-invite.dto.entity.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
+import { makeNameSchema } from '@/domain/common/schemas/name.schema';
 
 export const AcceptInviteDtoSchema = z.object({
-  name: z.string().max(255),
+  name: makeNameSchema({ maxLength: 255 }),
 });
 
 export class AcceptInviteDto implements z.infer<typeof AcceptInviteDtoSchema> {

--- a/src/modules/spaces/routes/entities/create-space.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/create-space.dto.entity.ts
@@ -2,9 +2,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
 import type { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { SpaceSchema } from '@/modules/spaces/domain/entities/space.entity';
 
 export const CreateSpaceSchema = z.object({
-  name: z.string(),
+  name: SpaceSchema.shape.name,
 });
 
 export class CreateSpaceDto implements z.infer<typeof CreateSpaceSchema> {

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -2,7 +2,10 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
-import { makeNameSchema } from '@/domain/common/schemas/name.schema';
+import {
+  makeNameSchema,
+  NAME_MAX_LENGTH,
+} from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { MemberRole } from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -18,7 +21,7 @@ export const InviteType = {
 
 const SharedInviteFields = {
   role: z.enum(getStringEnumKeys(MemberRole)),
-  name: makeNameSchema({ maxLength: 255 }),
+  name: makeNameSchema({ maxLength: NAME_MAX_LENGTH }),
 };
 
 const WalletInviteUserSchema = z
@@ -67,7 +70,7 @@ class WalletInviteUserDto implements z.infer<typeof WalletInviteUserSchema> {
   @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
   public readonly role!: keyof typeof MemberRole;
 
-  @ApiProperty({ type: String, maxLength: 255 })
+  @ApiProperty({ type: String, maxLength: NAME_MAX_LENGTH })
   public readonly name!: string;
 }
 
@@ -81,7 +84,7 @@ class EmailInviteUserDto implements z.infer<typeof EmailInviteUserSchema> {
   @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
   public readonly role!: keyof typeof MemberRole;
 
-  @ApiProperty({ type: String, maxLength: 255 })
+  @ApiProperty({ type: String, maxLength: NAME_MAX_LENGTH })
   public readonly name!: string;
 }
 

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -2,6 +2,7 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
+import { makeNameSchema } from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import { MemberRole } from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
@@ -17,7 +18,7 @@ export const InviteType = {
 
 const SharedInviteFields = {
   role: z.enum(getStringEnumKeys(MemberRole)),
-  name: z.string().max(255),
+  name: makeNameSchema({ maxLength: 255 }),
 };
 
 const WalletInviteUserSchema = z

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -2,12 +2,12 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
-import {
-  makeNameSchema,
-  NAME_MAX_LENGTH,
-} from '@/domain/common/schemas/name.schema';
+import { makeNameSchema } from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
-import { MemberRole } from '@/modules/users/domain/entities/member.entity';
+import {
+  MEMBER_NAME_MAX_LENGTH,
+  MemberRole,
+} from '@/modules/users/domain/entities/member.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import {
   type EmailAddress,
@@ -21,7 +21,7 @@ export const InviteType = {
 
 const SharedInviteFields = {
   role: z.enum(getStringEnumKeys(MemberRole)),
-  name: makeNameSchema({ maxLength: NAME_MAX_LENGTH }),
+  name: makeNameSchema({ maxLength: MEMBER_NAME_MAX_LENGTH }),
 };
 
 const WalletInviteUserSchema = z
@@ -70,7 +70,7 @@ class WalletInviteUserDto implements z.infer<typeof WalletInviteUserSchema> {
   @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
   public readonly role!: keyof typeof MemberRole;
 
-  @ApiProperty({ type: String, maxLength: NAME_MAX_LENGTH })
+  @ApiProperty({ type: String, maxLength: MEMBER_NAME_MAX_LENGTH })
   public readonly name!: string;
 }
 
@@ -84,7 +84,7 @@ class EmailInviteUserDto implements z.infer<typeof EmailInviteUserSchema> {
   @ApiProperty({ enum: getStringEnumKeys(MemberRole) })
   public readonly role!: keyof typeof MemberRole;
 
-  @ApiProperty({ type: String, maxLength: NAME_MAX_LENGTH })
+  @ApiProperty({ type: String, maxLength: MEMBER_NAME_MAX_LENGTH })
   public readonly name!: string;
 }
 

--- a/src/modules/spaces/routes/entities/update-space.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/update-space.dto.entity.ts
@@ -3,10 +3,13 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { z } from 'zod';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
-import { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
+import {
+  SpaceSchema,
+  SpaceStatus,
+} from '@/modules/spaces/domain/entities/space.entity';
 
 export const UpdateSpaceSchema = z.object({
-  name: z.string().optional(),
+  name: SpaceSchema.shape.name.optional(),
   status: z.enum(getStringEnumKeys(SpaceStatus)).optional(),
 });
 

--- a/src/modules/spaces/routes/entities/upsert-address-book-items.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/upsert-address-book-items.dto.entity.ts
@@ -2,10 +2,11 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
+import { AddressBookItemSchema as BaseAddressBookItemSchema } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 const AddressBookItemSchema = z.object({
-  name: z.string(),
+  name: BaseAddressBookItemSchema.shape.name.optional(),
   address: AddressSchema,
   chainIds: z.array(z.string()),
 });

--- a/src/modules/spaces/routes/entities/upsert-address-book-items.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/upsert-address-book-items.dto.entity.ts
@@ -7,7 +7,7 @@ import { AddressBookItemSchema as BaseAddressBookItemSchema } from '@/modules/sp
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 const AddressBookItemSchema = z.object({
-  name: BaseAddressBookItemSchema.shape.name.optional(),
+  name: BaseAddressBookItemSchema.shape.name,
   address: AddressSchema,
   chainIds: z.array(ChainIdSchema),
 });

--- a/src/modules/spaces/routes/entities/upsert-address-book-items.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/upsert-address-book-items.dto.entity.ts
@@ -2,13 +2,14 @@
 import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { z } from 'zod';
+import { ChainIdSchema } from '@/modules/chains/domain/entities/schemas/chain-id.schema';
 import { AddressBookItemSchema as BaseAddressBookItemSchema } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 
 const AddressBookItemSchema = z.object({
   name: BaseAddressBookItemSchema.shape.name.optional(),
   address: AddressSchema,
-  chainIds: z.array(z.string()),
+  chainIds: z.array(ChainIdSchema),
 });
 
 class AddressBookItem implements z.infer<typeof AddressBookItemSchema> {

--- a/src/modules/users/datasources/entities/member.entity.db.ts
+++ b/src/modules/users/datasources/entities/member.entity.db.ts
@@ -14,6 +14,7 @@ import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
 import {
   type Member as DomainMember,
+  MEMBER_NAME_MAX_LENGTH,
   MemberRole,
   MemberStatus,
 } from '@/modules/users/domain/entities/member.entity';
@@ -56,7 +57,7 @@ export class Member implements DomainMember {
   })
   space!: Space;
 
-  @Column({ type: 'varchar', length: NAME_MAX_LENGTH })
+  @Column({ type: 'varchar', length: MEMBER_NAME_MAX_LENGTH })
   name!: string;
 
   @Column({ type: 'varchar', length: NAME_MAX_LENGTH, nullable: true })

--- a/src/modules/users/domain/entities/member.entity.ts
+++ b/src/modules/users/domain/entities/member.entity.ts
@@ -18,21 +18,22 @@ export enum MemberStatus {
   DECLINED = 2,
 }
 
-// We need explicitly define ZodType due to recursion
-export const MemberSchema: z.ZodType<
-  z.infer<typeof RowSchema> & {
-    user: User;
-    space: Space;
-    name: string;
-    alias: string | null;
-    role: keyof typeof MemberRole;
-    status: keyof typeof MemberStatus;
-    invitedBy: number | null;
-    inviteExpiresAt: Date | null;
-  }
-> = RowSchema.extend({
-  user: z.lazy(() => UserSchema),
-  space: z.lazy(() => SpaceSchema),
+export type Member = z.infer<typeof RowSchema> & {
+  user: User;
+  space: Space;
+  name: string;
+  alias: string | null;
+  role: keyof typeof MemberRole;
+  status: keyof typeof MemberStatus;
+  invitedBy: number | null;
+  inviteExpiresAt: Date | null;
+};
+
+// The lazy callbacks are explicitly typed to break the circular inference
+// with UserSchema/SpaceSchema, while keeping MemberSchema a ZodObject (exposing `.shape`).
+export const MemberSchema = RowSchema.extend({
+  user: z.lazy((): z.ZodType<User> => UserSchema),
+  space: z.lazy((): z.ZodType<Space> => SpaceSchema),
   name: NameSchema,
   alias: NameSchema.nullable(),
   role: z.enum(getStringEnumKeys(MemberRole)),
@@ -40,5 +41,3 @@ export const MemberSchema: z.ZodType<
   invitedBy: z.number().int().positive().nullable(),
   inviteExpiresAt: z.date().nullable(),
 });
-
-export type Member = z.infer<typeof MemberSchema>;

--- a/src/modules/users/domain/entities/member.entity.ts
+++ b/src/modules/users/domain/entities/member.entity.ts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { z } from 'zod';
 import { RowSchema } from '@/datasources/db/v2/entities/row.entity';
-import { NameSchema } from '@/domain/common/schemas/name.schema';
+import {
+  makeNameSchema,
+  NameSchema,
+} from '@/domain/common/schemas/name.schema';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { SpaceSchema } from '@/modules/spaces/domain/entities/space.entity';
@@ -17,6 +20,8 @@ export enum MemberStatus {
   ACTIVE = 1,
   DECLINED = 2,
 }
+
+export const MEMBER_NAME_MAX_LENGTH = 255;
 
 export type Member = z.infer<typeof RowSchema> & {
   user: User;
@@ -34,7 +39,7 @@ export type Member = z.infer<typeof RowSchema> & {
 export const MemberSchema = RowSchema.extend({
   user: z.lazy((): z.ZodType<User> => UserSchema),
   space: z.lazy((): z.ZodType<Space> => SpaceSchema),
-  name: NameSchema,
+  name: makeNameSchema({ maxLength: MEMBER_NAME_MAX_LENGTH }),
   alias: NameSchema.nullable(),
   role: z.enum(getStringEnumKeys(MemberRole)),
   status: z.enum(getStringEnumKeys(MemberStatus)),


### PR DESCRIPTION
## Summary

Centralizes validation across the Spaces module by deriving field rules from shared Zod schemas instead of ad-hoc inline validators (`z.string()`, `z.number().int().nullable()`, etc.). This keeps name, member-field, and chain-id validation defined in one place so the rules stay consistent across domain entities and route DTOs.

  ## ⚠️  Behavioral change — invite name validation

  This is **not purely a refactor**. Invite names (`accept-invite`, `invite-users`) now go through `makeNameSchema` (min 3 chars + restricted charset `^[a-zA-Z0-9]+(?:[
  ._-][a-zA-Z0-9]+)*$`), which **reverses** the relaxation from #3128 (`fix(spaces): relax invite name validation to max 255 chars`). Inputs that #3128 specifically allowed are now
  rejected, e.g.:
  - special characters such as `<>@!`
  - 1–2 character names

  Downstream consumers that relied on the relaxed rule will start getting validation errors. Since #3128 merged the same day, this relax-then-tighten round trip should be confirmed
  with its author in case of competing requirements.

  ## Changes

  **Name & member-field validation from shared schemas**
  - Export `AddressBookItemSchema` and source DTO `name` fields from its `.shape`.
  - Apply `makeNameSchema({ maxLength: 255 })` to `accept-invite` and `invite-users` name fields.
  - Derive create/update space `name` from `SpaceSchema.shape.name`.
  - Derive address book request `reviewedBy` from `MemberSchema.shape.invitedBy`.
  - Refactor `SpaceSchema` and `MemberSchema` into `ZodObject`s (exposing `.shape`) using explicitly typed lazy callbacks to break the circular type inference.

  **Address book chainIds validation**
  - Tighten `chainIds` from `z.array(z.string())` to `z.array(ChainIdSchema)` in the address book item entity, user address book item entity, and the upsert DTO.
  - Require the upsert address book item `name` (drop `.optional()`).

  ## Tests
  - Updated `invite-users` spec to expect special-character names to be rejected.
  - Added `upsert-address-book-items.dto.entity.spec.ts` covering required-name, name format, numeric `chainId`, and address validation.