### PR TITLE
fix: hide sensitive data in API responses

### DIFF
--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -1260,8 +1260,6 @@ describe('MembersController', () => {
                   id: adminUserId,
                   status: 'ACTIVE',
                   email: null,
-                  createdAt: expect.any(String),
-                  updatedAt: expect.any(String),
                 },
               },
               {
@@ -1278,8 +1276,6 @@ describe('MembersController', () => {
                   id: expect.any(Number),
                   status: 'PENDING',
                   email: null,
-                  createdAt: expect.any(String),
-                  updatedAt: expect.any(String),
                 },
               },
               {
@@ -1296,8 +1292,6 @@ describe('MembersController', () => {
                   id: expect.any(Number),
                   status: 'PENDING',
                   email: null,
-                  createdAt: expect.any(String),
-                  updatedAt: expect.any(String),
                 },
               },
             ],

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -73,7 +73,8 @@ describe('MembersService', () => {
           {
             ...invitedMember,
             user: {
-              ...invitedMember.user,
+              id: invitedMember.user.id,
+              status: invitedMember.user.status,
               email: null,
             },
           },
@@ -111,16 +112,49 @@ describe('MembersService', () => {
 
       await expect(service.get({ authPayload, spaceId })).resolves.toEqual({
         members: [
-          callerMember,
+          {
+            ...callerMember,
+            user: {
+              id: callerMember.user.id,
+              status: callerMember.user.status,
+              email: callerMember.user.email,
+            },
+          },
           {
             ...invitedMember,
             user: {
-              ...invitedMember.user,
+              id: invitedMember.user.id,
+              status: invitedMember.user.status,
               email,
             },
           },
         ],
       });
+    });
+
+    it('should not expose extUserId in the member user', async () => {
+      const invitedMember = memberBuilder()
+        .with('role', 'MEMBER')
+        .with('status', 'INVITED')
+        .with(
+          'user',
+          userBuilder()
+            .with('extUserId', faker.string.uuid())
+            .with('status', 'PENDING')
+            .build(),
+        )
+        .build();
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+
+      membersRepositoryMock.findAuthorizedMembersOrFail.mockResolvedValue([
+        invitedMember,
+      ]);
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(null);
+
+      const result = await service.get({ authPayload, spaceId });
+
+      expect(result.members[0].user).not.toHaveProperty('extUserId');
     });
   });
 

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -93,15 +93,14 @@ export class MembersService {
     return {
       members: members.map((member) => ({
         ...member,
-        user: {
-          ...member.user,
+        user: this.toMemberUser(
+          member.user,
           // Until the member accepted the invite, only expose their email
           // to active admins.
-          email:
-            member.status === 'ACTIVE' || isActiveAdmin
-              ? member.user.email
-              : null,
-        },
+          member.status === 'ACTIVE' || isActiveAdmin
+            ? member.user.email
+            : null,
+        ),
       })),
     };
   }
@@ -110,10 +109,26 @@ export class MembersService {
     authPayload: AuthPayload;
     spaceId: Space['id'];
   }): Promise<MemberDto> {
-    return await this.membersRepository.findSelfMembershipOrFail({
+    const member = await this.membersRepository.findSelfMembershipOrFail({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
+    return {
+      ...member,
+      user: this.toMemberUser(member.user, member.user.email),
+    };
+  }
+
+  /**
+   * Maps a domain user to the public shape exposed in member responses,
+   * explicitly omitting sensitive fields such as `extUserId`.
+   */
+  private toMemberUser(user: User, email: User['email']): MemberDto['user'] {
+    return {
+      id: user.id,
+      status: user.status,
+      email,
+    };
   }
 
   public async updateRole(args: {


### PR DESCRIPTION
## Summary

I have noticed that we were leaking internal identifiers in /members and /membership endpoints. This PR addresses it and only propagates used/public fields for user data


