### PR TITLE
feat: enable circuit-breaker for decoder service calls

### DIFF
--- a/src/datasources/circuit-breaker/circuit-breaker.keys.ts
+++ b/src/datasources/circuit-breaker/circuit-breaker.keys.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
 /**
  * Circuit Breaker Key Generator
  *
@@ -8,6 +9,7 @@
 export class CircuitBreakerKeys {
   private static readonly SERVICE_PREFIX = {
     TRANSACTION_SERVICE: 'txs-service',
+    DATA_DECODER_SERVICE: 'data-decoder-service',
   };
 
   /**
@@ -18,5 +20,17 @@ export class CircuitBreakerKeys {
    */
   static getTransactionServiceKey(chainId: string): string {
     return `${CircuitBreakerKeys.SERVICE_PREFIX.TRANSACTION_SERVICE}-${chainId}`;
+  }
+
+  /**
+   * Generates the circuit breaker key for the Data Decoder Service
+   *
+   * The Data Decoder Service is a single deployment serving all chains,
+   * so the key is not chain-scoped.
+   *
+   * @returns Circuit breaker key: `data-decoder-service`
+   */
+  static getDataDecoderServiceKey(): string {
+    return CircuitBreakerKeys.SERVICE_PREFIX.DATA_DECODER_SERVICE;
   }
 }

--- a/src/modules/data-decoder/datasources/data-decoder-api.service.spec.ts
+++ b/src/modules/data-decoder/datasources/data-decoder-api.service.spec.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import { getAddress, type Hex } from 'viem';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
 import type { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
+import { CircuitBreakerKeys } from '@/datasources/circuit-breaker/circuit-breaker.keys';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import { NetworkResponseError } from '@/datasources/network/entities/network.error.entity';
 import { pageBuilder } from '@/domain/entities/__tests__/page.builder';
@@ -82,6 +83,11 @@ describe('DataDecoderApi', () => {
         url: getDataDecodedUrl,
         notFoundExpireTimeSeconds,
         data: { chainId, to, data },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
+          },
+        },
       });
     });
 
@@ -123,6 +129,11 @@ describe('DataDecoderApi', () => {
         url: getDataDecodedUrl,
         notFoundExpireTimeSeconds,
         data: { chainId, to, data },
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
+          },
+        },
       });
     });
   });
@@ -159,6 +170,9 @@ describe('DataDecoderApi', () => {
             chain_ids: contract.chainId.toString(),
             limit: undefined,
             offset: undefined,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
           },
         },
       });
@@ -209,6 +223,9 @@ describe('DataDecoderApi', () => {
             limit: undefined,
             offset: undefined,
           },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
+          },
         },
       });
     });
@@ -254,6 +271,9 @@ describe('DataDecoderApi', () => {
             limit,
             offset,
           },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
+          },
         },
       });
     });
@@ -292,6 +312,9 @@ describe('DataDecoderApi', () => {
             trusted_for_delegate_call: true,
             limit: undefined,
             offset: undefined,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
           },
         },
       });
@@ -340,6 +363,9 @@ describe('DataDecoderApi', () => {
             trusted_for_delegate_call: true,
             limit: undefined,
             offset: undefined,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
           },
         },
       });

--- a/src/modules/data-decoder/datasources/data-decoder-api.service.ts
+++ b/src/modules/data-decoder/datasources/data-decoder-api.service.ts
@@ -4,6 +4,7 @@ import type { Address } from 'viem';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { CacheFirstDataSource } from '@/datasources/cache/cache.first.data.source';
 import { CacheRouter } from '@/datasources/cache/cache.router';
+import { CircuitBreakerKeys } from '@/datasources/circuit-breaker/circuit-breaker.keys';
 import { HttpErrorFactory } from '@/datasources/errors/http-error-factory';
 import type { Page } from '@/domain/entities/page.entity';
 import type { IDataDecoderApi } from '@/domain/interfaces/data-decoder-api.interface';
@@ -61,6 +62,11 @@ export class DataDecoderApi implements IDataDecoderApi {
         notFoundExpireTimeSeconds: this.defaultNotFoundExpirationTimeSeconds,
         url,
         data: args,
+        networkRequest: {
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
+          },
+        },
       });
     } catch (error) {
       throw this.httpErrorFactory.from(error);
@@ -91,6 +97,9 @@ export class DataDecoderApi implements IDataDecoderApi {
             limit: args.limit,
             offset: args.offset,
           },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
+          },
         },
       });
     } catch (error) {
@@ -118,6 +127,9 @@ export class DataDecoderApi implements IDataDecoderApi {
             trusted_for_delegate_call: true,
             limit: args.limit,
             offset: args.offset,
+          },
+          circuitBreaker: {
+            key: CircuitBreakerKeys.getDataDecoderServiceKey(),
           },
         },
       });


### PR DESCRIPTION
## Summary

Enables the circuit breaker on Data Decoder Service calls. The circuit breaker was previously only applied to Safe Transaction Service calls, so a degraded decoder service would keep receiving requests and slow down the gateway.

Resolves [WA-2553](https://linear.app/safe-global/issue/WA-2553/enable-circuit-breaker-on-data-decoder-service-calls)

## Changes

- **`src/datasources/circuit-breaker/circuit-breaker.keys.ts`**: added `getDataDecoderServiceKey()`, returning a single global key (`data-decoder-service`). Unlike the per-chain Transaction Services (`txs-service-{chainId}`), the decoder service is a single deployment serving all chains, so a chain-scoped key would fragment failure counts and delay the circuit from opening.
- **`src/modules/data-decoder/datasources/data-decoder-api.service.ts`**: all three outbound calls (`getDecodedData`, `getContracts`, `getTrustedForDelegateCallContracts`) now pass `networkRequest.circuitBreaker` with that key, mirroring the existing Transaction Service pattern.
- **`src/modules/data-decoder/datasources/data-decoder-api.service.spec.ts`**: updated call assertions to include the new `circuitBreaker` field.

## Notes

- No changes to the circuit breaker service, network module, or configuration — the existing `CIRCUIT_BREAKER_*` env vars (enabled, threshold, timeout, rolling window) govern this circuit as well, since the config is global.
- The `data-decoder-service` circuit has independent state: failures against the decoder service never count toward any Transaction Service circuit, and vice versa.
- Enabled/disabled behavior is already covered by `circuit-breaker.service.spec.ts` and `network.module.integration.spec.ts`; the decoder API spec only asserts the key is passed, consistent with `transaction-api.service.spec.ts`.

## Testing

- `yarn test` — decoder API and circuit breaker suites pass (36 tests)
- `yarn tsc --noEmit` — clean
- `yarn lint` — clean