### PR TITLE
fix(spaces): expose invited members' email to space admins

### DIFF
--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -1344,20 +1344,17 @@ describe('MembersController', () => {
         });
     });
 
-    it('should hide email for invited members', async () => {
-      const spaceName = nameBuilder();
-      const invitedAddress = getAddress(faker.finance.ethereumAddress());
-      const invitedName = faker.person.firstName();
-      const email = fakeEmailAddress();
-
-      const userId = await usersRepository.findOrCreateByExtUserIdAndEmail(
-        faker.string.uuid(),
-        email,
-      );
-      const authPayloadDto = oidcAuthPayloadDtoBuilder()
-        .with('sub', userId.toString())
-        .build();
+    it('should return email for invited members when the caller is an active admin', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
       const accessToken = jwtService.sign(authPayloadDto);
+      const spaceName = nameBuilder();
+      const invitedName = faker.person.firstName();
+      const invitedEmail = fakeEmailAddress();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(201);
 
       const createSpaceResponse = await request(app.getHttpServer())
         .post('/v1/spaces')
@@ -1366,21 +1363,22 @@ describe('MembersController', () => {
         .expect(201);
       const spaceId = createSpaceResponse.body.id;
 
-      await request(app.getHttpServer())
+      const inviteResponse = await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
         .set('Cookie', [`access_token=${accessToken}`])
         .send({
           users: [
             {
+              type: 'email',
               role: 'MEMBER',
-              address: invitedAddress,
+              email: invitedEmail,
               name: invitedName,
             },
           ],
         })
         .expect(201);
-      const invitedUser =
-        await usersRepository.findByWalletAddressOrFail(invitedAddress);
+      const invitedUserId = inviteResponse.body[0].userId;
+
       await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}/members`)
         .set('Cookie', [`access_token=${accessToken}`])
@@ -1391,7 +1389,67 @@ describe('MembersController', () => {
               expect.objectContaining({
                 status: 'INVITED',
                 user: expect.objectContaining({
-                  id: invitedUser.id,
+                  id: invitedUserId,
+                  email: invitedEmail,
+                }),
+              }),
+            ]),
+          );
+        });
+    });
+
+    it('should hide email for invited members when the caller is not an active admin', async () => {
+      const authPayloadDto = siweAuthPayloadDtoBuilder().build();
+      const accessToken = jwtService.sign(authPayloadDto);
+      const spaceName = nameBuilder();
+      const invitedName = faker.person.firstName();
+      const invitedEmail = fakeEmailAddress();
+
+      await request(app.getHttpServer())
+        .post('/v1/users/wallet')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(201);
+
+      const createSpaceResponse = await request(app.getHttpServer())
+        .post('/v1/spaces')
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({ name: spaceName })
+        .expect(201);
+      const spaceId = createSpaceResponse.body.id;
+
+      const inviteResponse = await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/invite`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          users: [
+            {
+              type: 'email',
+              role: 'MEMBER',
+              email: invitedEmail,
+              name: invitedName,
+            },
+          ],
+        })
+        .expect(201);
+      const invitedUserId = inviteResponse.body[0].userId;
+
+      // The invited member can list members but is not an active admin.
+      const invitedAuthPayloadDto = oidcAuthPayloadDtoBuilder()
+        .with('sub', invitedUserId.toString())
+        .build();
+      const invitedAccessToken = jwtService.sign(invitedAuthPayloadDto);
+
+      await request(app.getHttpServer())
+        .get(`/v1/spaces/${spaceId}/members`)
+        .set('Cookie', [`access_token=${invitedAccessToken}`])
+        .expect(200)
+        .expect(({ body }) => {
+          expect(body.members).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                status: 'INVITED',
+                user: expect.objectContaining({
+                  id: invitedUserId,
                   email: null,
                 }),
               }),

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -50,9 +50,10 @@ describe('MembersService', () => {
   });
 
   describe('get', () => {
-    it('should hide stored email for invited members', async () => {
+    it('should hide stored email for invited members when the caller is not an active admin', async () => {
       const email = fakeEmailAddress();
-      const member = memberBuilder()
+      const invitedMember = memberBuilder()
+        .with('role', 'MEMBER')
         .with('status', 'INVITED')
         .with(
           'user',
@@ -63,16 +64,59 @@ describe('MembersService', () => {
       const spaceId = faker.number.int({ min: 1 });
 
       membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
-        member,
+        invitedMember,
       ]);
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(null);
 
       await expect(service.get({ authPayload, spaceId })).resolves.toEqual({
         members: [
           {
-            ...member,
+            ...invitedMember,
             user: {
-              ...member.user,
+              ...invitedMember.user,
               email: null,
+            },
+          },
+        ],
+      });
+      expect(membersRepositoryMock.findActiveAdmin).toHaveBeenCalledWith({
+        userId: Number(authPayload.sub),
+        spaceId,
+      });
+    });
+
+    it('should expose stored email for invited members when the caller is an active admin', async () => {
+      const email = fakeEmailAddress();
+      const invitedMember = memberBuilder()
+        .with('role', 'MEMBER')
+        .with('status', 'INVITED')
+        .with(
+          'user',
+          userBuilder().with('email', email).with('status', 'PENDING').build(),
+        )
+        .build();
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const callerMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .with('user', userBuilder().with('id', Number(authPayload.sub)).build())
+        .build();
+      const spaceId = faker.number.int({ min: 1 });
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        callerMember,
+        invitedMember,
+      ]);
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(callerMember);
+
+      await expect(service.get({ authPayload, spaceId })).resolves.toEqual({
+        members: [
+          callerMember,
+          {
+            ...invitedMember,
+            user: {
+              ...invitedMember.user,
+              email,
             },
           },
         ],

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -79,18 +79,27 @@ export class MembersService {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<MembersDto> {
+    const members = await this.membersRepository.findAuthorizedMembersOrFail({
+      authPayload: args.authPayload,
+      spaceId: args.spaceId,
+    });
+    const isActiveAdmin = Boolean(
+      await this.membersRepository.findActiveAdmin({
+        userId: getAuthenticatedUserIdOrFail(args.authPayload),
+        spaceId: args.spaceId,
+      }),
+    );
     return {
-      members: (
-        await this.membersRepository.findAuthorizedMembersOrFail({
-          authPayload: args.authPayload,
-          spaceId: args.spaceId,
-        })
-      ).map((member) => ({
+      members: members.map((member) => ({
         ...member,
         user: {
           ...member.user,
-          // Only expose email once the member accepted the invite.
-          email: member.status === 'ACTIVE' ? member.user.email : null,
+          // Until the member accepted the invite, only expose their email
+          // to active admins.
+          email:
+            member.status === 'ACTIVE' || isActiveAdmin
+              ? member.user.email
+              : null,
         },
       })),
     };

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -79,16 +79,17 @@ export class MembersService {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<MembersDto> {
-    const members = await this.membersRepository.findAuthorizedMembersOrFail({
-      authPayload: args.authPayload,
-      spaceId: args.spaceId,
-    });
-    const isActiveAdmin = Boolean(
-      await this.membersRepository.findActiveAdmin({
+    const [members, activeAdmin] = await Promise.all([
+      this.membersRepository.findAuthorizedMembersOrFail({
+        authPayload: args.authPayload,
+        spaceId: args.spaceId,
+      }),
+      this.membersRepository.findActiveAdmin({
         userId: getAuthenticatedUserIdOrFail(args.authPayload),
         spaceId: args.spaceId,
       }),
-    );
+    ]);
+    const isActiveAdmin = Boolean(activeAdmin);
     return {
       members: members.map((member) => ({
         ...member,


### PR DESCRIPTION
## Summary

- `GET /v1/spaces/:spaceId/members` now returns the stored email of `INVITED` members when the caller is an active admin of the space; previously emails were only exposed once a member accepted the invite.
- Non-admin callers (including invited admins) keep seeing `email: null` for invited members; active members' emails are unchanged.
- Admin status is checked via the existing `MembersRepository.findActiveAdmin`, so the role/status predicate is not duplicated in the service.
- Unit tests cover both caller roles; e2e tests use email-type invites (the case where an invited user actually has a stored email) for the admin and non-admin caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)