### PR TITLE
refactor: adjust error message text for max amount of safes in the space

### DIFF
--- a/src/modules/spaces/domain/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/space-safes.repository.integration.spec.ts
@@ -432,6 +432,60 @@ describe('SpaceSafesRepository', () => {
       );
     });
 
+    it('should not mention remaining slots when the Space is already at the limit', async () => {
+      const user = await dbUserRepo.insert({
+        status: 'ACTIVE',
+      });
+      const userId = user.identifiers[0].id as User['id'];
+      await dbWalletRepo.insert({
+        user: { id: userId },
+        address: getAddress(faker.finance.ethereumAddress()),
+      });
+      const space = await dbSpaceRepository.insert({
+        status: faker.helpers.arrayElement(getStringEnumKeys(SpaceStatus)),
+        name: faker.word.noun(),
+      });
+      const spaceId = space.identifiers[0].id as Space['id'];
+      await dbMembersRepository.insert({
+        user: { id: userId },
+        role: 'ADMIN',
+        status: 'ACTIVE',
+        name: faker.word.noun(),
+        space: { id: spaceId },
+      });
+
+      await spaceSafesRepo.create({
+        spaceId: spaceId,
+        payload: faker.helpers.multiple(
+          () => ({
+            chainId: faker.string.numeric(),
+            address: getAddress(faker.finance.ethereumAddress()),
+          }),
+          { count: maxSafesPerSpace },
+        ),
+      });
+
+      await expect(
+        spaceSafesRepo.create({
+          spaceId: spaceId,
+          payload: [
+            {
+              chainId: faker.string.numeric(),
+              address: getAddress(faker.finance.ethereumAddress()),
+            },
+          ],
+        }),
+      ).rejects.toThrow(
+        new BadRequestException(
+          `This Workspace only allows a maximum of ${maxSafesPerSpace} Safe Accounts.`,
+        ),
+      );
+
+      await expect(spaceSafesRepo.findBySpaceId(spaceId)).resolves.toHaveLength(
+        maxSafesPerSpace,
+      );
+    });
+
     it('should fail if a SpaceSafe with the same address and chainId already exists', async () => {
       const chainId = faker.string.numeric();
       const address = getAddress(faker.finance.ethereumAddress());

--- a/src/modules/spaces/domain/space-safes.repository.ts
+++ b/src/modules/spaces/domain/space-safes.repository.ts
@@ -45,8 +45,11 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
 
     const existingSafes = await this.findBySpaceId(args.spaceId);
     if (existingSafes.length + safesToInsert.length > this.maxSafesPerSpace) {
+      const remaining = this.maxSafesPerSpace - existingSafes.length;
       throw new BadRequestException(
-        `This Workspace only allows a maximum of ${this.maxSafesPerSpace} Safe Accounts. You can only add up to ${this.maxSafesPerSpace - existingSafes.length} more.`,
+        remaining > 0
+          ? `This Workspace only allows a maximum of ${this.maxSafesPerSpace} Safe Accounts. You can only add up to ${remaining} more.`
+          : `This Workspace only allows a maximum of ${this.maxSafesPerSpace} Safe Accounts.`,
       );
     }
 


### PR DESCRIPTION
## Summary

Resolves: [WA-2471](https://linear.app/safe-global/issue/WA-2471/wrong-wording-when-the-40-space-limit-is-reached)

Problem:
<img width="450" height="330" alt="image" src="https://github.com/user-attachments/assets/f585751c-5339-44f7-8c74-6adc5135aec4" />

Fixes the confusing error message shown when adding Safes to a Space that is at its limit. Previously it read "...maximum of 40 Safe Accounts. You can only add up to 0 more.", which made no sense. Now the "add up to N more" sentence is only included when there is actually room left.

## Changes

- `space-safes.repository.ts`: only append "You can only add up to N more." when `remaining > 0`; otherwise show just the limit message.
- Added an integration test covering the at-limit case (message without the remaining-slots sentence).
