### PR TITLE
feat: renew invites endpoint

### DIFF
--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -514,6 +514,98 @@ describe('MembersController', () => {
     });
   });
 
+  describe('POST /v1/spaces/:spaceId/members/:userId/invite/renew', () => {
+    it('should renew a pending invite, preserving its metadata', async () => {
+      const { accessToken, spaceId, userId } = await createSpaceForSigner(
+        nameBuilder(),
+      );
+      const inviteeAddress = getAddress(faker.finance.ethereumAddress());
+      const inviteeName = faker.person.firstName();
+
+      const inviteResponse = await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/invite`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .send({
+          users: [
+            { role: 'MEMBER', address: inviteeAddress, name: inviteeName },
+          ],
+        })
+        .expect(201);
+      const inviteeUserId = inviteResponse.body[0].userId;
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/${inviteeUserId}/invite/renew`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(201)
+        .expect(({ body }) =>
+          expect(body).toEqual({
+            userId: inviteeUserId,
+            spaceId,
+            name: inviteeName,
+            role: 'MEMBER',
+            status: 'INVITED',
+            invitedBy: userId,
+          }),
+        );
+    });
+
+    it('should throw a 403 if the signer is not an active admin of the space', async () => {
+      const { spaceId } = await createSpaceForSigner(nameBuilder());
+      const targetUserId = faker.number.int({
+        min: 69420,
+        max: DB_MAX_SAFE_INTEGER,
+      });
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/${targetUserId}/invite/renew`)
+        .set('Cookie', [`access_token=${nonMemberToken()}`])
+        .expect(403)
+        .expect({
+          message: 'User is not an active admin.',
+          error: 'Forbidden',
+          statusCode: 403,
+        });
+    });
+
+    it('should throw a 404 if the target member does not exist', async () => {
+      const { accessToken, spaceId } = await createSpaceForSigner(
+        nameBuilder(),
+      );
+      const missingUserId = faker.number.int({
+        min: 69420,
+        max: DB_MAX_SAFE_INTEGER,
+      });
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/${missingUserId}/invite/renew`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(404)
+        .expect({
+          message: 'Member not found.',
+          error: 'Not Found',
+          statusCode: 404,
+        });
+    });
+
+    it('should throw a 409 when the target is already an active member', async () => {
+      // The admin themselves is an ACTIVE member, so resending for their own
+      // userId must conflict.
+      const { accessToken, spaceId, userId } = await createSpaceForSigner(
+        nameBuilder(),
+      );
+
+      await request(app.getHttpServer())
+        .post(`/v1/spaces/${spaceId}/members/${userId}/invite/renew`)
+        .set('Cookie', [`access_token=${accessToken}`])
+        .expect(409)
+        .expect({
+          message: 'Only a pending invitation can be resent.',
+          error: 'Conflict',
+          statusCode: 409,
+        });
+    });
+  });
+
   describe('POST /v1/spaces/:spaceId/members/accept', () => {
     it('should accept an invite for a user', async () => {
       const inviteeAuthPayloadDto = siweAuthPayloadDtoBuilder().build();

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -599,7 +599,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(409)
         .expect({
-          message: 'Only a pending invitation can be resent.',
+          message: 'Only a pending invitation can be renewed.',
           error: 'Conflict',
           statusCode: 409,
         });

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -189,6 +189,54 @@ export class MembersController {
   }
 
   @ApiOperation({
+    summary: 'Renew space invitation',
+    description:
+      'Renews a pending invitation to a space, refreshing its expiry. ' +
+      'Only space admins can renew, and only pending invitations can be renewed.' +
+      'Note: renewal for email invites also resends the invitation email.',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'number',
+    description: 'Space ID containing the invitation',
+    example: 1,
+  })
+  @ApiParam({
+    name: 'userId',
+    type: 'number',
+    description: 'User ID of the invited member',
+    example: 123,
+  })
+  @ApiOkResponse({
+    description: 'Invitation renewed successfully',
+    type: Invitation,
+  })
+  @ApiForbiddenResponse({
+    description: 'Access forbidden - user is not an active admin of this space',
+  })
+  @ApiNotFoundResponse({
+    description: 'User, space, or member not found',
+  })
+  @ApiConflictResponse({
+    description: 'Invitation is not in a pending state',
+  })
+  @Post('/:spaceId/members/:userId/invite/renew')
+  @UseGuards(AuthGuard)
+  public async renewInvite(
+    @Auth() authPayload: AuthPayload,
+    @Param('spaceId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    spaceId: number,
+    @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
+    userId: number,
+  ): Promise<Invitation> {
+    return await this.membersService.renewInvite({
+      authPayload,
+      spaceId,
+      userId,
+    });
+  }
+
+  @ApiOperation({
     summary: 'Get space members',
     description:
       'Retrieves all members of a space including their roles, status, and membership information.',

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
-import { ForbiddenException } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import {
   oidcAuthPayloadDtoBuilder,
@@ -21,7 +25,9 @@ const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const membersRepositoryMock = {
   findActiveAdmin: jest.fn(),
   findAuthorizedMembersOrFail: jest.fn(),
+  findOneOrFail: jest.fn(),
   inviteUsers: jest.fn(),
+  renewInvite: jest.fn(),
 } as jest.MockedObjectDeep<IMembersRepository>;
 
 const configurationServiceMock = {
@@ -213,6 +219,104 @@ describe('MembersService', () => {
           authPayload,
           spaceId,
           users: [],
+          inviteExpiresAt: new Date(now.getTime() + INVITE_TTL_MS),
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+
+  describe('renewInvite', () => {
+    it('should throw ForbiddenException when the caller is not an active admin', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(null);
+
+      await expect(
+        service.renewInvite({ authPayload, spaceId, userId }),
+      ).rejects.toThrow(new ForbiddenException('User is not an active admin.'));
+      expect(membersRepositoryMock.findOneOrFail).not.toHaveBeenCalled();
+      expect(membersRepositoryMock.renewInvite).not.toHaveBeenCalled();
+    });
+
+    it('should propagate NotFoundException when the member does not exist', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.findOneOrFail.mockRejectedValue(
+        new NotFoundException('Member not found.'),
+      );
+
+      await expect(
+        service.renewInvite({ authPayload, spaceId, userId }),
+      ).rejects.toThrow(new NotFoundException('Member not found.'));
+      expect(membersRepositoryMock.renewInvite).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'ACTIVE',
+      'DECLINED',
+    ] as const)('should throw ConflictException without renewing when the member is %s', async (status) => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      const targetMember = memberBuilder().with('status', status).build();
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.findOneOrFail.mockResolvedValue(targetMember);
+
+      await expect(
+        service.renewInvite({ authPayload, spaceId, userId }),
+      ).rejects.toThrow(
+        new ConflictException('Only a pending invitation can be renewed.'),
+      );
+      expect(membersRepositoryMock.renewInvite).not.toHaveBeenCalled();
+    });
+
+    it('should renew the invite and return the preserved invitation metadata', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const targetMember = memberBuilder()
+        .with('status', 'INVITED')
+        .with('role', 'MEMBER')
+        .build();
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      const now = new Date('2026-01-15T00:00:00Z');
+      jest.useFakeTimers().setSystemTime(now);
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.findOneOrFail.mockResolvedValue(targetMember);
+
+      try {
+        await expect(
+          service.renewInvite({ authPayload, spaceId, userId }),
+        ).resolves.toEqual({
+          userId,
+          spaceId,
+          name: targetMember.name,
+          role: targetMember.role,
+          status: 'INVITED',
+          invitedBy: targetMember.invitedBy,
+        });
+        expect(membersRepositoryMock.renewInvite).toHaveBeenCalledWith({
+          memberId: targetMember.id,
           inviteExpiresAt: new Date(now.getTime() + INVITE_TTL_MS),
         });
       } finally {

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -53,6 +53,22 @@ export class MembersService {
     });
   }
 
+  public async renewInvite(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+    userId: User['id'];
+  }): Promise<Invitation> {
+    await this.assertActiveAdmin({
+      authPayload: args.authPayload,
+      spaceId: args.spaceId,
+    });
+    return await this.membersRepository.renewInvite({
+      spaceId: args.spaceId,
+      userId: args.userId,
+      inviteExpiresAt: new Date(Date.now() + this.inviteTtlMs),
+    });
+  }
+
   public async acceptInvite(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -62,11 +62,26 @@ export class MembersService {
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
-    return await this.membersRepository.renewInvite({
-      spaceId: args.spaceId,
-      userId: args.userId,
+    const member = await this.membersRepository.findOneOrFail({
+      user: { id: args.userId },
+      space: { id: args.spaceId },
+    });
+    if (member.status !== 'INVITED') {
+      throw new ConflictException('Only a pending invitation can be renewed.');
+    }
+    await this.membersRepository.renewInvite({
+      memberId: member.id,
       inviteExpiresAt: new Date(Date.now() + this.inviteTtlMs),
     });
+
+    return {
+      userId: args.userId,
+      spaceId: args.spaceId,
+      name: member.name,
+      role: member.role,
+      status: member.status,
+      invitedBy: member.invitedBy,
+    };
   }
 
   public async acceptInvite(args: {

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -1125,18 +1125,16 @@ describe('MembersRepository', () => {
   });
 
   describe('renewInvite', () => {
-    it('should refresh the expiry of an expired pending invite, preserving the invite metadata', async () => {
+    it("should refresh the member's inviteExpiresAt, leaving the rest untouched", async () => {
       const invitedBy = faker.number.int({ max: DB_MAX_SAFE_INTEGER });
       const inviteeName = nameBuilder();
       const expiredAt = faker.date.past();
       const renewedInviteExpiresAt = faker.date.future();
       const invitee = await dbUserRepo.insert({ status: 'PENDING' });
-      const inviteeId = invitee.generatedMaps[0].id as User['id'];
       const space = await dbSpacesRepository.insert({
         name: nameBuilder(),
         status: 'ACTIVE',
       });
-      const spaceId = space.generatedMaps[0].id;
       const memberInsert = await dbMembersRepository.insert({
         user: invitee.generatedMaps[0],
         space: space.generatedMaps[0],
@@ -1150,19 +1148,12 @@ describe('MembersRepository', () => {
 
       await expect(
         membersRepository.renewInvite({
-          spaceId,
-          userId: inviteeId,
+          memberId,
           inviteExpiresAt: renewedInviteExpiresAt,
         }),
-      ).resolves.toEqual({
-        userId: inviteeId,
-        spaceId,
-        name: inviteeName,
-        role: 'MEMBER',
-        status: 'INVITED',
-        invitedBy,
-      });
+      ).resolves.toBeUndefined();
 
+      // Only the expiry changes; status/name/role/invitedBy are untouched.
       await expect(
         dbMembersRepository.findOneOrFail({ where: { id: memberId } }),
       ).resolves.toEqual(
@@ -1175,76 +1166,6 @@ describe('MembersRepository', () => {
           inviteExpiresAt: renewedInviteExpiresAt,
         }),
       );
-    });
-
-    it('should throw a NotFoundException when the member does not exist', async () => {
-      const space = await dbSpacesRepository.insert({
-        name: nameBuilder(),
-        status: 'ACTIVE',
-      });
-      const spaceId = space.generatedMaps[0].id;
-
-      await expect(
-        membersRepository.renewInvite({
-          spaceId,
-          userId: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
-          inviteExpiresAt: faker.date.future(),
-        }),
-      ).rejects.toThrow('Member not found.');
-    });
-
-    it('should throw when trying to renew an active member', async () => {
-      const activeUser = await dbUserRepo.insert({ status: 'ACTIVE' });
-      const activeUserId = activeUser.generatedMaps[0].id as User['id'];
-      const space = await dbSpacesRepository.insert({
-        name: nameBuilder(),
-        status: 'ACTIVE',
-      });
-      const spaceId = space.generatedMaps[0].id;
-      await dbMembersRepository.insert({
-        user: activeUser.generatedMaps[0],
-        space: space.generatedMaps[0],
-        name: nameBuilder(),
-        role: 'MEMBER',
-        status: 'ACTIVE',
-        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
-        inviteExpiresAt: null,
-      });
-
-      await expect(
-        membersRepository.renewInvite({
-          spaceId,
-          userId: activeUserId,
-          inviteExpiresAt: faker.date.future(),
-        }),
-      ).rejects.toThrow('Only a pending invitation can be renewed.');
-    });
-
-    it('should throw when trying to renew a declined member', async () => {
-      const declinedUser = await dbUserRepo.insert({ status: 'PENDING' });
-      const declinedUserId = declinedUser.generatedMaps[0].id as User['id'];
-      const space = await dbSpacesRepository.insert({
-        name: nameBuilder(),
-        status: 'ACTIVE',
-      });
-      const spaceId = space.generatedMaps[0].id;
-      await dbMembersRepository.insert({
-        user: declinedUser.generatedMaps[0],
-        space: space.generatedMaps[0],
-        name: nameBuilder(),
-        role: 'MEMBER',
-        status: 'DECLINED',
-        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
-        inviteExpiresAt: null,
-      });
-
-      await expect(
-        membersRepository.renewInvite({
-          spaceId,
-          userId: declinedUserId,
-          inviteExpiresAt: faker.date.future(),
-        }),
-      ).rejects.toThrow('Only a pending invitation can be renewed.');
     });
   });
 

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -968,7 +968,7 @@ describe('MembersRepository', () => {
     });
 
     it('should throw when reinviting a declined member to the same space', async () => {
-      // A declined invite cannot be resent; re-inviting must be rejected.
+      // A declined invite cannot be renewed; re-inviting must be rejected.
       const spaceName = nameBuilder();
       const adminName = nameBuilder();
       const { user: owner, authPayload } = await createSiweUser();

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -1124,6 +1124,130 @@ describe('MembersRepository', () => {
     });
   });
 
+  describe('renewInvite', () => {
+    it('should refresh the expiry of an expired pending invite, preserving the invite metadata', async () => {
+      const invitedBy = faker.number.int({ max: DB_MAX_SAFE_INTEGER });
+      const inviteeName = nameBuilder();
+      const expiredAt = faker.date.past();
+      const renewedInviteExpiresAt = faker.date.future();
+      const invitee = await dbUserRepo.insert({ status: 'PENDING' });
+      const inviteeId = invitee.generatedMaps[0].id as User['id'];
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      const memberInsert = await dbMembersRepository.insert({
+        user: invitee.generatedMaps[0],
+        space: space.generatedMaps[0],
+        name: inviteeName,
+        role: 'MEMBER',
+        status: 'INVITED',
+        invitedBy,
+        inviteExpiresAt: expiredAt,
+      });
+      const memberId = memberInsert.identifiers[0].id as Member['id'];
+
+      await expect(
+        membersRepository.renewInvite({
+          spaceId,
+          userId: inviteeId,
+          inviteExpiresAt: renewedInviteExpiresAt,
+        }),
+      ).resolves.toEqual({
+        userId: inviteeId,
+        spaceId,
+        name: inviteeName,
+        role: 'MEMBER',
+        status: 'INVITED',
+        invitedBy,
+      });
+
+      await expect(
+        dbMembersRepository.findOneOrFail({ where: { id: memberId } }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          id: memberId,
+          name: inviteeName,
+          role: 'MEMBER',
+          status: 'INVITED',
+          invitedBy,
+          inviteExpiresAt: renewedInviteExpiresAt,
+        }),
+      );
+    });
+
+    it('should throw a NotFoundException when the member does not exist', async () => {
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+
+      await expect(
+        membersRepository.renewInvite({
+          spaceId,
+          userId: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+          inviteExpiresAt: faker.date.future(),
+        }),
+      ).rejects.toThrow('Member not found.');
+    });
+
+    it('should throw when trying to renew an active member', async () => {
+      const activeUser = await dbUserRepo.insert({ status: 'ACTIVE' });
+      const activeUserId = activeUser.generatedMaps[0].id as User['id'];
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: activeUser.generatedMaps[0],
+        space: space.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'MEMBER',
+        status: 'ACTIVE',
+        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        inviteExpiresAt: null,
+      });
+
+      await expect(
+        membersRepository.renewInvite({
+          spaceId,
+          userId: activeUserId,
+          inviteExpiresAt: faker.date.future(),
+        }),
+      ).rejects.toThrow('Only a pending invitation can be renewed.');
+    });
+
+    it('should throw when trying to renew a declined member', async () => {
+      const declinedUser = await dbUserRepo.insert({ status: 'PENDING' });
+      const declinedUserId = declinedUser.generatedMaps[0].id as User['id'];
+      const space = await dbSpacesRepository.insert({
+        name: nameBuilder(),
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: declinedUser.generatedMaps[0],
+        space: space.generatedMaps[0],
+        name: nameBuilder(),
+        role: 'MEMBER',
+        status: 'DECLINED',
+        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        inviteExpiresAt: null,
+      });
+
+      await expect(
+        membersRepository.renewInvite({
+          spaceId,
+          userId: declinedUserId,
+          inviteExpiresAt: faker.date.future(),
+        }),
+      ).rejects.toThrow('Only a pending invitation can be renewed.');
+    });
+  });
+
   describe('acceptInvite', () => {
     it('should accept an invite to a space, setting the member and user to ACTIVE', async () => {
       const memberInvitedBy = faker.number.int({ max: DB_MAX_SAFE_INTEGER });

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -967,6 +967,59 @@ describe('MembersRepository', () => {
       );
     });
 
+    it('should throw when reinviting a declined member to the same space', async () => {
+      // A declined invite cannot be resent; re-inviting must be rejected.
+      const spaceName = nameBuilder();
+      const adminName = nameBuilder();
+      const { user: owner, authPayload } = await createSiweUser();
+      const { user: declinedMember } = await createSiweUser();
+      const declinedMemberAddress = getAddress(faker.finance.ethereumAddress());
+      await dbWalletRepo.insert({
+        user: declinedMember,
+        address: declinedMemberAddress,
+      });
+      const space = await dbSpacesRepository.insert({
+        name: spaceName,
+        status: 'ACTIVE',
+      });
+      const spaceId = space.generatedMaps[0].id;
+      await dbMembersRepository.insert({
+        user: owner,
+        space: space.generatedMaps[0],
+        name: adminName,
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+      });
+      await dbMembersRepository.insert({
+        user: declinedMember,
+        space: space.generatedMaps[0],
+        name: faker.person.firstName(),
+        role: 'MEMBER',
+        status: 'DECLINED',
+        invitedBy: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+        inviteExpiresAt: null,
+      });
+
+      await expect(
+        membersRepository.inviteUsers({
+          authPayload,
+          spaceId,
+          users: [
+            {
+              type: InviteType.Wallet,
+              address: declinedMemberAddress,
+              role: 'ADMIN',
+              name: faker.person.firstName(),
+            },
+          ],
+          inviteExpiresAt: faker.date.future(),
+        }),
+      ).rejects.toThrow(
+        `${declinedMemberAddress} is already in this workspace or has a pending invite.`,
+      );
+    });
+
     it('should invite by email, creating a PENDING placeholder user', async () => {
       const inviteExpiresAt = faker.date.future();
       const { user: owner, authPayload } = await createSiweUser();

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -52,16 +52,13 @@ export interface IMembersRepository {
   }): Promise<Array<Invitation>>;
 
   /**
-   * Renews a pending space invitation, refreshing its expiry.
-   * Only invitations in the `INVITED` state can be renewed; the original
-   * `invitedBy`, `name` and `role` are preserved. Active or declined
-   * members cannot be renewed.
+   * Refreshes the expiry of an existing invite. Callers are responsible for
+   * loading the member and enforcing that it is still pending.
    */
   renewInvite(args: {
-    spaceId: Space['id'];
-    userId: User['id'];
+    memberId: Member['id'];
     inviteExpiresAt: Date;
-  }): Promise<Invitation>;
+  }): Promise<void>;
 
   /**
    * Accepts a pending space invite for the authenticated user.

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -52,6 +52,18 @@ export interface IMembersRepository {
   }): Promise<Array<Invitation>>;
 
   /**
+   * Renews a pending space invitation, refreshing its expiry.
+   * Only invitations in the `INVITED` state can be renewed; the original
+   * `invitedBy`, `name` and `role` are preserved. Active or declined
+   * members cannot be renewed.
+   */
+  renewInvite(args: {
+    spaceId: Space['id'];
+    userId: User['id'];
+    inviteExpiresAt: Date;
+  }): Promise<Invitation>;
+
+  /**
    * Accepts a pending space invite for the authenticated user.
    * Expired invites cannot be accepted.
    */

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -39,8 +39,10 @@ export interface IMembersRepository {
 
   /**
    * Invites users to a space until the provided expiry date.
-   * Existing invited members are overwritten with the new invite data.
-   * Active members cannot be invited again.
+   * Existing invited members are renewed: the stored invite data is
+   * overwritten with the new invite, including a refreshed expiry. This
+   * doubles as resending a (lapsed) invite.
+   * Active and declined members cannot be (re-)invited.
    */
   inviteUsers(args: {
     authPayload: AuthPayload;

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import type { EntityManager } from 'typeorm';
 import { QueryFailedError } from 'typeorm';
 import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
@@ -255,6 +256,100 @@ describe('MembersRepository', () => {
         ),
       );
       expect(entityManager.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe('renewInvite', () => {
+    let dbMembersRepository: { findOne: jest.Mock };
+
+    beforeEach(() => {
+      dbMembersRepository = { findOne: jest.fn() };
+      postgresDatabaseService.getRepository = jest
+        .fn()
+        .mockResolvedValue(dbMembersRepository);
+    });
+
+    it('should refresh the expiry of a pending invite, preserving the invite metadata', async () => {
+      const existingMember = memberBuilder()
+        .with('space', space)
+        .with('status', 'INVITED')
+        .with('role', 'MEMBER')
+        .with('invitedBy', authenticatedUserId)
+        .with('inviteExpiresAt', faker.date.past())
+        .build();
+      dbMembersRepository.findOne.mockResolvedValue(existingMember);
+
+      await expect(
+        target.renewInvite({
+          spaceId: space.id,
+          userId: existingMember.user.id,
+          inviteExpiresAt,
+        }),
+      ).resolves.toEqual({
+        userId: existingMember.user.id,
+        spaceId: space.id,
+        name: existingMember.name,
+        role: existingMember.role,
+        status: 'INVITED',
+        invitedBy: existingMember.invitedBy,
+      });
+
+      expect(entityManager.update).toHaveBeenCalledWith(
+        DbMember,
+        existingMember.id,
+        { inviteExpiresAt },
+      );
+    });
+
+    it('should throw a NotFoundException when the member does not exist', async () => {
+      dbMembersRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        target.renewInvite({
+          spaceId: space.id,
+          userId: faker.number.int(),
+          inviteExpiresAt,
+        }),
+      ).rejects.toThrow(new NotFoundException('Member not found.'));
+      expect(entityManager.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw a ConflictException when the member is active', async () => {
+      const existingMember = memberBuilder()
+        .with('space', space)
+        .with('status', 'ACTIVE')
+        .build();
+      dbMembersRepository.findOne.mockResolvedValue(existingMember);
+
+      await expect(
+        target.renewInvite({
+          spaceId: space.id,
+          userId: existingMember.user.id,
+          inviteExpiresAt,
+        }),
+      ).rejects.toThrow(
+        new ConflictException('Only a pending invitation can be renewed.'),
+      );
+      expect(entityManager.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw a ConflictException when the member declined (not renewable)', async () => {
+      const existingMember = memberBuilder()
+        .with('space', space)
+        .with('status', 'DECLINED')
+        .build();
+      dbMembersRepository.findOne.mockResolvedValue(existingMember);
+
+      await expect(
+        target.renewInvite({
+          spaceId: space.id,
+          userId: existingMember.user.id,
+          inviteExpiresAt,
+        }),
+      ).rejects.toThrow(
+        new ConflictException('Only a pending invitation can be renewed.'),
+      );
+      expect(entityManager.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -191,6 +191,39 @@ describe('MembersRepository', () => {
       expect(entityManager.update).not.toHaveBeenCalled();
     });
 
+    it('should throw without attempting an insert when the existing member declined', async () => {
+      // A declined invite cannot be resent: re-inviting must be rejected
+      // rather than reviving the member.
+      const existingMember = memberBuilder()
+        .with('space', space)
+        .with('status', 'DECLINED')
+        .build();
+      const wallet = walletBuilder().with('user', existingMember.user).build();
+      const userToInvite = {
+        type: InviteType.Wallet,
+        address: wallet.address,
+        role: 'ADMIN' as const,
+        name: nameBuilder(),
+      };
+      entityManager.find.mockResolvedValue([wallet]);
+      entityManager.findOne.mockResolvedValue(existingMember);
+
+      await expect(
+        target.inviteUsers({
+          authPayload,
+          spaceId: space.id,
+          users: [userToInvite],
+          inviteExpiresAt,
+        }),
+      ).rejects.toThrow(
+        new UniqueConstraintError(
+          `${wallet.address} is already in this workspace or has a pending invite.`,
+        ),
+      );
+      expect(entityManager.insert).not.toHaveBeenCalled();
+      expect(entityManager.update).not.toHaveBeenCalled();
+    });
+
     it('should translate insert unique constraint races to a domain error', async () => {
       const wallet = walletBuilder().build();
       const userToInvite = {

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -193,8 +193,6 @@ describe('MembersRepository', () => {
     });
 
     it('should throw without attempting an insert when the existing member declined', async () => {
-      // A declined invite cannot be resent: re-inviting must be rejected
-      // rather than reviving the member.
       const existingMember = memberBuilder()
         .with('space', space)
         .with('status', 'DECLINED')

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { faker } from '@faker-js/faker';
-import { ConflictException, NotFoundException } from '@nestjs/common';
 import type { EntityManager } from 'typeorm';
 import { QueryFailedError } from 'typeorm';
 import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
@@ -258,96 +257,23 @@ describe('MembersRepository', () => {
   });
 
   describe('renewInvite', () => {
-    let dbMembersRepository: { findOne: jest.Mock };
+    let dbMembersRepository: { update: jest.Mock };
 
     beforeEach(() => {
-      dbMembersRepository = { findOne: jest.fn() };
+      dbMembersRepository = { update: jest.fn() };
       postgresDatabaseService.getRepository = jest
         .fn()
         .mockResolvedValue(dbMembersRepository);
     });
 
-    it('should refresh the expiry of a pending invite, preserving the invite metadata', async () => {
-      const existingMember = memberBuilder()
-        .with('space', space)
-        .with('status', 'INVITED')
-        .with('role', 'MEMBER')
-        .with('invitedBy', authenticatedUserId)
-        .with('inviteExpiresAt', faker.date.past())
-        .build();
-      dbMembersRepository.findOne.mockResolvedValue(existingMember);
+    it("should update the member's inviteExpiresAt by id", async () => {
+      const memberId = faker.number.int();
 
-      await expect(
-        target.renewInvite({
-          spaceId: space.id,
-          userId: existingMember.user.id,
-          inviteExpiresAt,
-        }),
-      ).resolves.toEqual({
-        userId: existingMember.user.id,
-        spaceId: space.id,
-        name: existingMember.name,
-        role: existingMember.role,
-        status: 'INVITED',
-        invitedBy: existingMember.invitedBy,
+      await target.renewInvite({ memberId, inviteExpiresAt });
+
+      expect(dbMembersRepository.update).toHaveBeenCalledWith(memberId, {
+        inviteExpiresAt,
       });
-
-      expect(entityManager.update).toHaveBeenCalledWith(
-        DbMember,
-        existingMember.id,
-        { inviteExpiresAt },
-      );
-    });
-
-    it('should throw a NotFoundException when the member does not exist', async () => {
-      dbMembersRepository.findOne.mockResolvedValue(null);
-
-      await expect(
-        target.renewInvite({
-          spaceId: space.id,
-          userId: faker.number.int(),
-          inviteExpiresAt,
-        }),
-      ).rejects.toThrow(new NotFoundException('Member not found.'));
-      expect(entityManager.update).not.toHaveBeenCalled();
-    });
-
-    it('should throw a ConflictException when the member is active', async () => {
-      const existingMember = memberBuilder()
-        .with('space', space)
-        .with('status', 'ACTIVE')
-        .build();
-      dbMembersRepository.findOne.mockResolvedValue(existingMember);
-
-      await expect(
-        target.renewInvite({
-          spaceId: space.id,
-          userId: existingMember.user.id,
-          inviteExpiresAt,
-        }),
-      ).rejects.toThrow(
-        new ConflictException('Only a pending invitation can be renewed.'),
-      );
-      expect(entityManager.update).not.toHaveBeenCalled();
-    });
-
-    it('should throw a ConflictException when the member declined (not renewable)', async () => {
-      const existingMember = memberBuilder()
-        .with('space', space)
-        .with('status', 'DECLINED')
-        .build();
-      dbMembersRepository.findOne.mockResolvedValue(existingMember);
-
-      await expect(
-        target.renewInvite({
-          spaceId: space.id,
-          userId: existingMember.user.id,
-          inviteExpiresAt,
-        }),
-      ).rejects.toThrow(
-        new ConflictException('Only a pending invitation can be renewed.'),
-      );
-      expect(entityManager.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -251,6 +251,36 @@ export class MembersRepository implements IMembersRepository {
     throw duplicateInviteError();
   }
 
+  public async renewInvite(args: {
+    spaceId: Space['id'];
+    userId: User['id'];
+    inviteExpiresAt: Date;
+  }): Promise<Invitation> {
+    const member = await this.findOneOrFail({
+      user: { id: args.userId },
+      space: { id: args.spaceId },
+    });
+
+    if (member.status !== 'INVITED') {
+      throw new ConflictException('Only a pending invitation can be renewed.');
+    }
+
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      await entityManager.update(DbMember, member.id, {
+        inviteExpiresAt: args.inviteExpiresAt,
+      });
+    });
+
+    return {
+      userId: args.userId,
+      spaceId: args.spaceId,
+      name: member.name,
+      role: member.role,
+      status: member.status,
+      invitedBy: member.invitedBy,
+    };
+  }
+
   public async acceptInvite(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -252,33 +252,14 @@ export class MembersRepository implements IMembersRepository {
   }
 
   public async renewInvite(args: {
-    spaceId: Space['id'];
-    userId: User['id'];
+    memberId: Member['id'];
     inviteExpiresAt: Date;
-  }): Promise<Invitation> {
-    const member = await this.findOneOrFail({
-      user: { id: args.userId },
-      space: { id: args.spaceId },
+  }): Promise<void> {
+    const membersRepository =
+      await this.postgresDatabaseService.getRepository(DbMember);
+    await membersRepository.update(args.memberId, {
+      inviteExpiresAt: args.inviteExpiresAt,
     });
-
-    if (member.status !== 'INVITED') {
-      throw new ConflictException('Only a pending invitation can be renewed.');
-    }
-
-    await this.postgresDatabaseService.transaction(async (entityManager) => {
-      await entityManager.update(DbMember, member.id, {
-        inviteExpiresAt: args.inviteExpiresAt,
-      });
-    });
-
-    return {
-      userId: args.userId,
-      spaceId: args.spaceId,
-      name: member.name,
-      role: member.role,
-      status: member.status,
-      invitedBy: member.invitedBy,
-    };
   }
 
   public async acceptInvite(args: {


### PR DESCRIPTION
## WA-2313 — BE: Invitation can be resent

Linear: https://linear.app/safe-global/issue/WA-2313/be-invitation-can-be-resent

### What & why
Adds an admin-only endpoint to renew a pending space-member invitation, refreshing its expiry. There is no "invitation id" in the model (invitations are member rows keyed by `(user, space)`), and reusing the invite endpoint would force the frontend to reconstruct a wallet payload from data it can't reliably reconstruct (the members list doesn't expose wallet addresses, and a user can have multiple wallets). So renewal is done server-side by `userId`: the backend resets the existing invite itself — no payload, no wallet-address exposure.

### Endpoint
`POST /v1/spaces/:spaceId/members/:userId/invite/renew`
- Admin-only (reuses the existing active-admin check).
- `INVITED` (expired or not) → refreshes `inviteExpiresAt`; status stays `INVITED`; `invitedBy`/`name`/`role` preserved.
- `DECLINED` / `ACTIVE` → 409 (not renewable).
- member not found → 404; non-admin → 403.

### Changes
- src/modules/spaces/routes/members.controller.ts — new `renewInvite` route (guards + Swagger), mirrors accept/decline/role routes.
- src/modules/spaces/routes/members.service.ts — `renewInvite`: active-admin check + computes `now + inviteTtlMs`, delegates to repo.
- src/modules/users/domain/members.repository.ts — `renewInvite`: loads member by `(userId, spaceId)`, status guard, updates only `inviteExpiresAt`, returns the `Invitation`.
- src/modules/users/domain/members.repository.interface.ts — `renewInvite` signature + doc; clarified `inviteUsers` doc (renew-on-reinvite; active/declined can't be re-invited).
- Tests: repo unit + integration (renew expired-pending preserves metadata; not-found/active/declined rejected) and controller e2e (happy / 403 / 404 / 409).

Also includes the earlier commit hardening the existing invite-renew path with tests (declined not resendable; active rejected).

### Scope notes
- Renewal currently only refreshes the invite's expiry. Re-sending the invite **email** is out of scope — invite-email delivery isn't implemented yet; this endpoint is where that hook will live (follow-up).
- The frontend need here is renew-only (it does not display the invited wallet address), so no wallet address is exposed.

### Testing
- `yarn test src/modules/users/domain/members.repository.spec.ts`
- `yarn test:integration src/modules/users/domain/members.repository.integration.spec.ts`
- `yarn test:e2e src/modules/spaces/routes/members.controller.e2e-spec.ts`
- (integration/e2e require the local Postgres)