### PR TITLE
feat: send email on renew invite flow

### DIFF
--- a/src/config/entities/schemas/configuration.schema.ts
+++ b/src/config/entities/schemas/configuration.schema.ts
@@ -195,7 +195,14 @@ export const RootConfigurationSchema = z
     CAPTCHA_SECRET_KEY: z.string().optional(),
   })
   .superRefine((config, ctx) => {
-    // Check for AWS_* and Blockaid fields in production and staging environments
+    // These fields are only required in deployed (production/staging) environments.
+    const isDeployedEnv =
+      !!config.CGW_ENV && ['production', 'staging'].includes(config.CGW_ENV);
+    if (!isDeployedEnv) {
+      return;
+    }
+    const isSesEnabled = config.FF_SES_EMAIL?.toLowerCase() === 'true';
+
     for (const {
       field,
       requiredWhen = true,
@@ -211,18 +218,12 @@ export const RootConfigurationSchema = z
       // SES permissions are set via IRSA in deployed environments, not static AWS keys.
       {
         field: 'AWS_WEB_IDENTITY_TOKEN_FILE',
-        requiredWhen: config.FF_SES_EMAIL?.toLowerCase() === 'true',
+        requiredWhen: isSesEnabled,
         message:
           'is required in production and staging environments when SES email is enabled',
       },
     ]) {
-      if (
-        config.CGW_ENV &&
-        config instanceof Object &&
-        ['production', 'staging'].includes(config.CGW_ENV) &&
-        requiredWhen &&
-        !(config as Record<string, unknown>)[field]
-      ) {
+      if (requiredWhen && !(config as Record<string, unknown>)[field]) {
         ctx.addIssue({ code: 'custom', message, path: [field] });
       }
     }

--- a/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/invite-users.dto.entity.ts
@@ -46,6 +46,7 @@ export const InviteUserSchema = z.discriminatedUnion('type', [
 ]);
 
 export type InviteUserInput = z.infer<typeof InviteUserSchema>;
+export type EmailInviteUserInput = z.infer<typeof EmailInviteUserSchema>;
 
 // Defaults missing `type` to wallet so legacy clients keep working.
 // TODO: remove once wallet-1 wa-2052 ships.

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -41,6 +41,7 @@ const configurationServiceMock = {
 
 const spaceInviteEmailServiceMock = {
   enqueueInviteEmails: jest.fn(),
+  enqueueRenewalEmail: jest.fn(),
 } as jest.MockedObjectDeep<SpaceInviteEmailService>;
 
 describe('MembersService', () => {
@@ -379,6 +380,84 @@ describe('MembersService', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it('should load the member with its user relation', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const targetMember = memberBuilder().with('status', 'INVITED').build();
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.findOneOrFail.mockResolvedValue(targetMember);
+
+      await service.renewInvite({ authPayload, spaceId, userId });
+
+      expect(membersRepositoryMock.findOneOrFail).toHaveBeenCalledWith(
+        { user: { id: userId }, space: { id: spaceId } },
+        { user: true },
+      );
+    });
+
+    it('should enqueue a renewal email when the invited member has an email', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const email = fakeEmailAddress();
+      const targetMember = memberBuilder()
+        .with('status', 'INVITED')
+        .with('role', 'MEMBER')
+        .with('user', userBuilder().with('email', email).build())
+        .build();
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.findOneOrFail.mockResolvedValue(targetMember);
+
+      await service.renewInvite({ authPayload, spaceId, userId });
+
+      expect(
+        spaceInviteEmailServiceMock.enqueueRenewalEmail,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        spaceInviteEmailServiceMock.enqueueRenewalEmail,
+      ).toHaveBeenCalledWith({
+        name: targetMember.name,
+        email,
+        spaceId,
+      });
+    });
+
+    it('should not enqueue a renewal email when the invited member has no email', async () => {
+      const authPayload = new AuthPayload(siweAuthPayloadDtoBuilder().build());
+      const spaceId = faker.number.int({ min: 1 });
+      const userId = faker.number.int({ min: 1 });
+      const targetMember = memberBuilder()
+        .with('status', 'INVITED')
+        .with('role', 'MEMBER')
+        .with('user', userBuilder().with('email', null).build())
+        .build();
+      const adminMember = memberBuilder()
+        .with('role', 'ADMIN')
+        .with('status', 'ACTIVE')
+        .build();
+
+      membersRepositoryMock.findActiveAdmin.mockResolvedValue(adminMember);
+      membersRepositoryMock.findOneOrFail.mockResolvedValue(targetMember);
+
+      await service.renewInvite({ authPayload, spaceId, userId });
+
+      expect(membersRepositoryMock.renewInvite).toHaveBeenCalledTimes(1);
+      expect(
+        spaceInviteEmailServiceMock.enqueueRenewalEmail,
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -106,10 +106,10 @@ export class MembersService {
     return {
       userId: args.userId,
       spaceId: args.spaceId,
-      name: name,
-      role: role,
-      status: status,
-      invitedBy: invitedBy,
+      name,
+      role,
+      status,
+      invitedBy,
     };
   }
 

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -79,25 +79,37 @@ export class MembersService {
       authPayload: args.authPayload,
       spaceId: args.spaceId,
     });
-    const member = await this.membersRepository.findOneOrFail({
-      user: { id: args.userId },
-      space: { id: args.spaceId },
-    });
-    if (member.status !== 'INVITED') {
+    const { id, user, name, status, role, invitedBy } =
+      await this.membersRepository.findOneOrFail(
+        {
+          user: { id: args.userId },
+          space: { id: args.spaceId },
+        },
+        { user: true },
+      );
+    if (status !== 'INVITED') {
       throw new ConflictException('Only a pending invitation can be renewed.');
     }
     await this.membersRepository.renewInvite({
-      memberId: member.id,
+      memberId: id,
       inviteExpiresAt: new Date(Date.now() + this.inviteTtlMs),
     });
+
+    if (user.email) {
+      await this.spaceInviteEmailService.enqueueRenewalEmail({
+        name: name,
+        email: user.email,
+        spaceId: args.spaceId,
+      });
+    }
 
     return {
       userId: args.userId,
       spaceId: args.spaceId,
-      name: member.name,
-      role: member.role,
-      status: member.status,
-      invitedBy: member.invitedBy,
+      name: name,
+      role: role,
+      status: status,
+      invitedBy: invitedBy,
     };
   }
 

--- a/src/modules/spaces/routes/space-invite-email.service.spec.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.spec.ts
@@ -12,6 +12,7 @@ import {
   walletInviteUserDtoBuilder,
 } from '@/modules/spaces/routes/entities/__tests__/invite-user.dto.builder';
 import { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
 
 const BASE_URI = 'https://app.safe.global';
 const INVITE_URL = 'https://app.safe.global/welcome/spaces';
@@ -146,5 +147,67 @@ describe('SpaceInviteEmailService', () => {
     expect(loggingServiceMock.warn).toHaveBeenCalledWith(
       'Error while enqueueing space invite email: Redis connection refused',
     );
+  });
+
+  describe('enqueueRenewalEmail', () => {
+    it('should enqueue an email job for the renewed invitation', async () => {
+      const spaceId = faker.number.int({ min: 1 });
+      const name = nameBuilder();
+      const email = fakeEmailAddress();
+      sesEmailQueueServiceMock.enqueue.mockResolvedValue(undefined);
+
+      await service.enqueueRenewalEmail({ name, email, spaceId });
+
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledTimes(1);
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledWith({
+        to: email,
+        subject: 'You have been invited to a Safe workspace',
+        htmlBody: expect.stringContaining(INVITE_URL),
+        textBody: expect.stringContaining(INVITE_URL),
+        metadata: {
+          spaceId,
+        },
+      });
+      expect(sesEmailQueueServiceMock.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          htmlBody: expect.stringContaining(workspaceName),
+        }),
+      );
+    });
+
+    it('should be a no-op when the SES email queue is not available', async () => {
+      const noQueueService = buildService(undefined);
+      const spaceId = faker.number.int({ min: 1 });
+
+      await expect(
+        noQueueService.enqueueRenewalEmail({
+          name: nameBuilder(),
+          email: fakeEmailAddress(),
+          spaceId,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(spacesRepositoryMock.findOneOrFail).not.toHaveBeenCalled();
+      expect(sesEmailQueueServiceMock.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('should swallow and log errors raised while enqueueing', async () => {
+      const spaceId = faker.number.int({ min: 1 });
+      sesEmailQueueServiceMock.enqueue.mockRejectedValueOnce(
+        new Error('Redis connection refused'),
+      );
+
+      await expect(
+        service.enqueueRenewalEmail({
+          name: nameBuilder(),
+          email: fakeEmailAddress(),
+          spaceId,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(loggingServiceMock.warn).toHaveBeenCalledWith(
+        'Error while enqueueing space invite email: Redis connection refused',
+      );
+    });
   });
 });

--- a/src/modules/spaces/routes/space-invite-email.service.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.ts
@@ -10,6 +10,7 @@ import { SesEmailQueueService } from '@/modules/email/ses/ses-email-queue.servic
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import {
+  type EmailInviteUserInput,
   InviteType,
   type InviteUserInput,
 } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
@@ -19,6 +20,12 @@ import {
   SPACE_INVITE_EMAIL_SUBJECT,
   SPACE_INVITE_PATH,
 } from '@/modules/spaces/routes/templates/space-invite-email.template';
+import type { EmailAddress } from '@/validation/entities/schemas/email-address.schema';
+
+interface InviteEmailRecipient {
+  name: string;
+  email: EmailAddress;
+}
 
 /**
  * Builds and enqueues space invite emails.
@@ -52,40 +59,68 @@ export class SpaceInviteEmailService {
     users: Array<InviteUserInput>;
     spaceId: Space['id'];
   }): Promise<void> {
+    const recipients = args.users
+      .filter(
+        (user): user is EmailInviteUserInput => user.type === InviteType.Email,
+      )
+      .map((user) => ({ name: user.name, email: user.email }));
+
+    await this.enqueueEmails({ recipients, spaceId: args.spaceId });
+  }
+
+  /**
+   * Re-enqueues the invite email for a single renewed invitation.
+   *
+   * @param args.name - Display name of the invited member.
+   * @param args.email - Recipient email address.
+   * @param args.spaceId - Space the invitation belongs to.
+   */
+  public async enqueueRenewalEmail(args: {
+    name: string;
+    email: EmailAddress;
+    spaceId: Space['id'];
+  }): Promise<void> {
+    await this.enqueueEmails({
+      recipients: [{ name: args.name, email: args.email }],
+      spaceId: args.spaceId,
+    });
+  }
+
+  private async enqueueEmails(args: {
+    recipients: Array<InviteEmailRecipient>;
+    spaceId: Space['id'];
+  }): Promise<void> {
     if (!this.sesEmailQueueService) {
       return;
     }
     const queue = this.sesEmailQueueService;
-    const emailInvites = args.users.flatMap((user) =>
-      user.type === InviteType.Email ? [user] : [],
-    );
+    const { recipients, spaceId } = args;
 
-    if (emailInvites.length === 0) {
+    if (!recipients.length) {
       return;
     }
 
     try {
-      const space = await this.spacesRepository.findOneOrFail({
-        where: { id: args.spaceId },
+      const { name } = await this.spacesRepository.findOneOrFail({
+        where: { id: spaceId },
         select: { name: true },
       });
-      const workspaceName = space.name;
 
-      const jobs = emailInvites.map((invitation) => {
+      const jobs = recipients.map((recipient) => {
         const templateArgs = {
-          name: invitation.name,
-          email: invitation.email,
-          workspaceName,
+          name: recipient.name,
+          email: recipient.email,
+          workspaceName: name,
           actionUrl: this.inviteUrl,
         };
 
         return queue.enqueue({
-          to: invitation.email,
+          to: recipient.email,
           subject: SPACE_INVITE_EMAIL_SUBJECT,
           htmlBody: renderSpaceInviteEmailHtml(templateArgs),
           textBody: renderSpaceInviteEmailText(templateArgs),
           metadata: {
-            spaceId: args.spaceId,
+            spaceId,
           },
         });
       });

--- a/src/modules/spaces/routes/space-invite-email.service.ts
+++ b/src/modules/spaces/routes/space-invite-email.service.ts
@@ -101,16 +101,18 @@ export class SpaceInviteEmailService {
     }
 
     try {
-      const { name } = await this.spacesRepository.findOneOrFail({
-        where: { id: spaceId },
-        select: { name: true },
-      });
+      const { name: workspaceName } = await this.spacesRepository.findOneOrFail(
+        {
+          where: { id: spaceId },
+          select: { name: true },
+        },
+      );
 
       const jobs = recipients.map((recipient) => {
         const templateArgs = {
           name: recipient.name,
           email: recipient.email,
-          workspaceName: name,
+          workspaceName,
           actionUrl: this.inviteUrl,
         };
 


### PR DESCRIPTION
## Summary [WA-2512](https://linear.app/safe-global/issue/WA-2512/wire-email-delivery-into-resend-endpoint)

Sends an invite email when an email-based space invite is **renewed**, reusing the same template/subject as the original invite. 

## Changes

**Renewal email flow**
- `src/modules/spaces/routes/members.service.ts`: `renewInvite` now loads the member with its `user` relation (`{ user: true }`), and after a successful renewal enqueues a renewal email when the member has a stored email. Email presence is the signal for an email invite — email invites create a user via `findOrCreateByEmail` (sets `user.email`); wallet invites don't.
- `src/modules/spaces/routes/space-invite-email.service.ts`: extracted a shared private `enqueueEmails({ recipients, spaceId })` core; `enqueueInviteEmails` maps email invites to recipients and delegates; added a public `enqueueRenewalEmail({ name, email, spaceId })` for the single-recipient renewal case. Same subject, template, and metadata as the original invite.
- `src/modules/spaces/routes/entities/invite-users.dto.entity.ts`: exported `EmailInviteUserInput` (inferred from the existing email invite schema) to type the invite filter cleanly.

**Config validation refactor**
- `src/config/entities/schemas/configuration.schema.ts`: simplified the production/staging `superRefine` — early-return for non-deployed environments and hoisted the `isSesEnabled` check, removing the repeated per-field env guard.

## Tests
- `src/modules/spaces/routes/members.service.spec.ts`: renew loads the member with its user relation; enqueues a renewal email when the member has an email; does not enqueue (but still renews) when there's no email.
- `src/modules/spaces/routes/space-invite-email.service.spec.ts`: `enqueueRenewalEmail` enqueues a correct job, is a no-op when the SES queue is unavailable, and swallows/logs enqueue errors.
