### PR TITLE
feat(spaces): send email for space invites

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -210,6 +210,12 @@
     "required": false
   },
   {
+    "name": "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "description": "Path to the projected web identity token file used for AWS IRSA credentials",
+    "defaultValue": "",
+    "required": false
+  },
+  {
     "name": "FF_SES_EMAIL",
     "description": "Enable SES email module (BullMQ queue + SES sending)",
     "defaultValue": "false",

--- a/.env.sample.json
+++ b/.env.sample.json
@@ -210,6 +210,18 @@
     "required": false
   },
   {
+    "name": "SES_AWS_ACCESS_KEY_ID",
+    "description": "AWS access key ID with SES email sending permissions",
+    "defaultValue": "",
+    "required": false
+  },
+  {
+    "name": "SES_AWS_SECRET_ACCESS_KEY",
+    "description": "AWS secret access key with SES email sending permissions",
+    "defaultValue": "",
+    "required": false
+  },
+  {
     "name": "AWS_WEB_IDENTITY_TOKEN_FILE",
     "description": "Path to the projected web identity token file used for AWS IRSA credentials",
     "defaultValue": "",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@aws-sdk/client-kms": "3.1056.0",
     "@aws-sdk/client-s3": "3.1056.0",
     "@aws-sdk/client-sesv2": "3.1056.0",
+    "@aws-sdk/credential-provider-web-identity": "3.972.45",
     "@aws-sdk/lib-storage": "3.1056.0",
     "@aws-sdk/s3-request-presigner": "3.1056.0",
     "@blockaid/client": "^0.65.0",

--- a/src/config/configuration.validator.spec.ts
+++ b/src/config/configuration.validator.spec.ts
@@ -289,6 +289,47 @@ describe('Configuration validator', () => {
         `Configuration is invalid: ${key} is required in production and staging environments`,
       );
     });
