### PR TITLE
fix(spaces): wire SES invite email queue

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -44,7 +44,6 @@ import { CounterfactualSafesModule } from '@/modules/counterfactual-safes/counte
 import { CsvExportModule } from '@/modules/csv-export/csv-export.module';
 import { DataDecoderModule } from '@/modules/data-decoder/data-decoder.module';
 import { DelegateModule } from '@/modules/delegate/delegate.module';
-import { SesEmailModule } from '@/modules/email/ses/ses-email.module';
 import { EstimationsModule } from '@/modules/estimations/estimations.module';
 import { FeesModule } from '@/modules/fees/fees.module';
 import { HealthModule } from '@/modules/health/health.module';
@@ -80,7 +79,6 @@ export class AppModule implements NestModule {
       oidc_auth: isOidcAuthFeatureEnabled,
       users: isUsersFeatureEnabled,
       email: isEmailFeatureEnabled,
-      sesEmail: isSesEmailFeatureEnabled,
       zerionPositions: isZerionPositionsFeatureEnabled,
     } = configFactory().features;
 
@@ -105,7 +103,6 @@ export class AppModule implements NestModule {
         DelegateModule,
         // Note: this feature will not work as expected until we reintegrate the email service
         ...(isEmailFeatureEnabled ? [AlertsModule, RecoveryModule] : []),
-        ...(isSesEmailFeatureEnabled ? [SesEmailModule] : []),
         EstimationsModule,
         FeesModule,
         HealthModule,

--- a/src/modules/spaces/spaces.module.ts
+++ b/src/modules/spaces/spaces.module.ts
@@ -2,8 +2,10 @@
 
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import configuration from '@/config/entities/configuration';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { AuthModule } from '@/modules/auth/auth.module';
+import { SesEmailModule } from '@/modules/email/ses/ses-email.module';
 import { AddressBookItem } from '@/modules/spaces/datasources/entities/address-book-item.entity.db';
 import { AddressBookRequest } from '@/modules/spaces/datasources/entities/address-book-request.entity.db';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
@@ -37,6 +39,8 @@ import { UserIdentityResolverModule } from '@/modules/users/domain/user-identity
 import { UsersModule } from '@/modules/users/users.module';
 import { WalletsModule } from '@/modules/wallets/wallets.module';
 
+const isSesEmailFeatureEnabled = configuration().features.sesEmail;
+
 @Module({
   imports: [
     PostgresDatabaseModuleV2,
@@ -50,6 +54,7 @@ import { WalletsModule } from '@/modules/wallets/wallets.module';
     ]),
     forwardRef(() => AuthModule),
     forwardRef(() => UsersModule),
+    ...(isSesEmailFeatureEnabled ? [SesEmailModule] : []),
     UserIdentityResolverModule,
     WalletsModule,
   ],


### PR DESCRIPTION
## Summary

Fixes SES invite email delivery by wiring the SES queue module into the Spaces module, where `SpaceInviteEmailService` is instantiated.

## Root cause

`SesEmailModule` was imported as an AppModule sibling. That starts the SES queue module, but it does not make `SesEmailQueueService` visible to providers declared inside `SpacesModule`. Because the queue dependency in `SpaceInviteEmailService` is optional, invite creation succeeded while email queueing became a no-op.

## Changes

- Import `SesEmailModule` conditionally from `SpacesModule`.
- Remove the top-level `SesEmailModule` import from `AppModule` to avoid duplicate queue workers.

## Checks

- `yarn test:e2e src/app.module.e2e-spec.ts --no-watchman`
- `yarn run format-check`
- `yarn run lint-check`
