### PR TITLE
chore: Fix flaky unit test

### DIFF
--- a/src/modules/auth/utils/auth-redirect.helper.spec.ts
+++ b/src/modules/auth/utils/auth-redirect.helper.spec.ts
@@ -162,7 +162,7 @@ describe('Auth-redirect helper functions', () => {
       });
 
       it('should accept subdomain of allowed domain', () => {
-        const subdomain = faker.word.noun();
+        const subdomain = faker.internet.domainWord();
         const path = `/${faker.word.noun()}`;
         const url = `https://${subdomain}.${allowedDomain}${path}`;
 


### PR DESCRIPTION
## Summary

Detected here: https://github.com/safe-global/safe-client-gateway/actions/runs/27347232616/job/80799104507

```
Summary of all failing tests
FAIL src/modules/auth/utils/auth-redirect.helper.spec.ts
  ● Auth-redirect helper functions › resolveAndValidateRedirectUrl › non-production with allowedRedirectDomain › should accept subdomain of allowed domain

    expect(received).toBe(expected) // Object.is equality

    Expected: "https://suv.nice-jogging.info/meal"
    Received: "https://suv.nice-jogging.info/meal"

      167 |         const url = `https://${subdomain}.${allowedDomain}${path}`;
      168 |
    > 169 |         expect(resolveAndValidateRedirectUrl(config, url)).toBe(url);
          |                                                            ^
      170 |       });
      171 |
      172 |       it('should accept exact match of allowed domain', () => {

      at Object.<anonymous> (src/modules/auth/utils/auth-redirect.helper.spec.ts:169:60)
```

## Changes

- Fix the flaky unit test