### PR TITLE
feat: Expose allowed gas tokens endpoint

### DIFF
--- a/src/datasources/cache/cache.router.ts
+++ b/src/datasources/cache/cache.router.ts
@@ -23,6 +23,7 @@ export class CacheRouter {
   private static readonly DECODED_DATA_KEY = 'decoded_data';
   private static readonly DELEGATES_KEY = 'delegates';
   private static readonly FIREBASE_OAUTH2_TOKEN_KEY = 'firebase_oauth2_token';
+  private static readonly GAS_TOKENS_KEY = 'gas_tokens';
   private static readonly INCOMING_TRANSFERS_KEY = 'incoming_transfers';
   private static readonly INDEXING_KEY = 'indexing';
   private static readonly MESSAGE_KEY = 'message';
@@ -571,6 +572,23 @@ export class CacheRouter {
 
   static getChainCacheDir(chainId: string): CacheDir {
     return new CacheDir(CacheRouter.getChainCacheKey(chainId), '');
+  }
+
+  static getGasTokensCacheKey(chainId: string): string {
+    return `${chainId}_${CacheRouter.GAS_TOKENS_KEY}`;
+  }
+
+  static getGasTokensCacheDir(
+    chainId: string,
+    args: {
+      limit?: number;
+      offset?: number;
+    },
+  ): CacheDir {
+    return new CacheDir(
+      CacheRouter.getGasTokensCacheKey(chainId),
+      `${args.limit}_${args.offset}`,
+    );
   }
 
   static getChainsCacheKeyV2(serviceKey: string): string {

--- a/src/datasources/config-api/config-api.service.spec.ts
+++ b/src/datasources/config-api/config-api.service.spec.ts
@@ -9,6 +9,7 @@ import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { DataSourceError } from '@/domain/errors/data-source.error';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { chainBuilder } from '@/modules/chains/domain/entities/__tests__/chain.builder';
+import { gasTokenBuilder } from '@/modules/fees/domain/entities/__tests__/gas-token.builder';
 import { safeAppBuilder } from '@/modules/safe-apps/domain/entities/__tests__/safe-app.builder';
 import { rawify } from '@/validation/entities/raw.entity';
 
@@ -112,6 +113,57 @@ describe('ConfigApi', () => {
       expireTimeSeconds: expirationTimeInSeconds,
     });
     expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return the gas tokens retrieved by chainId', async () => {
+    const chainId = faker.string.numeric();
+    const data = [gasTokenBuilder().build(), gasTokenBuilder().build()];
+    mockDataSource.get.mockResolvedValue(rawify(data));
+
+    const actual = await service.getGasTokens(chainId, {});
+
+    expect(actual).toBe(data);
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
+      cacheDir: new CacheDir(`${chainId}_gas_tokens`, 'undefined_undefined'),
+      url: `${baseUri}/api/v1/chains/${chainId}/gas-tokens/`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: { params: { limit: undefined, offset: undefined } },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return the gas tokens retrieved by chainId with pagination', async () => {
+    const chainId = faker.string.numeric();
+    const limit = faker.number.int({ min: 1, max: 100 });
+    const offset = faker.number.int({ min: 0, max: 100 });
+    const data = [gasTokenBuilder().build()];
+    mockDataSource.get.mockResolvedValue(rawify(data));
+
+    const actual = await service.getGasTokens(chainId, { limit, offset });
+
+    expect(actual).toBe(data);
+    expect(mockDataSource.get).toHaveBeenCalledTimes(1);
+    expect(mockDataSource.get).toHaveBeenCalledWith({
+      cacheDir: new CacheDir(`${chainId}_gas_tokens`, `${limit}_${offset}`),
+      url: `${baseUri}/api/v1/chains/${chainId}/gas-tokens/`,
+      notFoundExpireTimeSeconds: notFoundExpirationTimeInSeconds,
+      networkRequest: { params: { limit, offset } },
+      expireTimeSeconds: expirationTimeInSeconds,
+    });
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(0);
+  });
+
+  it('should forward errors from the data source when retrieving gas tokens', async () => {
+    const chainId = faker.string.numeric();
+    const expected = new DataSourceError('some error');
+    mockHttpErrorFactory.from.mockReturnValue(expected);
+    mockDataSource.get.mockRejectedValueOnce(new Error());
+
+    await expect(service.getGasTokens(chainId, {})).rejects.toThrow(expected);
+
+    expect(mockHttpErrorFactory.from).toHaveBeenCalledTimes(1);
   });
 
   it('should return the safe apps retrieved by chainId', async () => {

--- a/src/datasources/config-api/config-api.service.ts
+++ b/src/datasources/config-api/config-api.service.ts
@@ -15,6 +15,7 @@ import {
   LoggingService,
 } from '@/logging/logging.interface';
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
+import type { GasToken } from '@/modules/fees/domain/entities/gas-token.entity';
 import type { SafeApp } from '@/modules/safe-apps/domain/entities/safe-app.entity';
 import type { Raw } from '@/validation/entities/raw.entity';
 
@@ -78,6 +79,29 @@ export class ConfigApi implements IConfigApi {
         url,
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         networkRequest: undefined,
+        expireTimeSeconds: this.defaultExpirationTimeInSeconds,
+      });
+    } catch (error) {
+      throw this.httpErrorFactory.from(error);
+    }
+  }
+
+  async getGasTokens(
+    chainId: string,
+    args: {
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<Raw<Page<GasToken>>> {
+    try {
+      const url = `${this.baseUri}/api/v1/chains/${chainId}/gas-tokens/`;
+      const params = { limit: args.limit, offset: args.offset };
+      const cacheDir = CacheRouter.getGasTokensCacheDir(chainId, args);
+      return await this.dataSource.get<GasToken>({
+        cacheDir,
+        url,
+        notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
+        networkRequest: { params },
         expireTimeSeconds: this.defaultExpirationTimeInSeconds,
       });
     } catch (error) {

--- a/src/domain/interfaces/config-api.interface.ts
+++ b/src/domain/interfaces/config-api.interface.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import type { Page } from '@/domain/entities/page.entity';
 import type { Chain } from '@/modules/chains/domain/entities/chain.entity';
+import type { GasToken } from '@/modules/fees/domain/entities/gas-token.entity';
 import type { SafeApp } from '@/modules/safe-apps/domain/entities/safe-app.entity';
 import type { Raw } from '@/validation/entities/raw.entity';
 
@@ -15,6 +16,14 @@ export interface IConfigApi {
   getChain(chainId: string): Promise<Raw<Chain>>;
 
   clearChain(chainId: string): Promise<void>;
+
+  getGasTokens(
+    chainId: string,
+    args: {
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<Raw<Page<GasToken>>>;
 
   getChainsV2(
     serviceKey: string,

--- a/src/modules/fees/domain/entities/__tests__/gas-token.builder.ts
+++ b/src/modules/fees/domain/entities/__tests__/gas-token.builder.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import type { GasToken } from '@/modules/fees/domain/entities/gas-token.entity';
+
+export function gasTokenBuilder(): IBuilder<GasToken> {
+  return new Builder<GasToken>()
+    .with('address', getAddress(faker.finance.ethereumAddress()))
+    .with('symbol', faker.finance.currencyCode());
+}

--- a/src/modules/fees/domain/entities/gas-token.entity.ts
+++ b/src/modules/fees/domain/entities/gas-token.entity.ts
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { z } from 'zod';
+import type { GasTokenSchema } from '@/modules/fees/domain/entities/schemas/gas-token.schema';
+
+export type GasToken = z.infer<typeof GasTokenSchema>;

--- a/src/modules/fees/domain/entities/schemas/__tests__/gas-token.schema.spec.ts
+++ b/src/modules/fees/domain/entities/schemas/__tests__/gas-token.schema.spec.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { getAddress } from 'viem';
+import { gasTokenBuilder } from '@/modules/fees/domain/entities/__tests__/gas-token.builder';
+import { GasTokenSchema } from '@/modules/fees/domain/entities/schemas/gas-token.schema';
+
+describe('GasTokenSchema', () => {
+  it('should validate a valid gas token', () => {
+    const gasToken = gasTokenBuilder().build();
+
+    const result = GasTokenSchema.safeParse(gasToken);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('should checksum the address', () => {
+    const nonChecksummed = faker.finance.ethereumAddress().toLowerCase();
+    const gasToken = gasTokenBuilder()
+      .with('address', nonChecksummed as `0x${string}`)
+      .build();
+
+    const result = GasTokenSchema.safeParse(gasToken);
+
+    expect(result.success && result.data.address).toBe(
+      getAddress(nonChecksummed),
+    );
+  });
+
+  it('should not validate an invalid address', () => {
+    const gasToken = gasTokenBuilder()
+      .with('address', 'invalid' as `0x${string}`)
+      .build();
+
+    const result = GasTokenSchema.safeParse(gasToken);
+
+    expect(!result.success && result.error.issues[0]).toMatchObject({
+      code: 'custom',
+      message: 'Invalid address',
+      path: ['address'],
+    });
+  });
+
+  it('should not validate a missing symbol', () => {
+    const { address } = gasTokenBuilder().build();
+
+    const result = GasTokenSchema.safeParse({ address });
+
+    expect(!result.success && result.error.issues[0]).toMatchObject({
+      code: 'invalid_type',
+      path: ['symbol'],
+    });
+  });
+});

--- a/src/modules/fees/domain/entities/schemas/gas-token.schema.ts
+++ b/src/modules/fees/domain/entities/schemas/gas-token.schema.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { buildLenientPageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+
+export const GasTokenSchema = z.object({
+  address: AddressSchema,
+  symbol: z.string(),
+});
+
+export const GasTokenLenientPageSchema = buildLenientPageSchema(GasTokenSchema);

--- a/src/modules/fees/domain/gas-tokens.repository.interface.ts
+++ b/src/modules/fees/domain/gas-tokens.repository.interface.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { Page } from '@/domain/entities/page.entity';
+import type { GasToken } from '@/modules/fees/domain/entities/gas-token.entity';
+
+export const IGasTokensRepository = Symbol('IGasTokensRepository');
+
+export interface IGasTokensRepository {
+  getGasTokens(args: {
+    chainId: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<GasToken>>;
+}

--- a/src/modules/fees/domain/gas-tokens.repository.spec.ts
+++ b/src/modules/fees/domain/gas-tokens.repository.spec.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
+import type { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { gasTokenBuilder } from '@/modules/fees/domain/entities/__tests__/gas-token.builder';
+import type { GasToken } from '@/modules/fees/domain/entities/gas-token.entity';
+import { GasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository';
+import { rawify } from '@/validation/entities/raw.entity';
+
+const mockLoggingService = {
+  error: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+const mockConfigApi = {
+  getGasTokens: jest.fn(),
+} as jest.MockedObjectDeep<IConfigApi>;
+
+describe('GasTokensRepository', () => {
+  let target: GasTokensRepository;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    target = new GasTokensRepository(mockLoggingService, mockConfigApi);
+  });
+
+  it('should return the gas tokens preserving the config order', async () => {
+    const chainId = faker.string.numeric();
+    const gasTokens = [
+      gasTokenBuilder().build(),
+      gasTokenBuilder().build(),
+      gasTokenBuilder().build(),
+    ];
+    const page = pageBuilder<GasToken>()
+      .with('results', gasTokens)
+      .with('count', gasTokens.length)
+      .build();
+    mockConfigApi.getGasTokens.mockResolvedValue(rawify(page));
+
+    const result = await target.getGasTokens({ chainId, limit: 20, offset: 0 });
+
+    expect(result.results).toStrictEqual(gasTokens);
+    expect(mockConfigApi.getGasTokens).toHaveBeenCalledTimes(1);
+    expect(mockConfigApi.getGasTokens).toHaveBeenCalledWith(chainId, {
+      limit: 20,
+      offset: 0,
+    });
+    expect(mockLoggingService.error).not.toHaveBeenCalled();
+  });
+
+  it('should filter out invalid gas tokens and log an error', async () => {
+    const chainId = faker.string.numeric();
+    const valid = gasTokenBuilder().build();
+    const invalid = { address: 'invalid', symbol: 123 };
+    const page = pageBuilder<GasToken>()
+      .with('results', [valid, invalid as unknown as GasToken])
+      .with('count', 2)
+      .build();
+    mockConfigApi.getGasTokens.mockResolvedValue(rawify(page));
+
+    const result = await target.getGasTokens({ chainId });
+
+    expect(result.results).toStrictEqual([valid]);
+    expect(mockConfigApi.getGasTokens).toHaveBeenCalledWith(chainId, {
+      limit: undefined,
+      offset: undefined,
+    });
+    expect(mockLoggingService.error).toHaveBeenCalledWith({
+      message: 'Some gas tokens could not be parsed',
+      errors: [invalid],
+    });
+  });
+});

--- a/src/modules/fees/domain/gas-tokens.repository.ts
+++ b/src/modules/fees/domain/gas-tokens.repository.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import differenceBy from 'lodash/differenceBy';
+import type { Page } from '@/domain/entities/page.entity';
+import { LenientBasePageSchema } from '@/domain/entities/schemas/page.schema.factory';
+import { IConfigApi } from '@/domain/interfaces/config-api.interface';
+import {
+  type ILoggingService,
+  LoggingService,
+} from '@/logging/logging.interface';
+import type { GasToken } from '@/modules/fees/domain/entities/gas-token.entity';
+import { GasTokenLenientPageSchema } from '@/modules/fees/domain/entities/schemas/gas-token.schema';
+import type { IGasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository.interface';
+
+@Injectable()
+export class GasTokensRepository implements IGasTokensRepository {
+  constructor(
+    @Inject(LoggingService) private readonly loggingService: ILoggingService,
+    @Inject(IConfigApi) private readonly configApi: IConfigApi,
+  ) {}
+
+  async getGasTokens(args: {
+    chainId: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<Page<GasToken>> {
+    const page = await this.configApi
+      .getGasTokens(args.chainId, { limit: args.limit, offset: args.offset })
+      .then(LenientBasePageSchema.parse);
+    const valid = GasTokenLenientPageSchema.parse(page);
+    if (valid.results.length < page.results.length) {
+      this.loggingService.error({
+        message: 'Some gas tokens could not be parsed',
+        errors: differenceBy(page.results, valid.results, 'address'),
+      });
+    }
+    return valid;
+  }
+}

--- a/src/modules/fees/fees.module.ts
+++ b/src/modules/fees/fees.module.ts
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Module } from '@nestjs/common';
+import { ConfigApiModule } from '@/datasources/config-api/config-api.module';
 import { FeeServiceApiModule } from '@/datasources/fee-service-api/fee-service-api.module';
+import { GasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository';
+import { IGasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository.interface';
 import { FeesController } from '@/modules/fees/routes/fees.controller';
 import { FeesService } from '@/modules/fees/routes/fees.service';
 
 @Module({
-  imports: [FeeServiceApiModule],
+  imports: [FeeServiceApiModule, ConfigApiModule],
   controllers: [FeesController],
-  providers: [FeesService],
+  providers: [
+    FeesService,
+    { provide: IGasTokensRepository, useClass: GasTokensRepository },
+  ],
 })
 export class FeesModule {}

--- a/src/modules/fees/routes/__tests__/gas-tokens.fees.controller.integration.spec.ts
+++ b/src/modules/fees/routes/__tests__/gas-tokens.fees.controller.integration.spec.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import type { Server } from 'node:net';
+import { faker } from '@faker-js/faker';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { TestAppProvider } from '@/__tests__/test-app.provider';
+import { createTestModule } from '@/__tests__/testing-module';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
+import type { INetworkService } from '@/datasources/network/network.service.interface';
+import { NetworkService } from '@/datasources/network/network.service.interface';
+import { limitAndOffsetUrlFactory } from '@/domain/entities/__tests__/page.builder';
+import { gasTokenBuilder } from '@/modules/fees/domain/entities/__tests__/gas-token.builder';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { rawify } from '@/validation/entities/raw.entity';
+
+describe('Fees Controller - gas tokens', () => {
+  let app: INestApplication<Server>;
+  let safeConfigUrl: string;
+  let networkService: jest.MockedObjectDeep<INetworkService>;
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+
+    const moduleFixture = await createTestModule();
+
+    const configurationService = moduleFixture.get<IConfigurationService>(
+      IConfigurationService,
+    );
+    safeConfigUrl = configurationService.getOrThrow('safeConfig.baseUri');
+    networkService = moduleFixture.get(NetworkService);
+
+    app = await new TestAppProvider().provide(moduleFixture);
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('Success', async () => {
+    const chainId = faker.string.numeric();
+    const results = [gasTokenBuilder().build(), gasTokenBuilder().build()];
+    networkService.get.mockResolvedValueOnce({
+      data: rawify({ count: 2, next: null, previous: null, results }),
+      status: 200,
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/gas-tokens`)
+      .expect(200)
+      .expect({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [
+          { address: results[0].address, symbol: results[0].symbol },
+          { address: results[1].address, symbol: results[1].symbol },
+        ],
+      });
+
+    expect(networkService.get).toHaveBeenCalledTimes(1);
+    expect(networkService.get).toHaveBeenCalledWith({
+      url: `${safeConfigUrl}/api/v1/chains/${chainId}/gas-tokens/`,
+      networkRequest: {
+        params: {
+          limit: PaginationData.DEFAULT_LIMIT,
+          offset: PaginationData.DEFAULT_OFFSET,
+        },
+      },
+    });
+  });
+
+  it('preserves the priority order returned by the config service', async () => {
+    const chainId = faker.string.numeric();
+    const results = [
+      gasTokenBuilder().with('symbol', 'USDC').build(),
+      gasTokenBuilder().with('symbol', 'USDT').build(),
+      gasTokenBuilder().with('symbol', 'DAI').build(),
+    ];
+    networkService.get.mockResolvedValueOnce({
+      data: rawify({ count: 3, next: null, previous: null, results }),
+      status: 200,
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/gas-tokens`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(
+          body.results.map((gasToken: { symbol: string }) => gasToken.symbol),
+        ).toEqual(['USDC', 'USDT', 'DAI']);
+      });
+  });
+
+  it('maps the config pagination to cursor URLs', async () => {
+    const chainId = faker.string.numeric();
+    const results = [gasTokenBuilder().build()];
+    const next = limitAndOffsetUrlFactory(
+      20,
+      20,
+      faker.internet.url({ appendSlash: false }),
+    );
+    const previous = limitAndOffsetUrlFactory(
+      20,
+      0,
+      faker.internet.url({ appendSlash: false }),
+    );
+    networkService.get.mockResolvedValueOnce({
+      data: rawify({ count: 40, next, previous, results }),
+      status: 200,
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/gas-tokens`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.next).toContain('cursor=limit%3D20%26offset%3D20');
+        expect(body.previous).toContain('cursor=limit%3D20%26offset%3D0');
+      });
+  });
+
+  it('should exclude gas tokens that fail validation', async () => {
+    const chainId = faker.string.numeric();
+    const valid = gasTokenBuilder().build();
+    networkService.get.mockResolvedValueOnce({
+      data: rawify({
+        count: 2,
+        next: null,
+        previous: null,
+        results: [valid, { address: 'invalid', symbol: 123 }],
+      }),
+      status: 200,
+    });
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/gas-tokens`)
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body.results).toEqual([
+          { address: valid.address, symbol: valid.symbol },
+        ]);
+      });
+  });
+
+  it('Failure: network service fails', async () => {
+    const chainId = faker.string.numeric();
+    const error = new NetworkResponseError(
+      new URL(`${safeConfigUrl}/api/v1/chains/${chainId}/gas-tokens/`),
+      { status: 500 } as Response,
+    );
+    networkService.get.mockRejectedValueOnce(error);
+
+    await request(app.getHttpServer())
+      .get(`/v1/chains/${chainId}/fees/gas-tokens`)
+      .expect(500)
+      .expect({ message: 'An error occurred', code: 500 });
+  });
+});

--- a/src/modules/fees/routes/entities/gas-token-page.entity.ts
+++ b/src/modules/fees/routes/entities/gas-token-page.entity.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty } from '@nestjs/swagger';
+import { GasToken } from '@/modules/fees/routes/entities/gas-token.entity';
+import { Page } from '@/routes/common/entities/page.entity';
+
+export class GasTokenPage extends Page<GasToken> {
+  @ApiProperty({ type: GasToken, isArray: true })
+  results!: Array<GasToken>;
+}

--- a/src/modules/fees/routes/entities/gas-token.entity.ts
+++ b/src/modules/fees/routes/entities/gas-token.entity.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty } from '@nestjs/swagger';
+import type { Address } from 'viem';
+
+export class GasToken {
+  @ApiProperty({
+    description: 'Gas token contract address',
+    example: '0x0000000000000000000000000000000000000000',
+  })
+  address: Address;
+
+  @ApiProperty({ description: "The token's ticker symbol", example: 'USDC' })
+  symbol: string;
+
+  constructor(args: { address: Address; symbol: string }) {
+    this.address = args.address;
+    this.symbol = args.symbol;
+  }
+}

--- a/src/modules/fees/routes/fees.controller.ts
+++ b/src/modules/fees/routes/fees.controller.ts
@@ -1,18 +1,25 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { Body, Controller, HttpCode, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Param, Post } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
   ApiBody,
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import type { Address } from 'viem';
 import { FeePreviewResponse } from '@/modules/fees/routes/entities/fee-preview-response.entity';
 import { FeePreviewTransactionDto } from '@/modules/fees/routes/entities/fee-preview-transaction.dto.entity';
+import { GasToken } from '@/modules/fees/routes/entities/gas-token.entity';
+import { GasTokenPage } from '@/modules/fees/routes/entities/gas-token-page.entity';
 import { FeePreviewTransactionDtoSchema } from '@/modules/fees/routes/entities/schemas/fee-preview-transaction.dto.schema';
 import { FeesService } from '@/modules/fees/routes/fees.service';
+import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
+import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
+import type { Page } from '@/routes/common/entities/page.entity';
+import type { PaginationData } from '@/routes/common/pagination/pagination.data';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
@@ -24,6 +31,36 @@ import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 })
 export class FeesController {
   constructor(private readonly feesService: FeesService) {}
+
+  @ApiOperation({
+    summary: 'Get supported gas tokens',
+    description:
+      'Retrieves a paginated list of gas tokens supported for Pay with Safe on the given chain, ordered by selection priority.',
+  })
+  @ApiParam({
+    name: 'chainId',
+    type: 'string',
+    description: 'Chain ID where the Safe is deployed',
+    example: '1',
+  })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+    description: 'Pagination cursor for retrieving the next set of results',
+  })
+  @ApiOkResponse({
+    type: GasTokenPage,
+    description: 'Paginated list of supported gas tokens, ordered by priority',
+  })
+  @Get('gas-tokens')
+  getGasTokens(
+    @Param('chainId', new ValidationPipe(NumericStringSchema)) chainId: string,
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+  ): Promise<Page<GasToken>> {
+    return this.feesService.getGasTokens(routeUrl, chainId, paginationData);
+  }
 
   @ApiOperation({
     summary: 'Get transaction fee preview',

--- a/src/modules/fees/routes/fees.service.ts
+++ b/src/modules/fees/routes/fees.service.ts
@@ -1,16 +1,47 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import type { Address } from 'viem';
+import type { Page } from '@/domain/entities/page.entity';
 import { IFeeServiceApi } from '@/domain/interfaces/fee-service-api.interface';
+import { IGasTokensRepository } from '@/modules/fees/domain/gas-tokens.repository.interface';
 import { FeePreviewResponse } from '@/modules/fees/routes/entities/fee-preview-response.entity';
 import type { FeePreviewTransactionDto } from '@/modules/fees/routes/entities/fee-preview-transaction.dto.entity';
+import { GasToken } from '@/modules/fees/routes/entities/gas-token.entity';
+import {
+  cursorUrlFromLimitAndOffset,
+  type PaginationData,
+} from '@/routes/common/pagination/pagination.data';
 
 @Injectable()
 export class FeesService {
   constructor(
     @Inject(IFeeServiceApi)
     private readonly feeServiceApi: IFeeServiceApi,
+    @Inject(IGasTokensRepository)
+    private readonly gasTokensRepository: IGasTokensRepository,
   ) {}
+
+  async getGasTokens(
+    routeUrl: Readonly<URL>,
+    chainId: string,
+    paginationData: PaginationData,
+  ): Promise<Page<GasToken>> {
+    const result = await this.gasTokensRepository.getGasTokens({
+      chainId,
+      limit: paginationData.limit,
+      offset: paginationData.offset,
+    });
+
+    const nextURL = cursorUrlFromLimitAndOffset(routeUrl, result.next);
+    const previousURL = cursorUrlFromLimitAndOffset(routeUrl, result.previous);
+
+    return {
+      count: result.count,
+      next: nextURL?.toString() ?? null,
+      previous: previousURL?.toString() ?? null,
+      results: result.results.map((gasToken) => new GasToken(gasToken)),
+    };
+  }
 
   async getFeePreview(args: {
     chainId: string;


### PR DESCRIPTION
- Related with [PLA-1552](https://linear.app/safe-global/issue/PLA-1552/fee-engine-consume-gas-token-list-ordering-from-config-service)


## Summary

Adds a new CGW endpoint that exposes the **allowed gas tokens** of a chain, in the **priority order** defined by the `safe-config-service`, so the frontend can present the list to the user.

- GET /v1/chains/{chainId}/fees/gas-tokens

It is a paginated (cursor-based) passthrough of the config-service endpoint `GET /api/v1/chains/{chainId}/gas-tokens/`. Each item is `{ address, symbol }`.



The config-service ([PR](https://github.com/safe-global/safe-config-service/pull/1587)) gained an internal `priority` field on `GasToken` and now returns the allowed gas tokens already ordered by `priority, symbol, id`. The order is the priority. This PR is the CGW side: consume that ordered list and surface it to clients.

The actual gas token validation/selection for a transaction still happens in the **fee service** during the fee preview flow, this PR does not change that, it only exposes the list for display.