+
+    it(`should require AWS_WEB_IDENTITY_TOKEN_FILE when SES email is enabled in ${env} environment`, () => {
+      process.env.NODE_ENV = 'production';
+      const config = {
+        ...omit(validConfiguration, 'AWS_WEB_IDENTITY_TOKEN_FILE'),
+        CGW_ENV: env,
+        FF_SES_EMAIL: 'true',
+      };
+
+      expect(() =>
+        configurationValidator(config, RootConfigurationSchema),
+      ).toThrow(
+        `Configuration is invalid: AWS_WEB_IDENTITY_TOKEN_FILE is required in production and staging environments when SES email is enabled`,
+      );
+    });
+
+    it(`should not require AWS_WEB_IDENTITY_TOKEN_FILE when SES email is disabled in ${env} environment`, () => {
+      process.env.NODE_ENV = 'production';
+      const config = {
+        ...omit(validConfiguration, 'AWS_WEB_IDENTITY_TOKEN_FILE'),
+        CGW_ENV: env,
+        FF_SES_EMAIL: 'false',
+      };
+
+      expect(configurationValidator(config, RootConfigurationSchema)).toBe(
+        config,
+      );
+    });
+  });
+
+  it('should not require AWS_WEB_IDENTITY_TOKEN_FILE when SES email is enabled outside staging and production', () => {
+    process.env.NODE_ENV = 'production';
+    const config = {
+      ...omit(validConfiguration, 'AWS_WEB_IDENTITY_TOKEN_FILE'),
+      CGW_ENV: 'development',
+      FF_SES_EMAIL: 'true',
+    };
+
+    expect(configurationValidator(config, RootConfigurationSchema)).toBe(
+      config,
+    );
   });
 
   describe('RELAY_NO_FEE_CAMPAIGN relay rules validation', () => {

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -156,7 +156,11 @@ export default (): ReturnType<typeof configuration> => ({
     ses: {
       fromEmail: faker.internet.email(),
       fromName: faker.company.name(),
-      webIdentityTokenFile: faker.system.filePath(),
+      aws: {
+        accessKeyId: 'dummy',
+        secretAccessKey: 'dummy',
+        webIdentityTokenFile: faker.system.filePath(),
+      },
       queue: {
         removeOnComplete: {
           age: faker.number.int({ min: 0, max: 3600 }),

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -23,6 +23,9 @@ export default (): ReturnType<typeof configuration> => ({
     port: faker.internet.port().toString(),
     allowCors: faker.datatype.boolean(),
   },
+  aws: {
+    webIdentityTokenFile: faker.system.filePath(),
+  },
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),
     nonceTtlSeconds: faker.number.int(),
@@ -156,7 +159,6 @@ export default (): ReturnType<typeof configuration> => ({
     ses: {
       fromEmail: faker.internet.email(),
       fromName: faker.company.name(),
-      webIdentityTokenFile: faker.system.filePath(),
       queue: {
         removeOnComplete: {
           age: faker.number.int({ min: 0, max: 3600 }),

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -23,9 +23,6 @@ export default (): ReturnType<typeof configuration> => ({
     port: faker.internet.port().toString(),
     allowCors: faker.datatype.boolean(),
   },
-  aws: {
-    webIdentityTokenFile: faker.system.filePath(),
-  },
   auth: {
     token: faker.string.hexadecimal({ length: 32 }),
     nonceTtlSeconds: faker.number.int(),
@@ -159,6 +156,7 @@ export default (): ReturnType<typeof configuration> => ({
     ses: {
       fromEmail: faker.internet.email(),
       fromName: faker.company.name(),
+      webIdentityTokenFile: faker.system.filePath(),
       queue: {
         removeOnComplete: {
           age: faker.number.int({ min: 0, max: 3600 }),

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -156,6 +156,7 @@ export default (): ReturnType<typeof configuration> => ({
     ses: {
       fromEmail: faker.internet.email(),
       fromName: faker.company.name(),
+      webIdentityTokenFile: faker.system.filePath(),
       queue: {
         removeOnComplete: {
           age: faker.number.int({ min: 0, max: 3600 }),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -268,8 +268,12 @@ export default () => ({
       fromEmail: process.env.AWS_SES_FROM_EMAIL,
       // Display name shown in the "From" field. Defaults to 'Safe'.
       fromName: process.env.AWS_SES_FROM_NAME || 'Safe',
-      // EKS service-account token path. SES uses this for IRSA in deployed environments.
-      webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
+      aws: {
+        accessKeyId: process.env.SES_AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.SES_AWS_SECRET_ACCESS_KEY,
+        // EKS service-account token path. SES uses this for IRSA in deployed environments.
+        webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
+      },
       // BullMQ queue configuration for email sending.
       queue: {
         removeOnComplete: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -39,11 +39,6 @@ export default () => ({
     port: process.env.APPLICATION_PORT || '3000',
     allowCors: process.env.ALLOW_CORS?.toLowerCase() === 'true',
   },
-  aws: {
-    // EKS service-account token path. When present, AWS clients can use IRSA
-    // instead of static AWS env keys.
-    webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
-  },
   auth: {
     token: process.env.AUTH_TOKEN,
     nonceTtlSeconds: Number.parseInt(
@@ -273,6 +268,8 @@ export default () => ({
       fromEmail: process.env.AWS_SES_FROM_EMAIL,
       // Display name shown in the "From" field. Defaults to 'Safe'.
       fromName: process.env.AWS_SES_FROM_NAME || 'Safe',
+      // EKS service-account token path. SES uses this for IRSA in deployed environments.
+      webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
       // BullMQ queue configuration for email sending.
       queue: {
         removeOnComplete: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -39,6 +39,11 @@ export default () => ({
     port: process.env.APPLICATION_PORT || '3000',
     allowCors: process.env.ALLOW_CORS?.toLowerCase() === 'true',
   },
+  aws: {
+    // EKS service-account token path. When present, AWS clients can use IRSA
+    // instead of static AWS env keys.
+    webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
+  },
   auth: {
     token: process.env.AUTH_TOKEN,
     nonceTtlSeconds: Number.parseInt(
@@ -268,9 +273,6 @@ export default () => ({
       fromEmail: process.env.AWS_SES_FROM_EMAIL,
       // Display name shown in the "From" field. Defaults to 'Safe'.
       fromName: process.env.AWS_SES_FROM_NAME || 'Safe',
-      // EKS service-account token path. When present, SES uses IRSA credentials
-      // instead of static AWS env keys injected for S3/KMS.
-      webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
       // BullMQ queue configuration for email sending.
       queue: {
         removeOnComplete: {

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -268,6 +268,9 @@ export default () => ({
       fromEmail: process.env.AWS_SES_FROM_EMAIL,
       // Display name shown in the "From" field. Defaults to 'Safe'.
       fromName: process.env.AWS_SES_FROM_NAME || 'Safe',
+      // EKS service-account token path. When present, SES uses IRSA credentials
+      // instead of static AWS env keys injected for S3/KMS.
+      webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
       // BullMQ queue configuration for email sending.
       queue: {
         removeOnComplete: {

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -68,6 +68,7 @@ export const RootConfigurationSchema = z
     AWS_SES_FROM_EMAIL: z.email().optional(),
     AWS_SES_FROM_NAME: z.string().optional(),
     AWS_WEB_IDENTITY_TOKEN_FILE: z.string().optional(),
+    FF_SES_EMAIL: z.string().optional(),
     BLOCKLIST_ENCRYPTED_DATA: z.string(),
     BLOCKLIST_SECRET_KEY: z.string(),
     BLOCKLIST_SECRET_SALT: z.string(),
@@ -214,6 +215,20 @@ export const RootConfigurationSchema = z
           path: [field],
         });
       }
+    }
+
+    // SES permissions are set via IRSA in deployed environments, not static AWS keys.
+    if (
+      config.CGW_ENV &&
+      ['production', 'staging'].includes(config.CGW_ENV) &&
+      config.FF_SES_EMAIL?.toLowerCase() === 'true' &&
+      !config.AWS_WEB_IDENTITY_TOKEN_FILE
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `is required in production and staging environments when SES email is enabled`,
+        path: ['AWS_WEB_IDENTITY_TOKEN_FILE'],
+      });
     }
   });
 

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -67,6 +67,7 @@ export const RootConfigurationSchema = z
     AWS_REGION: z.string().optional(),
     AWS_SES_FROM_EMAIL: z.email().optional(),
     AWS_SES_FROM_NAME: z.string().optional(),
+    AWS_WEB_IDENTITY_TOKEN_FILE: z.string().optional(),
     BLOCKLIST_ENCRYPTED_DATA: z.string(),
     BLOCKLIST_SECRET_KEY: z.string(),
     BLOCKLIST_SECRET_SALT: z.string(),

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -194,41 +194,35 @@ export const RootConfigurationSchema = z
   })
   .superRefine((config, ctx) => {
     // Check for AWS_* and Blockaid fields in production and staging environments
-    for (const field of [
-      'AWS_ACCESS_KEY_ID',
-      'AWS_KMS_ENCRYPTION_KEY_ID',
-      'AWS_SECRET_ACCESS_KEY',
-      'AWS_REGION',
-      'CSV_AWS_ACCESS_KEY_ID',
-      'CSV_AWS_SECRET_ACCESS_KEY',
-      'BLOCKAID_CLIENT_API_KEY',
+    for (const {
+      field,
+      requiredWhen = true,
+      message = 'is required in production and staging environments',
+    } of [
+      { field: 'AWS_ACCESS_KEY_ID' },
+      { field: 'AWS_KMS_ENCRYPTION_KEY_ID' },
+      { field: 'AWS_SECRET_ACCESS_KEY' },
+      { field: 'AWS_REGION' },
+      { field: 'CSV_AWS_ACCESS_KEY_ID' },
+      { field: 'CSV_AWS_SECRET_ACCESS_KEY' },
+      { field: 'BLOCKAID_CLIENT_API_KEY' },
+      // SES permissions are set via IRSA in deployed environments, not static AWS keys.
+      {
+        field: 'AWS_WEB_IDENTITY_TOKEN_FILE',
+        requiredWhen: config.FF_SES_EMAIL?.toLowerCase() === 'true',
+        message:
+          'is required in production and staging environments when SES email is enabled',
+      },
     ]) {
       if (
         config.CGW_ENV &&
         config instanceof Object &&
         ['production', 'staging'].includes(config.CGW_ENV) &&
+        requiredWhen &&
         !(config as Record<string, unknown>)[field]
       ) {
-        ctx.addIssue({
-          code: 'custom',
-          message: `is required in production and staging environments`,
-          path: [field],
-        });
+        ctx.addIssue({ code: 'custom', message, path: [field] });
       }
-    }
-
-    // SES permissions are set via IRSA in deployed environments, not static AWS keys.
-    if (
-      config.CGW_ENV &&
-      ['production', 'staging'].includes(config.CGW_ENV) &&
-      config.FF_SES_EMAIL?.toLowerCase() === 'true' &&
-      !config.AWS_WEB_IDENTITY_TOKEN_FILE
-    ) {
-      ctx.addIssue({
-        code: 'custom',
-        message: `is required in production and staging environments when SES email is enabled`,
-        path: ['AWS_WEB_IDENTITY_TOKEN_FILE'],
-      });
     }
   });
 

--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -68,6 +68,8 @@ export const RootConfigurationSchema = z
     AWS_SES_FROM_EMAIL: z.email().optional(),
     AWS_SES_FROM_NAME: z.string().optional(),
     AWS_WEB_IDENTITY_TOKEN_FILE: z.string().optional(),
+    SES_AWS_ACCESS_KEY_ID: z.string().optional(),
+    SES_AWS_SECRET_ACCESS_KEY: z.string().optional(),
     FF_SES_EMAIL: z.string().optional(),
     BLOCKLIST_ENCRYPTED_DATA: z.string(),
     BLOCKLIST_SECRET_KEY: z.string(),

--- a/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
-import { MessageRejected } from '@aws-sdk/client-sesv2';
+import { MessageRejected, SESv2Client } from '@aws-sdk/client-sesv2';
+import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 import { faker } from '@faker-js/faker';
 import { FakeConfigurationService } from '@/config/__tests__/fake.configuration.service';
 import { AwsSesEmailService } from '@/modules/email/ses/datasources/aws-ses-email.service';
@@ -17,6 +18,10 @@ jest.mock('@aws-sdk/client-sesv2', () => ({
     send: mockSend,
   })),
   SendEmailCommand: jest.fn().mockImplementation((input) => input),
+}));
+
+jest.mock('@aws-sdk/credential-provider-web-identity', () => ({
+  fromTokenFile: jest.fn().mockReturnValue('mockCredentials'),
 }));
 
 describe('SesEmailService', () => {
@@ -40,6 +45,31 @@ describe('SesEmailService', () => {
     fakeConfigurationService.set('email.ses.fromName', sesFromName);
 
     service = new AwsSesEmailService(fakeConfigurationService);
+  });
+
+  describe('constructor', () => {
+    it('should use the default AWS credential chain when web identity token file is not set', () => {
+      expect(SESv2Client).toHaveBeenCalledWith({
+        maxAttempts: 1,
+      });
+      expect(fromTokenFile).not.toHaveBeenCalled();
+    });
+
+    it('should use web identity credentials when web identity token file is set', () => {
+      jest.clearAllMocks();
+      fakeConfigurationService.set(
+        'email.ses.webIdentityTokenFile',
+        '/var/run/secrets/eks.amazonaws.com/serviceaccount/token',
+      );
+
+      service = new AwsSesEmailService(fakeConfigurationService);
+
+      expect(fromTokenFile).toHaveBeenCalledTimes(1);
+      expect(SESv2Client).toHaveBeenCalledWith({
+        maxAttempts: 1,
+        credentials: 'mockCredentials',
+      });
+    });
   });
 
   describe('send', () => {

--- a/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
@@ -58,7 +58,7 @@ describe('SesEmailService', () => {
     it('should use web identity credentials when web identity token file is set', () => {
       jest.clearAllMocks();
       fakeConfigurationService.set(
-        'email.ses.webIdentityTokenFile',
+        'aws.webIdentityTokenFile',
         '/var/run/secrets/eks.amazonaws.com/serviceaccount/token',
       );
 

--- a/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
@@ -30,6 +30,8 @@ describe('SesEmailService', () => {
 
   const sesFromEmail = faker.internet.email();
   const sesFromName = 'Safe';
+  const accessKeyId = faker.string.uuid();
+  const secretAccessKey = faker.string.uuid();
 
   const sendArgs = (): { to: string; subject: string; htmlBody: string } => ({
     to: faker.internet.email(),
@@ -43,14 +45,23 @@ describe('SesEmailService', () => {
     fakeConfigurationService = new FakeConfigurationService();
     fakeConfigurationService.set('email.ses.fromEmail', sesFromEmail);
     fakeConfigurationService.set('email.ses.fromName', sesFromName);
+    fakeConfigurationService.set('email.ses.aws.accessKeyId', accessKeyId);
+    fakeConfigurationService.set(
+      'email.ses.aws.secretAccessKey',
+      secretAccessKey,
+    );
 
     service = new AwsSesEmailService(fakeConfigurationService);
   });
 
   describe('constructor', () => {
-    it('should use the default AWS credential chain when web identity token file is not set', () => {
+    it('should use SES static credentials when web identity token file is not set', () => {
       expect(SESv2Client).toHaveBeenCalledWith({
         maxAttempts: 1,
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
       });
       expect(fromTokenFile).not.toHaveBeenCalled();
     });
@@ -58,7 +69,7 @@ describe('SesEmailService', () => {
     it('should use web identity credentials when web identity token file is set', () => {
       jest.clearAllMocks();
       fakeConfigurationService.set(
-        'email.ses.webIdentityTokenFile',
+        'email.ses.aws.webIdentityTokenFile',
         '/var/run/secrets/eks.amazonaws.com/serviceaccount/token',
       );
 

--- a/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.spec.ts
@@ -58,7 +58,7 @@ describe('SesEmailService', () => {
     it('should use web identity credentials when web identity token file is set', () => {
       jest.clearAllMocks();
       fakeConfigurationService.set(
-        'aws.webIdentityTokenFile',
+        'email.ses.webIdentityTokenFile',
         '/var/run/secrets/eks.amazonaws.com/serviceaccount/token',
       );
 

--- a/src/modules/email/ses/datasources/aws-ses-email.service.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
-import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
+import {
+  SESv2Client,
+  type SESv2ClientConfig,
+  SendEmailCommand,
+} from '@aws-sdk/client-sesv2';
 import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
@@ -12,6 +16,7 @@ export class AwsSesEmailService implements IEmailService {
   private static readonly SES_CHARSET = 'UTF-8';
   private readonly client: SESv2Client;
   private readonly fromAddress: string;
+  private readonly credentials: SESv2ClientConfig['credentials'];
 
   constructor(
     @Inject(IConfigurationService)
@@ -23,15 +28,27 @@ export class AwsSesEmailService implements IEmailService {
     const fromName =
       this.configurationService.getOrThrow<string>('email.ses.fromName');
     const webIdentityTokenFile = this.configurationService.get<string>(
-      'email.ses.webIdentityTokenFile',
+      'email.ses.aws.webIdentityTokenFile',
     );
+
+    // Local development uses SES-specific static AWS keys. Deployed environments
+    // use IRSA via the projected web identity token file, so SES does not pick up
+    // the generic AWS keys used by other integrations.
+    this.credentials = webIdentityTokenFile
+      ? fromTokenFile()
+      : {
+          accessKeyId: this.configurationService.getOrThrow<string>(
+            'email.ses.aws.accessKeyId',
+          ),
+          secretAccessKey: this.configurationService.getOrThrow<string>(
+            'email.ses.aws.secretAccessKey',
+          ),
+        };
 
     this.client = new SESv2Client({
       maxAttempts: 1, //do not retry at the SDK level, let the JobQueue handle retries with backoff
       // Prefer IRSA over static env keys when running in EKS.
-      ...(webIdentityTokenFile && {
-        credentials: fromTokenFile(),
-      }),
+      credentials: this.credentials,
     });
     this.fromAddress = this.formatRfc5322Address(fromName, fromEmail);
   }

--- a/src/modules/email/ses/datasources/aws-ses-email.service.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.ts
@@ -23,7 +23,7 @@ export class AwsSesEmailService implements IEmailService {
     const fromName =
       this.configurationService.getOrThrow<string>('email.ses.fromName');
     const webIdentityTokenFile = this.configurationService.get<string>(
-      'aws.webIdentityTokenFile',
+      'email.ses.webIdentityTokenFile',
     );
 
     this.client = new SESv2Client({

--- a/src/modules/email/ses/datasources/aws-ses-email.service.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.ts
@@ -23,7 +23,7 @@ export class AwsSesEmailService implements IEmailService {
     const fromName =
       this.configurationService.getOrThrow<string>('email.ses.fromName');
     const webIdentityTokenFile = this.configurationService.get<string>(
-      'email.ses.webIdentityTokenFile',
+      'aws.webIdentityTokenFile',
     );
 
     this.client = new SESv2Client({

--- a/src/modules/email/ses/datasources/aws-ses-email.service.ts
+++ b/src/modules/email/ses/datasources/aws-ses-email.service.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
+import { fromTokenFile } from '@aws-sdk/credential-provider-web-identity';
 import { Inject, Injectable } from '@nestjs/common';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { SesEmailErrorMapper } from '@/modules/email/ses/datasources/ses-email-error.mapper';
@@ -21,9 +22,16 @@ export class AwsSesEmailService implements IEmailService {
     );
     const fromName =
       this.configurationService.getOrThrow<string>('email.ses.fromName');
+    const webIdentityTokenFile = this.configurationService.get<string>(
+      'email.ses.webIdentityTokenFile',
+    );
 
     this.client = new SESv2Client({
       maxAttempts: 1, //do not retry at the SDK level, let the JobQueue handle retries with backoff
+      // Prefer IRSA over static env keys when running in EKS.
+      ...(webIdentityTokenFile && {
+        credentials: fromTokenFile(),
+      }),
     });
     this.fromAddress = this.formatRfc5322Address(fromName, fromEmail);
   }

--- a/src/modules/email/ses/ses-email.module.ts
+++ b/src/modules/email/ses/ses-email.module.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { BullModule, getQueueToken } from '@nestjs/bullmq';
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import type { Queue } from 'bullmq';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { JobQueueService } from '@/datasources/job-queue/job-queue.service';
@@ -15,6 +15,7 @@ import { AwsSesEmailService } from '@/modules/email/ses/datasources/aws-ses-emai
 import { IEmailService } from '@/modules/email/ses/domain/interfaces/email-service.interface';
 import { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.service';
 
+@Global()
 @Module({
   imports: [
     BullModule.registerQueueAsync({

--- a/src/modules/email/ses/ses-email.module.ts
+++ b/src/modules/email/ses/ses-email.module.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { BullModule, getQueueToken } from '@nestjs/bullmq';
-import { Global, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import type { Queue } from 'bullmq';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { JobQueueService } from '@/datasources/job-queue/job-queue.service';
@@ -15,7 +15,6 @@ import { AwsSesEmailService } from '@/modules/email/ses/datasources/aws-ses-emai
 import { IEmailService } from '@/modules/email/ses/domain/interfaces/email-service.interface';
 import { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.service';
 
-@Global()
 @Module({
   imports: [
     BullModule.registerQueueAsync({

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -8,8 +8,13 @@ import {
   siweAuthPayloadDtoBuilder,
 } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import {
+  emailInviteUserDtoBuilder,
+  walletInviteUserDtoBuilder,
+} from '@/modules/spaces/routes/entities/__tests__/invite-user.dto.builder';
 import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import { MembersService } from '@/modules/spaces/routes/members.service';
+import type { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
 import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
 import { userBuilder } from '@/modules/users/datasources/entities/__tests__/users.entity.db.builder';
 import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
@@ -27,6 +32,10 @@ const membersRepositoryMock = {
 const configurationServiceMock = {
   getOrThrow: jest.fn(),
 } as jest.MockedObjectDeep<IConfigurationService>;
+
+const spaceInviteEmailServiceMock = {
+  enqueueInviteEmails: jest.fn(),
+} as jest.MockedObjectDeep<SpaceInviteEmailService>;
 
 describe('MembersService', () => {
   let service: MembersService;
@@ -46,6 +55,7 @@ describe('MembersService', () => {
     service = new MembersService(
       membersRepositoryMock,
       configurationServiceMock,
+      spaceInviteEmailServiceMock,
     );
   });
 
@@ -215,9 +225,56 @@ describe('MembersService', () => {
           users: [],
           inviteExpiresAt: new Date(now.getTime() + INVITE_TTL_MS),
         });
+        expect(
+          spaceInviteEmailServiceMock.enqueueInviteEmails,
+        ).toHaveBeenCalledWith({ users: [], spaceId });
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it('should delegate invite email sending to the SpaceInviteEmailService', async () => {
+      const authPayload = new AuthPayload(oidcAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const emailInvite = emailInviteUserDtoBuilder().build();
+      const walletInvite = walletInviteUserDtoBuilder().build();
+      const inviteUsersDto: InviteUsersDto = {
+        users: [emailInvite, walletInvite],
+      };
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+      const emailInvitation = {
+        userId: faker.number.int({ min: 1 }),
+        spaceId,
+        name: emailInvite.name,
+        role: emailInvite.role,
+        status: 'INVITED' as const,
+        invitedBy: Number(authPayload.sub),
+      };
+      const walletInvitation = {
+        userId: faker.number.int({ min: 1 }),
+        spaceId,
+        name: walletInvite.name,
+        role: walletInvite.role,
+        status: 'INVITED' as const,
+        invitedBy: Number(authPayload.sub),
+      };
+      const invitations = [emailInvitation, walletInvitation];
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.inviteUsers.mockResolvedValue(invitations);
+
+      await expect(
+        service.inviteUser({ authPayload, spaceId, inviteUsersDto }),
+      ).resolves.toEqual(invitations);
+
+      expect(
+        spaceInviteEmailServiceMock.enqueueInviteEmails,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        spaceInviteEmailServiceMock.enqueueInviteEmails,
+      ).toHaveBeenCalledWith({ users: inviteUsersDto.users, spaceId });
     });
   });
 });

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -5,7 +5,7 @@ import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.en
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { AcceptInviteDto } from '@/modules/spaces/routes/entities/accept-invite.dto.entity';
-import type { Invitation as RouteInvitation } from '@/modules/spaces/routes/entities/invitation.entity';
+import type { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
 import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import type {
   MemberDto,
@@ -46,7 +46,7 @@ export class MembersService {
     authPayload: AuthPayload;
     spaceId: Space['id'];
     inviteUsersDto: InviteUsersDto;
-  }): Promise<Array<RouteInvitation>> {
+  }): Promise<Array<Invitation>> {
     await this.assertActiveAdmin({
       authPayload: args.authPayload,
       spaceId: args.spaceId,

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -5,7 +5,7 @@ import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.en
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import type { AcceptInviteDto } from '@/modules/spaces/routes/entities/accept-invite.dto.entity';
-import type { Invitation } from '@/modules/spaces/routes/entities/invitation.entity';
+import type { Invitation as RouteInvitation } from '@/modules/spaces/routes/entities/invitation.entity';
 import type { InviteUsersDto } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
 import type {
   MemberDto,
@@ -13,6 +13,7 @@ import type {
 } from '@/modules/spaces/routes/entities/members.dto.entity';
 import type { UpdateMemberAliasDto } from '@/modules/spaces/routes/entities/update-member-name.dto.entity';
 import type { UpdateRoleDto } from '@/modules/spaces/routes/entities/update-role.dto.entity';
+import { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
 
@@ -25,6 +26,7 @@ export class MembersService {
     private readonly membersRepository: IMembersRepository,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    private readonly spaceInviteEmailService: SpaceInviteEmailService,
   ) {
     this.maxInvites =
       this.configurationService.getOrThrow<number>('spaces.maxInvites');
@@ -33,11 +35,18 @@ export class MembersService {
     );
   }
 
+  /**
+   * Invites users and queues invite emails for email invites.
+   *
+   * @param args.authPayload - Authenticated caller.
+   * @param args.spaceId - Target space ID.
+   * @param args.inviteUsersDto - Users to invite.
+   */
   public async inviteUser(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
     inviteUsersDto: InviteUsersDto;
-  }): Promise<Array<Invitation>> {
+  }): Promise<Array<RouteInvitation>> {
     await this.assertActiveAdmin({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
@@ -45,12 +54,20 @@ export class MembersService {
     if (args.inviteUsersDto.users.length > this.maxInvites) {
       throw new ConflictException('Too many invites.');
     }
-    return await this.membersRepository.inviteUsers({
+    const invitations = await this.membersRepository.inviteUsers({
       authPayload: args.authPayload,
       spaceId: args.spaceId,
       users: args.inviteUsersDto.users,
       inviteExpiresAt: new Date(Date.now() + this.inviteTtlMs),
     });
+
+    // Only queue emails after invite creation succeeds.
+    await this.spaceInviteEmailService.enqueueInviteEmails({
+      users: args.inviteUsersDto.users,
+      spaceId: args.spaceId,
+    });
+
+    return invitations;
   }
 
   public async acceptInvite(args: {

--- a/src/modules/spaces/routes/space-invite-email.service.spec.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.spec.ts
@@ -5,6 +5,7 @@ import type { IConfigurationService } from '@/config/configuration.service.inter
 import { nameBuilder } from '@/domain/common/entities/name.builder';
 import type { ILoggingService } from '@/logging/logging.interface';
 import type { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.service';
+import { spaceBuilder } from '@/modules/spaces/domain/entities/__tests__/space.entity.db.builder';
 import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import {
   emailInviteUserDtoBuilder,
@@ -24,7 +25,7 @@ const loggingServiceMock = {
 } as jest.MockedObjectDeep<ILoggingService>;
 
 const spacesRepositoryMock = {
-  findOne: jest.fn(),
+  findOneOrFail: jest.fn(),
 } as jest.MockedObjectDeep<ISpacesRepository>;
 
 const sesEmailQueueServiceMock = {
@@ -54,9 +55,9 @@ describe('SpaceInviteEmailService', () => {
       throw new Error(`Unexpected config key: ${key}`);
     });
     workspaceName = nameBuilder();
-    spacesRepositoryMock.findOne.mockResolvedValue({
-      name: workspaceName,
-    } as Awaited<ReturnType<ISpacesRepository['findOne']>>);
+    spacesRepositoryMock.findOneOrFail.mockResolvedValue(
+      spaceBuilder().with('name', workspaceName).build(),
+    );
     service = buildService(sesEmailQueueServiceMock);
   });
 
@@ -84,18 +85,21 @@ describe('SpaceInviteEmailService', () => {
     );
   });
 
-  it('should fall back to a default workspace name when the space cannot be resolved', async () => {
+  it('should swallow and log errors raised while resolving the space', async () => {
     const spaceId = faker.number.int({ min: 1 });
     const invite = emailInviteUserDtoBuilder().build();
-    spacesRepositoryMock.findOne.mockResolvedValue(null);
+    spacesRepositoryMock.findOneOrFail.mockRejectedValueOnce(
+      new Error('Space not found'),
+    );
     sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
 
-    await service.enqueueInviteEmails({ users: [invite], spaceId });
+    await expect(
+      service.enqueueInviteEmails({ users: [invite], spaceId }),
+    ).resolves.toBeUndefined();
 
-    expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        textBody: expect.stringContaining('Safe workspace'),
-      }),
+    expect(sesEmailQueueServiceMock.enqueue).not.toHaveBeenCalled();
+    expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+      'Error while enqueueing space invite email: Space not found',
     );
   });
 
@@ -108,7 +112,7 @@ describe('SpaceInviteEmailService', () => {
       spaceId,
     });
 
-    expect(spacesRepositoryMock.findOne).not.toHaveBeenCalled();
+    expect(spacesRepositoryMock.findOneOrFail).not.toHaveBeenCalled();
     expect(sesEmailQueueServiceMock.enqueue).not.toHaveBeenCalled();
   });
 
@@ -124,7 +128,7 @@ describe('SpaceInviteEmailService', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(spacesRepositoryMock.findOne).not.toHaveBeenCalled();
+    expect(spacesRepositoryMock.findOneOrFail).not.toHaveBeenCalled();
     expect(sesEmailQueueServiceMock.enqueue).not.toHaveBeenCalled();
   });
 

--- a/src/modules/spaces/routes/space-invite-email.service.spec.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.spec.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import { nameBuilder } from '@/domain/common/entities/name.builder';
+import type { ILoggingService } from '@/logging/logging.interface';
+import type { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.service';
+import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
+import {
+  emailInviteUserDtoBuilder,
+  walletInviteUserDtoBuilder,
+} from '@/modules/spaces/routes/entities/__tests__/invite-user.dto.builder';
+import { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
+
+const BASE_URI = 'https://app.safe.global';
+const INVITE_URL = 'https://app.safe.global/welcome/spaces';
+
+const configurationServiceMock = {
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>;
+
+const loggingServiceMock = {
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+const spacesRepositoryMock = {
+  findOne: jest.fn(),
+} as jest.MockedObjectDeep<ISpacesRepository>;
+
+const sesEmailQueueServiceMock = {
+  enqueue: jest.fn(),
+} as jest.MockedObjectDeep<SesEmailQueueService>;
+
+describe('SpaceInviteEmailService', () => {
+  let service: SpaceInviteEmailService;
+  let workspaceName: string;
+
+  const buildService = (
+    queue?: SesEmailQueueService,
+  ): SpaceInviteEmailService =>
+    new SpaceInviteEmailService(
+      configurationServiceMock,
+      spacesRepositoryMock,
+      loggingServiceMock,
+      queue,
+    );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    configurationServiceMock.getOrThrow.mockImplementation((key: string) => {
+      if (key === 'safeWebApp.baseUri') {
+        return BASE_URI;
+      }
+      throw new Error(`Unexpected config key: ${key}`);
+    });
+    workspaceName = nameBuilder();
+    spacesRepositoryMock.findOne.mockResolvedValue({
+      name: workspaceName,
+    } as Awaited<ReturnType<ISpacesRepository['findOne']>>);
+    service = buildService(sesEmailQueueServiceMock);
+  });
+
+  it('should enqueue an email job for an email invite using the configured invite URL', async () => {
+    const spaceId = faker.number.int({ min: 1 });
+    const invite = emailInviteUserDtoBuilder().build();
+    sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+
+    await service.enqueueInviteEmails({ users: [invite], spaceId });
+
+    expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledTimes(1);
+    expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledWith({
+      to: invite.email,
+      subject: 'You have been invited to a Safe workspace',
+      htmlBody: expect.stringContaining(INVITE_URL),
+      textBody: expect.stringContaining(INVITE_URL),
+      metadata: {
+        spaceId,
+      },
+    });
+    expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        htmlBody: expect.stringContaining(workspaceName),
+      }),
+    );
+  });
+
+  it('should fall back to a default workspace name when the space cannot be resolved', async () => {
+    const spaceId = faker.number.int({ min: 1 });
+    const invite = emailInviteUserDtoBuilder().build();
+    spacesRepositoryMock.findOne.mockResolvedValue(null);
+    sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+
+    await service.enqueueInviteEmails({ users: [invite], spaceId });
+
+    expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        textBody: expect.stringContaining('Safe workspace'),
+      }),
+    );
+  });
+
+  it('should skip invitations without an invitee email', async () => {
+    const spaceId = faker.number.int({ min: 1 });
+    const walletInvite = walletInviteUserDtoBuilder().build();
+
+    await service.enqueueInviteEmails({
+      users: [walletInvite],
+      spaceId,
+    });
+
+    expect(spacesRepositoryMock.findOne).not.toHaveBeenCalled();
+    expect(sesEmailQueueServiceMock.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('should be a no-op when the SES email queue is not available', async () => {
+    const noQueueService = buildService(undefined);
+    const spaceId = faker.number.int({ min: 1 });
+    const invite = emailInviteUserDtoBuilder().build();
+
+    await expect(
+      noQueueService.enqueueInviteEmails({
+        users: [invite],
+        spaceId,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(spacesRepositoryMock.findOne).not.toHaveBeenCalled();
+    expect(sesEmailQueueServiceMock.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('should swallow and log errors raised while enqueueing', async () => {
+    const spaceId = faker.number.int({ min: 1 });
+    const invite = emailInviteUserDtoBuilder().build();
+    sesEmailQueueServiceMock.enqueue.mockRejectedValueOnce(
+      new Error('Redis connection refused'),
+    );
+
+    await expect(
+      service.enqueueInviteEmails({ users: [invite], spaceId }),
+    ).resolves.toBeUndefined();
+
+    expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+      'Error while enqueueing space invite email: Redis connection refused',
+    );
+  });
+});

--- a/src/modules/spaces/routes/space-invite-email.service.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import { asError } from '@/logging/utils';
+import { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.service';
+import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
+import {
+  InviteType,
+  type InviteUserInput,
+} from '@/modules/spaces/routes/entities/invite-users.dto.entity';
+import {
+  renderSpaceInviteEmailHtml,
+  renderSpaceInviteEmailText,
+  SPACE_INVITE_EMAIL_SUBJECT,
+  SPACE_INVITE_PATH,
+} from '@/modules/spaces/routes/templates/space-invite-email.template';
+
+const DEFAULT_WORKSPACE_NAME = 'Safe workspace';
+
+/**
+ * Builds and enqueues space invite emails.
+ */
+@Injectable()
+export class SpaceInviteEmailService {
+  private readonly inviteUrl: string;
+
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+    @Inject(ISpacesRepository)
+    private readonly spacesRepository: ISpacesRepository,
+    @Inject(LoggingService)
+    private readonly loggingService: ILoggingService,
+    @Optional()
+    private readonly sesEmailQueueService?: SesEmailQueueService,
+  ) {
+    const baseUri =
+      this.configurationService.getOrThrow<string>('safeWebApp.baseUri');
+    this.inviteUrl = new URL(SPACE_INVITE_PATH, baseUri).toString();
+  }
+
+  /**
+   * Enqueues emails for email-based invitations.
+   *
+   * @param args.users - Requested users to invite.
+   * @param args.spaceId - Space the invitations belong to.
+   */
+  public async enqueueInviteEmails(args: {
+    users: Array<InviteUserInput>;
+    spaceId: Space['id'];
+  }): Promise<void> {
+    if (!this.sesEmailQueueService) {
+      return;
+    }
+    const queue = this.sesEmailQueueService;
+    const emailInvites = args.users.flatMap((user) =>
+      user.type === InviteType.Email ? [user] : [],
+    );
+
+    if (emailInvites.length === 0) {
+      return;
+    }
+
+    try {
+      const space = await this.spacesRepository.findOne({
+        where: { id: args.spaceId },
+        select: { name: true },
+      });
+      const workspaceName = space?.name ?? DEFAULT_WORKSPACE_NAME;
+
+      const jobs = emailInvites.map((invitation) => {
+        const templateArgs = {
+          name: invitation.name,
+          email: invitation.email,
+          workspaceName,
+          actionUrl: this.inviteUrl,
+        };
+
+        return queue.enqueue({
+          to: invitation.email,
+          subject: SPACE_INVITE_EMAIL_SUBJECT,
+          htmlBody: renderSpaceInviteEmailHtml(templateArgs),
+          textBody: renderSpaceInviteEmailText(templateArgs),
+          metadata: {
+            spaceId: args.spaceId,
+          },
+        });
+      });
+
+      await Promise.all(jobs);
+    } catch (error) {
+      this.loggingService.warn(
+        `Error while enqueueing space invite email: ${asError(error).message}`,
+      );
+    }
+  }
+}

--- a/src/modules/spaces/routes/space-invite-email.service.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.ts
@@ -20,8 +20,6 @@ import {
   SPACE_INVITE_PATH,
 } from '@/modules/spaces/routes/templates/space-invite-email.template';
 
-const DEFAULT_WORKSPACE_NAME = 'Safe workspace';
-
 /**
  * Builds and enqueues space invite emails.
  */
@@ -67,11 +65,11 @@ export class SpaceInviteEmailService {
     }
 
     try {
-      const space = await this.spacesRepository.findOne({
+      const space = await this.spacesRepository.findOneOrFail({
         where: { id: args.spaceId },
         select: { name: true },
       });
-      const workspaceName = space?.name ?? DEFAULT_WORKSPACE_NAME;
+      const workspaceName = space.name;
 
       const jobs = emailInvites.map((invitation) => {
         const templateArgs = {

--- a/src/modules/spaces/routes/templates/space-invite-email.template.ts
+++ b/src/modules/spaces/routes/templates/space-invite-email.template.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import sanitizeHtml from 'sanitize-html';
+
+// Escape all interpolated template values.
+const ESCAPE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [],
+  disallowedTagsMode: 'escape',
+};
+
+export const SPACE_INVITE_EMAIL_SUBJECT =
+  'You have been invited to a Safe workspace';
+
+export const SPACE_INVITE_EMAIL_LOGO_URL =
+  'https://app.safe.global/images/email/logo-monogram.png';
+
+export const SPACE_INVITE_PATH = '/welcome/spaces';
+
+type SpaceInviteEmailTemplateArgs = {
+  name: string;
+  email: string;
+  workspaceName: string;
+  actionUrl: string;
+};
+
+function getSpaceInviteEmailCopy(args: SpaceInviteEmailTemplateArgs): {
+  preheader: string;
+  headline: string;
+  body: string;
+  footerDisclosure: string;
+  fallback: string;
+} {
+  return {
+    preheader: `You've been invited to ${args.workspaceName} on Safe{Wallet}`,
+    headline: `You've been invited to ${args.workspaceName}`,
+    body: `Hi ${args.name}, you've been added to the ${args.workspaceName} workspace on Safe{Wallet}. Accept the invite to collaborate and view Safe Accounts with your team.`,
+    footerDisclosure: `This invite was sent to ${args.email}. If unexpected, you can ignore it.`,
+    fallback: 'Button not working? Open the invite in your browser',
+  };
+}
+
+/**
+ * Renders the HTML body for a space invite email.
+ *
+ * @param args.name - Invitee display name.
+ * @param args.email - Invitee email address.
+ * @param args.workspaceName - Workspace name shown in the email.
+ * @param args.actionUrl - URL opened by the invite CTA.
+ */
+export function renderSpaceInviteEmailHtml(
+  args: SpaceInviteEmailTemplateArgs,
+): string {
+  const copy = getSpaceInviteEmailCopy(args);
+  const html = {
+    name: sanitizeHtml(args.name, ESCAPE_OPTIONS),
+    workspaceName: sanitizeHtml(args.workspaceName, ESCAPE_OPTIONS),
+    actionUrl: sanitizeHtml(args.actionUrl, ESCAPE_OPTIONS),
+    preheader: sanitizeHtml(copy.preheader, ESCAPE_OPTIONS),
+    headline: sanitizeHtml(copy.headline, ESCAPE_OPTIONS),
+    footerDisclosure: sanitizeHtml(copy.footerDisclosure, ESCAPE_OPTIONS),
+  };
+
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en" xmlns="http://www.w3.org/1999/xhtml">',
+    '<head>',
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    '  <meta http-equiv="X-UA-Compatible" content="IE=edge">',
+    '  <meta name="color-scheme" content="light">',
+    '  <meta name="supported-color-schemes" content="light">',
+    `  <title>You're invited to ${html.workspaceName}</title>`,
+    '  <style>',
+    "    @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap');",
+    '    body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }',
+    '    img { border: 0; line-height: 100%; outline: none; text-decoration: none; }',
+    '    @media only screen and (max-width: 640px) {',
+    '      .container { width: 100% !important; }',
+    '      .card-pad { padding: 32px 24px !important; }',
+    '    }',
+    '  </style>',
+    '</head>',
+    '<body style="margin:0; padding:0; background-color:#F5F5F5; font-family:\'DM Sans\', Helvetica, Arial, sans-serif;">',
+    `  <div style="display:none; max-height:0; overflow:hidden; mso-hide:all;">${html.preheader}</div>`,
+    '  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#F5F5F5;">',
+    '    <tr>',
+    '      <td align="center" style="padding:48px 16px;">',
+    '        <table role="presentation" class="container" width="560" cellpadding="0" cellspacing="0" style="width:560px; max-width:560px;">',
+    '          <tr>',
+    '            <td class="card-pad" style="background-color:#FFFFFF; border-radius:24px; padding:48px;">',
+    '              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">',
+    '                <tr>',
+    '                  <td align="center" style="padding:16px 0 32px 0;">',
+    `                    <img src="${SPACE_INVITE_EMAIL_LOGO_URL}" width="56" height="56" alt="Safe" style="display:block; width:56px; height:56px;">`,
+    '                  </td>',
+    '                </tr>',
+    '                <tr>',
+    `                  <td align="center" style="font-family:'DM Sans', Helvetica, Arial, sans-serif; font-size:24px; line-height:120%; font-weight:700; color:#1A1A1A; padding-bottom:16px;">${html.headline}</td>`,
+    '                </tr>',
+    '                <tr>',
+    `                  <td align="center" style="font-family:'DM Sans', Helvetica, Arial, sans-serif; font-size:16px; line-height:24px; color:#636669; padding-bottom:32px;">Hi ${html.name}, you've been added to the <strong style="font-weight:500; color:#1A1A1A;">${html.workspaceName}</strong> workspace on Safe&#123;Wallet&#125;. Accept the invite to collaborate and view Safe Accounts with your team.</td>`,
+    '                </tr>',
+    '                <tr>',
+    '                  <td align="center" style="padding-bottom:8px;">',
+    '                    <table role="presentation" cellpadding="0" cellspacing="0">',
+    '                      <tr>',
+    '                        <td align="center" style="background-color:#121312; border-radius:10px;">',
+    `                          <a href="${html.actionUrl}" target="_blank" style="display:inline-block; padding:14px 32px; font-family:'DM Sans', Helvetica, Arial, sans-serif; font-size:16px; line-height:24px; font-weight:500; color:#FFFFFF; text-decoration:none; border-radius:10px;">Accept invite</a>`,
+    '                        </td>',
+    '                      </tr>',
+    '                    </table>',
+    '                  </td>',
+    '                </tr>',
+    '              </table>',
+    '            </td>',
+    '          </tr>',
+    '          <tr>',
+    '            <td align="center" style="padding:32px 24px 0 24px;">',
+    '              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">',
+    '                <tr>',
+    `                  <td align="center" style="font-family:'DM Sans', Helvetica, Arial, sans-serif; font-size:14px; line-height:22px; color:#636669; padding-bottom:4px;">${html.footerDisclosure}</td>`,
+    '                </tr>',
+    '                <tr>',
+    `                  <td align="center" style="font-family:'DM Sans', Helvetica, Arial, sans-serif; font-size:14px; line-height:22px; color:#636669; padding-bottom:24px;">Button not working? <a href="${html.actionUrl}" target="_blank" style="color:#636669; text-decoration:underline;">Open the invite in your browser</a></td>`,
+    '                </tr>',
+    '                <tr>',
+    '                  <td align="center" style="font-family:\'DM Sans\', Helvetica, Arial, sans-serif; font-size:14px; line-height:22px; color:#A1A3A7;">',
+    '                    <a href="https://app.safe.global/privacy" target="_blank" style="color:#A1A3A7; text-decoration:none;">Privacy policy</a>',
+    '                    &nbsp;&nbsp;&nbsp;',
+    '                    <a href="https://app.safe.global/terms" target="_blank" style="color:#A1A3A7; text-decoration:none;">Terms of service</a>',
+    '                    &nbsp;&nbsp;&nbsp;',
+    '                    <a href="https://help.safe.global" target="_blank" style="color:#A1A3A7; text-decoration:none;">Support</a>',
+    '                  </td>',
+    '                </tr>',
+    '              </table>',
+    '            </td>',
+    '          </tr>',
+    '        </table>',
+    '      </td>',
+    '    </tr>',
+    '  </table>',
+    '</body>',
+    '</html>',
+  ].join('\n');
+}
+
+/**
+ * Renders the plain-text body for a space invite email.
+ *
+ * @param args.name - Invitee display name.
+ * @param args.email - Invitee email address.
+ * @param args.workspaceName - Workspace name shown in the email.
+ * @param args.actionUrl - URL opened by the invite CTA.
+ */
+export function renderSpaceInviteEmailText(
+  args: SpaceInviteEmailTemplateArgs,
+): string {
+  const copy = getSpaceInviteEmailCopy(args);
+
+  return [
+    copy.headline,
+    copy.body,
+    'Accept invite:',
+    args.actionUrl,
+    copy.footerDisclosure,
+    `${copy.fallback}: ${args.actionUrl}`,
+    'Privacy policy: https://app.safe.global/privacy',
+    'Terms of service: https://app.safe.global/terms',
+    'Support: https://help.safe.global',
+  ].join('\n\n');
+}

--- a/src/modules/spaces/spaces.module.ts
+++ b/src/modules/spaces/spaces.module.ts
@@ -25,6 +25,7 @@ import { AddressBooksController } from '@/modules/spaces/routes/address-books.co
 import { AddressBooksService } from '@/modules/spaces/routes/address-books.service';
 import { MembersController } from '@/modules/spaces/routes/members.controller';
 import { MembersService } from '@/modules/spaces/routes/members.service';
+import { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
 import { SpaceSafesController } from '@/modules/spaces/routes/space-safes.controller';
 import { SpaceSafesService } from '@/modules/spaces/routes/space-safes.service';
 import { SpacesController } from '@/modules/spaces/routes/spaces.controller';
@@ -67,6 +68,7 @@ import { WalletsModule } from '@/modules/wallets/wallets.module';
     SpacesService,
     SpaceSafesService,
     MembersService,
+    SpaceInviteEmailService,
     {
       provide: ISpacesRepository,
       useClass: SpacesRepository,

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,7 +415,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:^3.972.45":
+"@aws-sdk/credential-provider-web-identity@npm:3.972.45, @aws-sdk/credential-provider-web-identity@npm:^3.972.45":
   version: 3.972.45
   resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.45"
   dependencies:
@@ -8808,6 +8808,7 @@ __metadata:
     "@aws-sdk/client-kms": "npm:3.1056.0"
     "@aws-sdk/client-s3": "npm:3.1056.0"
     "@aws-sdk/client-sesv2": "npm:3.1056.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.972.45"
     "@aws-sdk/lib-storage": "npm:3.1056.0"
     "@aws-sdk/s3-request-presigner": "npm:3.1056.0"
     "@biomejs/biome": "npm:2.4.12"


### PR DESCRIPTION
Resolves https://linear.app/safe-global/issue/WA-2311/be-send-an-email-via-ses-on-email-invitation

## Summary

Send SES-backed invite emails when a user is invited to a space, while keeping the invite API response scoped to public route fields.

## Changes

- Wire the space invite flow to enqueue SES email jobs only after repository invite persistence succeeds.
- Build invite emails from the original email invite inputs and the resolved workspace name.
- Add a branded HTML/text invite email template with the Safe logo.
- Configure the SES client to prefer IRSA web-identity credentials when available, while preserving local env-key behavior.
- Override the SES module in shared test setup so route tests do not connect to BullMQ/Redis.

## Validation

- `pre-commit run --files .env.sample.json package.json src/config/entities/__tests__/configuration.ts src/config/entities/configuration.ts src/config/entities/schemas/configuration.schema.ts src/modules/email/ses/datasources/aws-ses-email.service.spec.ts src/modules/email/ses/datasources/aws-ses-email.service.ts src/modules/email/ses/ses-email.module.ts src/modules/spaces/routes/members.service.spec.ts src/modules/spaces/routes/members.service.ts src/modules/spaces/routes/space-invite-email.service.spec.ts src/modules/spaces/routes/space-invite-email.service.ts src/modules/spaces/routes/templates/space-invite-email.template.ts src/modules/spaces/spaces.module.ts yarn.lock`
- `yarn format-check`
- `yarn lint-check`
- `yarn env:validate:silent`
- `yarn test src/modules/spaces/routes/space-invite-email.service.spec.ts src/modules/spaces/routes/members.service.spec.ts src/modules/users/domain/members.repository.spec.ts src/modules/email/ses/datasources/aws-ses-email.service.spec.ts --no-watchman`
