### PR TITLE
feat(cow/ink): add Ink (Chain ID 57073) to CoW Swap API configuration

### DIFF
--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -472,6 +472,7 @@ export default (): ReturnType<typeof configuration> => ({
       11155111: faker.internet.url({ appendSlash: false }),
       59144: faker.internet.url({ appendSlash: false }),
       9745: faker.internet.url({ appendSlash: false }),
+      57073: faker.internet.url({ appendSlash: false }),
     },
     explorerBaseUri: faker.internet.url({ appendSlash: true }),
     restrictApps: false,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -813,6 +813,7 @@ export default () => ({
       11155111: 'https://api.cow.fi/sepolia',
       59144: 'https://api.cow.fi/linea',
       9745: 'https://api.cow.fi/plasma',
+      57073: 'https://api.cow.fi/ink',
     },
     explorerBaseUri:
       process.env.SWAPS_EXPLORER_URI || 'https://explorer.cow.fi/',


### PR DESCRIPTION
 ## Summary

  Adds Ink (Chain ID `57073`) to the CoW Swap API configuration, enabling the
  Swaps feature on Ink. The `SwapsApiFactory` resolves chains dynamically via
  `swaps.api.${chainId}`, so registering the chain's CoW endpoint is all that's
  required — no other wiring is needed. This mirrors the previous chain additions
  (e.g. Plasma #2877, which touched the same two files).

  ## Changes

  - Add `57073: 'https://api.cow.fi/ink'` to `swaps.api` in
    `src/config/entities/configuration.ts`.
  - Add the matching `57073` entry to the test configuration in
    `src/config/entities/__tests__/configuration.ts`.