### PR TITLE
Feat/space audit log

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -702,6 +702,12 @@
     "required": true
   },
   {
+    "name": "FF_SPACE_AUDIT_LOG",
+    "description": "Enable the append-only space audit log (OPTIONAL)",
+    "defaultValue": false,
+    "required": true
+  },
+  {
     "name": "FF_TRUSTED_DELEGATE_CALL",
     "description": "Enable trusted delegate call validation (OPTIONAL)",
     "defaultValue": true,

--- a/migrations/1781200000000-create-space-audit-log.ts
+++ b/migrations/1781200000000-create-space-audit-log.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSpaceAuditLog1781200000000 implements MigrationInterface {
+  name = 'CreateSpaceAuditLog1781200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "space_audit_log" (
+        "id" BIGINT GENERATED ALWAYS AS IDENTITY,
+        -- no FK: the log must survive space deletion
+        "space_id" integer NOT NULL,
+        "space_uuid" uuid NOT NULL,
+        "event_type" character varying(64) NOT NULL,
+        "actor_user_id" integer NOT NULL,
+        "payload" jsonb NOT NULL DEFAULT '{}',
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "PK_SAL_id" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_SAL_space_created_id" ON "space_audit_log" ("space_id", "created_at", "id")`,
+    );
+
+    await queryRunner.query(`
+      CREATE FUNCTION space_audit_log_immutable()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          RAISE EXCEPTION 'space_audit_log is append-only';
+      END;
+      $$ language 'plpgsql';`);
+    await queryRunner.query(`
+      CREATE TRIGGER space_audit_log_no_update_delete
+        BEFORE UPDATE OR DELETE ON space_audit_log
+        FOR EACH ROW EXECUTE PROCEDURE space_audit_log_immutable();`);
+    await queryRunner.query(`
+      CREATE TRIGGER space_audit_log_no_truncate
+        BEFORE TRUNCATE ON space_audit_log
+        FOR EACH STATEMENT EXECUTE PROCEDURE space_audit_log_immutable();`);
+
+    await queryRunner.query(`
+      CREATE FUNCTION space_audit_log_force_created_at()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          NEW.created_at = CURRENT_TIMESTAMP;
+          RETURN NEW;
+      END;
+      $$ language 'plpgsql';`);
+    await queryRunner.query(`
+      CREATE TRIGGER space_audit_log_force_created_at
+        BEFORE INSERT ON space_audit_log
+        FOR EACH ROW EXECUTE PROCEDURE space_audit_log_force_created_at();`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "space_audit_log"`);
+    await queryRunner.query(
+      `DROP FUNCTION IF EXISTS space_audit_log_immutable`,
+    );
+    await queryRunner.query(
+      `DROP FUNCTION IF EXISTS space_audit_log_force_created_at`,
+    );
+  }
+}

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -223,6 +223,7 @@ export default (): ReturnType<typeof configuration> => ({
     vaultTransactionsMapping: false,
     lifiTransactionsMapping: false,
     cacheInFlightRequests: false,
+    spaceAuditLog: true,
   },
   httpClient: {
     requestTimeout: faker.number.int(),

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -423,6 +423,7 @@ export default () => ({
     cacheInFlightRequests:
       process.env.HTTP_CLIENT_CACHE_IN_FLIGHT_REQUESTS?.toLowerCase() ===
       'true',
+    spaceAuditLog: process.env.FF_SPACE_AUDIT_LOG?.toLowerCase() === 'true',
   },
   httpClient: {
     // Timeout in milliseconds to be used for the HTTP client.

--- a/src/modules/spaces/datasources/entities/__tests__/space-audit-log.entity.db.builder.ts
+++ b/src/modules/spaces/datasources/entities/__tests__/space-audit-log.entity.db.builder.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import type { IBuilder } from '@/__tests__/builder';
+import { Builder } from '@/__tests__/builder';
+import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
+import type { SpaceAuditLog } from '@/modules/spaces/datasources/entities/space-audit-log.entity.db';
+import { fakeUuid } from '@/validation/entities/schemas/__tests__/uuid.builder';
+
+export function spaceAuditLogBuilder(): IBuilder<SpaceAuditLog> {
+  return new Builder<SpaceAuditLog>()
+    .with('id', faker.number.int({ max: DB_MAX_SAFE_INTEGER }).toString())
+    .with('spaceId', faker.number.int({ max: DB_MAX_SAFE_INTEGER }))
+    .with('spaceUuid', fakeUuid())
+    .with('eventType', 'MEMBER_INVITE_ACCEPTED')
+    .with('actorUserId', faker.number.int({ max: DB_MAX_SAFE_INTEGER }))
+    .with('payload', {
+      targetUserId: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
+    })
+    .with('createdAt', new Date());
+}

--- a/src/modules/spaces/datasources/entities/space-audit-log.entity.db.ts
+++ b/src/modules/spaces/datasources/entities/space-audit-log.entity.db.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { UUID } from 'node:crypto';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import type {
+  SpaceAuditEventPayload,
+  SpaceAuditEventType,
+} from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+
+/**
+ * Append-only audit log of space mutations. Rows are immutable — the table
+ * carries triggers that reject UPDATE/DELETE/TRUNCATE.
+ */
+@Entity('space_audit_log')
+@Index('IDX_SAL_space_created_id', ['spaceId', 'createdAt', 'id'])
+export class SpaceAuditLog {
+  @PrimaryGeneratedColumn('identity', {
+    type: 'bigint',
+    generatedIdentity: 'ALWAYS',
+    primaryKeyConstraintName: 'PK_SAL_id',
+  })
+  id!: string;
+
+  @Column({ name: 'space_id', type: 'integer', update: false })
+  spaceId!: number;
+
+  @Column({ name: 'space_uuid', type: 'uuid', update: false })
+  spaceUuid!: UUID;
+
+  @Column({
+    name: 'event_type',
+    type: 'varchar',
+    length: 64,
+    update: false,
+  })
+  eventType!: keyof typeof SpaceAuditEventType;
+
+  @Column({ name: 'actor_user_id', type: 'integer', update: false })
+  actorUserId!: number;
+
+  @Column({ type: 'jsonb', default: {}, update: false })
+  payload!: SpaceAuditEventPayload;
+
+  @Column({
+    name: 'created_at',
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+    update: false,
+    insert: false,
+  })
+  createdAt!: Date;
+}

--- a/src/modules/spaces/domain/address-books/address-book-items.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/address-books/address-book-items.repository.integration.spec.ts
@@ -25,6 +25,7 @@ import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.ent
 import { AddressBookItemsRepository } from '@/modules/spaces/domain/address-books/address-book-items.repository';
 import type { IAddressBookItemsRepository } from '@/modules/spaces/domain/address-books/address-book-items.repository.interface';
 import { addressBookItemBuilder } from '@/modules/spaces/domain/address-books/entities/__tests__/address-book-item.db.builder';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { spaceBuilder } from '@/modules/spaces/domain/entities/__tests__/space.entity.db.builder';
 import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
@@ -122,8 +123,13 @@ describe('AddressBookItemsRepository', () => {
 
     addressBookItemsRepository = new AddressBookItemsRepository(
       dbService,
-      new SpacesRepository(dbService, mockConfigurationService),
+      new SpacesRepository(
+        dbService,
+        mockConfigurationService,
+        createMockSpaceAuditRepository(),
+      ),
       mockConfigService,
+      createMockSpaceAuditRepository(),
     );
   });
 

--- a/src/modules/spaces/domain/address-books/address-book-items.repository.interface.ts
+++ b/src/modules/spaces/domain/address-books/address-book-items.repository.interface.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
+import type { EntityManager } from 'typeorm';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import type { AddressBookDbItem } from '@/modules/spaces/domain/address-books/entities/address-book-item.db.entity';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
@@ -32,12 +33,15 @@ export interface IAddressBookItemsRepository {
    * @param args.createdByOverride - If provided, new items are attributed to this
    *   user ID instead of the authenticated user. Used by the request-approval flow
    *   to attribute creation to the original requester.
+   * @param args.entityManager - If provided, the upsert joins this (caller-owned)
+   *   transaction instead of opening its own.
    */
   upsertMany(args: {
     authPayload: AuthPayload;
     spaceId: Space['id'];
     addressBookItems: UpsertAddressBookItemsDto['items'];
     createdByOverride?: number;
+    entityManager?: EntityManager;
   }): Promise<Array<AddressBookDbItem>>;
 
   /**

--- a/src/modules/spaces/domain/address-books/address-book-items.repository.ts
+++ b/src/modules/spaces/domain/address-books/address-book-items.repository.ts
@@ -11,6 +11,8 @@ import { AddressBookItem as DbAddressBookItem } from '@/modules/spaces/datasourc
 import { IAddressBookItemsRepository } from '@/modules/spaces/domain/address-books/address-book-items.repository.interface';
 import type { AddressBookDbItem } from '@/modules/spaces/domain/address-books/entities/address-book-item.db.entity';
 import { AddressBookItem } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { UpsertAddressBookItemsDto } from '@/modules/spaces/routes/entities/upsert-address-book-items.dto.entity';
@@ -28,6 +30,8 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
     private readonly spacesRepository: ISpacesRepository,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
   ) {
     this.maxItems = this.configurationService.getOrThrow<number>(
       'spaces.addressBooks.maxItems',
@@ -51,15 +55,18 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
     spaceId: Space['id'];
     addressBookItems: UpsertAddressBookItemsDto['items'];
     createdByOverride?: number;
+    entityManager?: EntityManager;
   }): Promise<Array<AddressBookDbItem>> {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
     const space = await this.getSpaceAs({
       ...args,
       memberRoleIn: ['ADMIN'],
     });
-    const repository = await this.db.getRepository(DbAddressBookItem);
-    await this.db.transaction(async (entityManager) => {
-      const existingAddresses = await this.updateExistingAddressBookItems({
+
+    const run = async (
+      entityManager: EntityManager,
+    ): Promise<Array<AddressBookDbItem>> => {
+      const updated = await this.updateExistingAddressBookItems({
         entityManager,
         addressBookItems: args.addressBookItems,
         space,
@@ -68,8 +75,8 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
 
       const newAddressBookItems = args.addressBookItems.filter(
         (item) =>
-          !existingAddresses.some((existingItem) =>
-            isAddressEqual(existingItem, item.address),
+          !updated.some((existingItem) =>
+            isAddressEqual(existingItem.address, item.address),
           ),
       );
 
@@ -80,8 +87,34 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
         userId,
         createdByOverride: args.createdByOverride,
       });
-    });
-    return repository.findBy({ space: { id: space.id } });
+
+      if (updated.length > 0 || newAddressBookItems.length > 0) {
+        await this.spaceAuditRepository.record(entityManager, {
+          spaceId: space.id,
+          spaceUuid: space.uuid,
+          eventType: SpaceAuditEventType.ADDRESS_BOOK_UPSERTED,
+          actorUserId: userId,
+          payload: {
+            created: newAddressBookItems.map((item) => ({
+              address: item.address,
+              name: item.name,
+            })),
+            updated,
+            ...(args.createdByOverride !== undefined && {
+              onBehalfOfUserId: args.createdByOverride,
+            }),
+          },
+        });
+      }
+
+      return entityManager.findBy(DbAddressBookItem, {
+        space: { id: space.id },
+      });
+    };
+
+    return args.entityManager
+      ? await run(args.entityManager)
+      : await this.db.transaction(run);
   }
 
   public async deleteByAddress(args: {
@@ -89,15 +122,29 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
     spaceId: Space['id'];
     address: AddressBookDbItem['address'];
   }): Promise<void> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
     const space = await this.getSpaceAs({
       ...args,
       memberRoleIn: ['ADMIN'],
     });
-    const repository = await this.db.getRepository(DbAddressBookItem);
 
-    await repository.delete({
-      address: args.address,
-      space: { id: space.id },
+    await this.db.transaction(async (entityManager) => {
+      const item = await entityManager.findOne(DbAddressBookItem, {
+        where: { address: args.address, space: { id: space.id } },
+      });
+      if (!item) {
+        return;
+      }
+
+      await entityManager.delete(DbAddressBookItem, item.id);
+
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.ADDRESS_BOOK_DELETED,
+        actorUserId: userId,
+        payload: { address: item.address, name: item.name },
+      });
     });
   }
 
@@ -119,17 +166,19 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
     });
   }
 
+  /** @returns the updated items as `{ address, name }` pairs (new name). */
   private async updateExistingAddressBookItems(args: {
     userId: number;
     addressBookItems: Array<AddressBookItem>;
     space: Space;
     entityManager: EntityManager;
-  }): Promise<Array<DbAddressBookItem['address']>> {
+  }): Promise<Array<Pick<DbAddressBookItem, 'address' | 'name'>>> {
     const repository = args.entityManager.getRepository(DbAddressBookItem);
     const existingAddressBookItems = await repository.findBy({
       space: { id: args.space.id },
       address: In(args.addressBookItems.map((item) => item.address)),
     });
+    const updated: Array<Pick<DbAddressBookItem, 'address' | 'name'>> = [];
     for (const item of existingAddressBookItems) {
       const patch = args.addressBookItems.find((addressBookItem) =>
         isAddressEqual(addressBookItem.address, item.address),
@@ -142,8 +191,9 @@ export class AddressBookItemsRepository implements IAddressBookItemsRepository {
         chainIds: patch.chainIds,
         lastUpdatedBy: args.userId,
       });
+      updated.push({ address: item.address, name: patch.name });
     }
-    return existingAddressBookItems.map((item) => item.address);
+    return updated;
   }
 
   private async createNewAddressBookItems(args: {

--- a/src/modules/spaces/domain/address-books/address-book-requests.repository.interface.ts
+++ b/src/modules/spaces/domain/address-books/address-book-requests.repository.interface.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
+import type { EntityManager } from 'typeorm';
 import type { AddressBookItem } from '@/modules/spaces/domain/address-books/entities/address-book-item.entity';
 import type {
   AddressBookRequest,
@@ -40,10 +41,6 @@ export interface IAddressBookRequestsRepository {
     spaceId: Space['id'];
     toStatus: 'APPROVED' | 'REJECTED';
     reviewedBy: User['id'];
+    entityManager?: EntityManager;
   }): Promise<boolean>;
-
-  revertToPending(args: {
-    id: AddressBookRequest['id'];
-    spaceId: Space['id'];
-  }): Promise<void>;
 }

--- a/src/modules/spaces/domain/address-books/address-book-requests.repository.ts
+++ b/src/modules/spaces/domain/address-books/address-book-requests.repository.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import { Injectable, NotFoundException } from '@nestjs/common';
-import type { FindOptionsWhere, InsertResult } from 'typeorm';
+import type { EntityManager, FindOptionsWhere, InsertResult } from 'typeorm';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
@@ -110,23 +110,15 @@ export class AddressBookRequestsRepository
     spaceId: Space['id'];
     toStatus: 'APPROVED' | 'REJECTED';
     reviewedBy: User['id'];
+    entityManager?: EntityManager;
   }): Promise<boolean> {
-    const repository = await this.db.getRepository(DbAddressBookRequest);
+    const repository = args.entityManager
+      ? args.entityManager.getRepository(DbAddressBookRequest)
+      : await this.db.getRepository(DbAddressBookRequest);
     const result = await repository.update(
       { id: args.id, space: { id: args.spaceId }, status: 'PENDING' },
       { status: args.toStatus, reviewedBy: args.reviewedBy },
     );
     return (result.affected ?? 0) > 0;
-  }
-
-  public async revertToPending(args: {
-    id: AddressBookRequest['id'];
-    spaceId: Space['id'];
-  }): Promise<void> {
-    const repository = await this.db.getRepository(DbAddressBookRequest);
-    await repository.update(
-      { id: args.id, space: { id: args.spaceId } },
-      { status: 'PENDING', reviewedBy: null },
-    );
   }
 }

--- a/src/modules/spaces/domain/audit/__tests__/space-audit.repository.mock.ts
+++ b/src/modules/spaces/domain/audit/__tests__/space-audit.repository.mock.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
+
+export function createMockSpaceAuditRepository(): jest.MockedObjectDeep<ISpaceAuditRepository> {
+  return {
+    record: jest.fn(),
+    findBySpaceId: jest.fn(),
+    findDistinctActorIds: jest.fn(),
+  } as jest.MockedObjectDeep<ISpaceAuditRepository>;
+}

--- a/src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts
+++ b/src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts
@@ -36,10 +36,6 @@ export const SpaceAuditEventTypeSchema = z.enum(
   getStringEnumKeys(SpaceAuditEventType),
 );
 
-const LowercaseAddressSchema = AddressSchema.transform((value) =>
-  value.toLowerCase(),
-);
-
 const UserIdSchema = z.number().int().positive();
 
 const SpaceFieldsSchema = z.object({
@@ -49,11 +45,11 @@ const SpaceFieldsSchema = z.object({
 
 const SpaceSafeSchema = z.object({
   chainId: NumericStringSchema,
-  address: LowercaseAddressSchema,
+  address: AddressSchema,
 });
 
 const AddressBookEntrySchema = z.object({
-  address: LowercaseAddressSchema,
+  address: AddressSchema,
   name: z.string(),
 });
 
@@ -148,7 +144,7 @@ export const AddressBookUpsertedEventSchema = z.object({
 export const AddressBookDeletedEventSchema = z.object({
   eventType: z.literal(SpaceAuditEventType.ADDRESS_BOOK_DELETED),
   payload: z.object({
-    address: LowercaseAddressSchema,
+    address: AddressSchema,
     name: z.string(),
   }),
 });
@@ -174,3 +170,7 @@ export const SpaceAuditEventSchema = z.discriminatedUnion('eventType', [
 export type SpaceAuditEvent = z.infer<typeof SpaceAuditEventSchema>;
 
 export type SpaceAuditEventPayload = SpaceAuditEvent['payload'];
+
+export type SpaceUpdatedPayload = z.infer<
+  typeof SpaceUpdatedEventSchema
+>['payload'];

--- a/src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts
+++ b/src/modules/spaces/domain/audit/entities/space-audit-event.entity.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { z } from 'zod';
+import { getStringEnumKeys } from '@/domain/common/utils/enum';
+import { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
+import { MemberRole } from '@/modules/users/domain/entities/member.entity';
+import { AddressSchema } from '@/validation/entities/schemas/address.schema';
+import { NumericStringSchema } from '@/validation/entities/schemas/numeric-string.schema';
+
+/**
+ * Event taxonomy of the append-only space audit log.
+ *
+ * Payloads are additive-only: rows are immutable, so a shape can gain
+ * optional fields but semantic changes require a new event type. The web
+ * app mirrors these shapes in its audit event copy.
+ */
+
+export enum SpaceAuditEventType {
+  SPACE_CREATED = 'SPACE_CREATED',
+  SPACE_UPDATED = 'SPACE_UPDATED',
+  SPACE_DELETED = 'SPACE_DELETED',
+  MEMBER_INVITED = 'MEMBER_INVITED',
+  MEMBER_INVITE_ACCEPTED = 'MEMBER_INVITE_ACCEPTED',
+  MEMBER_INVITE_DECLINED = 'MEMBER_INVITE_DECLINED',
+  MEMBER_INVITE_RENEWED = 'MEMBER_INVITE_RENEWED',
+  MEMBER_ROLE_UPDATED = 'MEMBER_ROLE_UPDATED',
+  MEMBER_ALIAS_UPDATED = 'MEMBER_ALIAS_UPDATED',
+  MEMBER_REMOVED = 'MEMBER_REMOVED',
+  MEMBER_LEFT = 'MEMBER_LEFT',
+  SAFE_ADDED = 'SAFE_ADDED',
+  SAFE_REMOVED = 'SAFE_REMOVED',
+  ADDRESS_BOOK_UPSERTED = 'ADDRESS_BOOK_UPSERTED',
+  ADDRESS_BOOK_DELETED = 'ADDRESS_BOOK_DELETED',
+}
+
+export const SpaceAuditEventTypeSchema = z.enum(
+  getStringEnumKeys(SpaceAuditEventType),
+);
+
+const LowercaseAddressSchema = AddressSchema.transform((value) =>
+  value.toLowerCase(),
+);
+
+const UserIdSchema = z.number().int().positive();
+
+const SpaceFieldsSchema = z.object({
+  name: z.string().optional(),
+  status: z.enum(getStringEnumKeys(SpaceStatus)).optional(),
+});
+
+const SpaceSafeSchema = z.object({
+  chainId: NumericStringSchema,
+  address: LowercaseAddressSchema,
+});
+
+const AddressBookEntrySchema = z.object({
+  address: LowercaseAddressSchema,
+  name: z.string(),
+});
+
+export const SpaceCreatedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.SPACE_CREATED),
+  payload: z.object({ name: z.string() }),
+});
+
+export const SpaceUpdatedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.SPACE_UPDATED),
+  payload: z.object({ old: SpaceFieldsSchema, new: SpaceFieldsSchema }),
+});
+
+export const SpaceDeletedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.SPACE_DELETED),
+  payload: z.object({ name: z.string() }),
+});
+
+export const MemberInvitedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_INVITED),
+  payload: z.object({
+    targetUserId: UserIdSchema,
+    role: z.enum(getStringEnumKeys(MemberRole)),
+    reinvite: z.boolean().optional(),
+  }),
+});
+
+export const MemberInviteAcceptedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_INVITE_ACCEPTED),
+  payload: z.object({ targetUserId: UserIdSchema }),
+});
+
+export const MemberInviteDeclinedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_INVITE_DECLINED),
+  payload: z.object({ targetUserId: UserIdSchema }),
+});
+
+export const MemberInviteRenewedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_INVITE_RENEWED),
+  payload: z.object({ targetUserId: UserIdSchema }),
+});
+
+export const MemberRoleUpdatedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_ROLE_UPDATED),
+  payload: z.object({
+    targetUserId: UserIdSchema,
+    oldRole: z.enum(getStringEnumKeys(MemberRole)),
+    newRole: z.enum(getStringEnumKeys(MemberRole)),
+  }),
+});
+
+export const MemberAliasUpdatedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_ALIAS_UPDATED),
+  payload: z.object({ targetUserId: UserIdSchema }),
+});
+
+export const MemberRemovedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_REMOVED),
+  payload: z.object({
+    targetUserId: UserIdSchema,
+    accountDeleted: z.boolean().optional(),
+  }),
+});
+
+export const MemberLeftEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.MEMBER_LEFT),
+  payload: z.object({
+    targetUserId: UserIdSchema,
+    accountDeleted: z.boolean().optional(),
+  }),
+});
+
+export const SafeAddedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.SAFE_ADDED),
+  payload: z.object({ safes: z.array(SpaceSafeSchema) }),
+});
+
+export const SafeRemovedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.SAFE_REMOVED),
+  payload: z.object({ safes: z.array(SpaceSafeSchema) }),
+});
+
+export const AddressBookUpsertedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.ADDRESS_BOOK_UPSERTED),
+  payload: z.object({
+    created: z.array(AddressBookEntrySchema),
+    updated: z.array(AddressBookEntrySchema),
+    onBehalfOfUserId: UserIdSchema.optional(),
+  }),
+});
+
+export const AddressBookDeletedEventSchema = z.object({
+  eventType: z.literal(SpaceAuditEventType.ADDRESS_BOOK_DELETED),
+  payload: z.object({
+    address: LowercaseAddressSchema,
+    name: z.string(),
+  }),
+});
+
+export const SpaceAuditEventSchema = z.discriminatedUnion('eventType', [
+  SpaceCreatedEventSchema,
+  SpaceUpdatedEventSchema,
+  SpaceDeletedEventSchema,
+  MemberInvitedEventSchema,
+  MemberInviteAcceptedEventSchema,
+  MemberInviteDeclinedEventSchema,
+  MemberInviteRenewedEventSchema,
+  MemberRoleUpdatedEventSchema,
+  MemberAliasUpdatedEventSchema,
+  MemberRemovedEventSchema,
+  MemberLeftEventSchema,
+  SafeAddedEventSchema,
+  SafeRemovedEventSchema,
+  AddressBookUpsertedEventSchema,
+  AddressBookDeletedEventSchema,
+]);
+
+export type SpaceAuditEvent = z.infer<typeof SpaceAuditEventSchema>;
+
+export type SpaceAuditEventPayload = SpaceAuditEvent['payload'];

--- a/src/modules/spaces/domain/audit/space-audit.module.ts
+++ b/src/modules/spaces/domain/audit/space-audit.module.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
+import { SpaceAuditLog } from '@/modules/spaces/datasources/entities/space-audit-log.entity.db';
+import { SpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
+
+/**
+ * Leaf module of the append-only space audit log, consumed by both
+ * `SpacesModule` and `UsersModule`. Writes are gated by
+ * `features.spaceAuditLog`.
+ */
+@Module({
+  imports: [
+    PostgresDatabaseModuleV2,
+    TypeOrmModule.forFeature([SpaceAuditLog]),
+  ],
+  providers: [
+    {
+      provide: ISpaceAuditRepository,
+      useClass: SpaceAuditRepository,
+    },
+  ],
+  exports: [ISpaceAuditRepository],
+})
+export class SpaceAuditModule {}

--- a/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
@@ -1,0 +1,633 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { faker } from '@faker-js/faker';
+import type { ConfigService } from '@nestjs/config';
+import { DataSource } from 'typeorm';
+import type { IConfigurationService } from '@/config/configuration.service.interface';
+import configuration from '@/config/entities/__tests__/configuration';
+import { postgresConfig } from '@/config/entities/postgres.config';
+import { DatabaseMigrator } from '@/datasources/db/v2/database-migrator.service';
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { nameBuilder } from '@/domain/common/entities/name.builder';
+import type { ILoggingService } from '@/logging/logging.interface';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { SpaceAuditLog } from '@/modules/spaces/datasources/entities/space-audit-log.entity.db';
+import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { SpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository';
+import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
+import {
+  InviteType,
+  type InviteUserInput,
+} from '@/modules/spaces/routes/entities/invite-users.dto.entity';
+import { Member } from '@/modules/users/datasources/entities/member.entity.db';
+import { User } from '@/modules/users/datasources/entities/users.entity.db';
+import { MembersRepository } from '@/modules/users/domain/members.repository';
+import { UsersRepository } from '@/modules/users/domain/users.repository';
+import { Wallet } from '@/modules/wallets/datasources/entities/wallets.entity.db';
+import { WalletsRepository } from '@/modules/wallets/domain/wallets.repository';
+import { fakeEmailAddress } from '@/validation/entities/schemas/__tests__/email-address.builder';
+
+const mockLoggingService = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+} as jest.MockedObjectDeep<ILoggingService>;
+
+const mockConfigurationService = jest.mocked({
+  getOrThrow: jest.fn(),
+} as jest.MockedObjectDeep<IConfigurationService>);
+
+describe('SpaceAuditRepository', () => {
+  let postgresDatabaseService: PostgresDatabaseService;
+  let spaceAuditRepository: SpaceAuditRepository;
+  let spacesRepository: SpacesRepository;
+  let membersRepository: MembersRepository;
+  let usersRepository: UsersRepository;
+
+  const testDatabaseName = faker.string.alpha({ length: 10, casing: 'lower' });
+  const testConfiguration = configuration();
+
+  const dataSource = new DataSource({
+    ...postgresConfig({
+      ...testConfiguration.db.connection.postgres,
+      type: 'postgres',
+      database: testDatabaseName,
+    }),
+    migrationsTableName: testConfiguration.db.orm.migrationsTableName,
+    entities: [Member, Space, SpaceAuditLog, SpaceSafe, User, Wallet],
+  });
+
+  const dbUserRepo = dataSource.getRepository(User);
+  const dbWalletRepo = dataSource.getRepository(Wallet);
+  const dbMembersRepo = dataSource.getRepository(Member);
+  const dbAuditRepo = dataSource.getRepository(SpaceAuditLog);
+
+  beforeAll(async () => {
+    // Create database
+    const testDataSource = new DataSource({
+      ...postgresConfig({
+        ...testConfiguration.db.connection.postgres,
+        type: 'postgres',
+        database: 'postgres',
+      }),
+    });
+    const testPostgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      testDataSource,
+    );
+    await testPostgresDatabaseService.initializeDatabaseConnection();
+    await testPostgresDatabaseService
+      .getDataSource()
+      .query(`CREATE DATABASE ${testDatabaseName}`);
+    await testPostgresDatabaseService.destroyDatabaseConnection();
+
+    // Create database connection
+    postgresDatabaseService = new PostgresDatabaseService(
+      mockLoggingService,
+      dataSource,
+    );
+    await postgresDatabaseService.initializeDatabaseConnection();
+
+    // Migrate database
+    const mockConfigService = {
+      getOrThrow: jest.fn().mockImplementation((key: string) => {
+        if (key === 'db.migrator.numberOfRetries') {
+          return testConfiguration.db.migrator.numberOfRetries;
+        }
+        if (key === 'db.migrator.retryAfterMs') {
+          return testConfiguration.db.migrator.retryAfterMs;
+        }
+      }),
+    } as jest.MockedObjectDeep<ConfigService>;
+    const migrator = new DatabaseMigrator(
+      mockLoggingService,
+      postgresDatabaseService,
+      mockConfigService,
+    );
+    await migrator.migrate();
+
+    mockConfigurationService.getOrThrow.mockImplementation((key) => {
+      if (key === 'features.spaceAuditLog') {
+        return true;
+      }
+      if (key === 'spaces.maxSpaceCreationsPerUser') {
+        return testConfiguration.spaces.maxSpaceCreationsPerUser;
+      }
+    });
+
+    spaceAuditRepository = new SpaceAuditRepository(
+      postgresDatabaseService,
+      mockConfigurationService,
+    );
+    spacesRepository = new SpacesRepository(
+      postgresDatabaseService,
+      mockConfigurationService,
+      spaceAuditRepository,
+    );
+    const walletsRepository = new WalletsRepository(postgresDatabaseService);
+    usersRepository = new UsersRepository(
+      postgresDatabaseService,
+      walletsRepository,
+      spaceAuditRepository,
+    );
+    membersRepository = new MembersRepository(
+      postgresDatabaseService,
+      usersRepository,
+      spacesRepository,
+      spaceAuditRepository,
+    );
+  });
+
+  afterEach(async () => {
+    // Audit rows are deliberately NOT deleted (the triggers forbid it):
+    // every test works on a fresh space and scopes its reads by spaceId.
+    await dbMembersRepo.createQueryBuilder().delete().where('1=1').execute();
+    await dataSource
+      .getRepository(Space)
+      .createQueryBuilder()
+      .delete()
+      .where('1=1')
+      .execute();
+    await dbWalletRepo.createQueryBuilder().delete().where('1=1').execute();
+    await dbUserRepo.createQueryBuilder().delete().where('1=1').execute();
+  });
+
+  afterAll(async () => {
+    await postgresDatabaseService.getDataSource().dropDatabase();
+    await postgresDatabaseService.destroyDatabaseConnection();
+  });
+
+  async function createSiweUser(): Promise<{
+    userId: number;
+    authPayload: AuthPayload;
+  }> {
+    const user = await dbUserRepo.insert({ status: 'ACTIVE' });
+    const userId = user.generatedMaps[0].id as number;
+    const authPayloadDto = siweAuthPayloadDtoBuilder()
+      .with('sub', userId.toString())
+      .build();
+    await dbWalletRepo.insert({
+      user: user.generatedMaps[0],
+      address: authPayloadDto.signer_address,
+    });
+    return { userId, authPayload: new AuthPayload(authPayloadDto) };
+  }
+
+  async function createSpaceWithAdmin(): Promise<{
+    spaceId: number;
+    spaceUuid: Space['uuid'];
+    adminUserId: number;
+    adminAuthPayload: AuthPayload;
+  }> {
+    const { userId, authPayload } = await createSiweUser();
+    const space = await spacesRepository.create({
+      userId,
+      name: nameBuilder(),
+      status: 'ACTIVE',
+    });
+    return {
+      spaceId: space.id,
+      spaceUuid: space.uuid,
+      adminUserId: userId,
+      adminAuthPayload: authPayload,
+    };
+  }
+
+  async function inviteUser(args: {
+    spaceId: number;
+    adminAuthPayload: AuthPayload;
+    role?: 'ADMIN' | 'MEMBER';
+  }): Promise<{ userId: number; authPayload: AuthPayload }> {
+    const invitee = await createSiweUser();
+    const wallet = await dbWalletRepo.findOneOrFail({
+      where: { user: { id: invitee.userId } },
+    });
+    await membersRepository.inviteUsers({
+      authPayload: args.adminAuthPayload,
+      spaceId: args.spaceId,
+      users: [
+        {
+          type: InviteType.Wallet,
+          address: wallet.address,
+          role: args.role ?? 'MEMBER',
+          name: nameBuilder(),
+        },
+      ],
+      inviteExpiresAt: faker.date.future(),
+    });
+    return invitee;
+  }
+
+  describe('record (through instrumented mutations)', () => {
+    it('should record SPACE_CREATED on space creation', async () => {
+      const { spaceId, spaceUuid, adminUserId } = await createSpaceWithAdmin();
+
+      const rows = await dbAuditRepo.findBy({ spaceId });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        spaceId,
+        spaceUuid,
+        eventType: 'SPACE_CREATED',
+        actorUserId: adminUserId,
+      });
+      expect(rows[0].payload).toHaveProperty('name');
+    });
+
+    it('should record MEMBER_ROLE_UPDATED with old and new role', async () => {
+      const { spaceId, adminUserId, adminAuthPayload } =
+        await createSpaceWithAdmin();
+      const invitee = await inviteUser({ spaceId, adminAuthPayload });
+
+      await membersRepository.updateRole({
+        authPayload: adminAuthPayload,
+        spaceId,
+        userId: invitee.userId,
+        role: 'ADMIN',
+      });
+
+      const rows = await dbAuditRepo.findBy({
+        spaceId,
+        eventType: 'MEMBER_ROLE_UPDATED',
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].actorUserId).toBe(adminUserId);
+      expect(rows[0].payload).toStrictEqual({
+        targetUserId: invitee.userId,
+        oldRole: 'MEMBER',
+        newRole: 'ADMIN',
+      });
+    });
+
+    it('should roll the business mutation back when the transaction fails after recording', async () => {
+      const { spaceId, spaceUuid, adminUserId } = await createSpaceWithAdmin();
+      const membersBefore = await dbMembersRepo.countBy({
+        space: { id: spaceId },
+      });
+
+      await expect(
+        postgresDatabaseService.transaction(async (entityManager) => {
+          await spaceAuditRepository.record(entityManager, {
+            spaceId,
+            spaceUuid,
+            eventType: SpaceAuditEventType.MEMBER_ALIAS_UPDATED,
+            actorUserId: adminUserId,
+            payload: { targetUserId: adminUserId },
+          });
+          await entityManager.update(
+            Member,
+            { space: { id: spaceId } },
+            { alias: 'rolled-back' },
+          );
+          throw new Error('boom');
+        }),
+      ).rejects.toThrow('boom');
+
+      const auditRows = await dbAuditRepo.findBy({
+        spaceId,
+        eventType: 'MEMBER_ALIAS_UPDATED',
+      });
+      expect(auditRows).toHaveLength(0);
+      await expect(
+        dbMembersRepo.countBy({ space: { id: spaceId }, alias: 'rolled-back' }),
+      ).resolves.toBe(0);
+      await expect(
+        dbMembersRepo.countBy({ space: { id: spaceId } }),
+      ).resolves.toBe(membersBefore);
+    });
+
+    it('should record one MEMBER_INVITED row per invitee in a single transaction', async () => {
+      const { spaceId, adminUserId, adminAuthPayload } =
+        await createSpaceWithAdmin();
+
+      await membersRepository.inviteUsers({
+        authPayload: adminAuthPayload,
+        spaceId,
+        users: Array.from(
+          { length: 3 },
+          (): InviteUserInput => ({
+            type: InviteType.Email,
+            email: fakeEmailAddress(),
+            role: 'MEMBER',
+            name: nameBuilder(),
+          }),
+        ),
+        inviteExpiresAt: faker.date.future(),
+      });
+
+      const rows = await dbAuditRepo.findBy({
+        spaceId,
+        eventType: 'MEMBER_INVITED',
+      });
+      expect(rows).toHaveLength(3);
+      // All rows of one transaction share created_at (CURRENT_TIMESTAMP is
+      // transaction start time).
+      const timestamps = new Set(
+        rows.map((row) => row.createdAt.toISOString()),
+      );
+      expect(timestamps.size).toBe(1);
+      for (const row of rows) {
+        expect(row.actorUserId).toBe(adminUserId);
+        expect(row.payload).toMatchObject({ role: 'MEMBER' });
+      }
+    });
+
+    it('should record MEMBER_LEFT with accountDeleted for every space on user deletion', async () => {
+      const spaceA = await createSpaceWithAdmin();
+      const spaceB = await createSpaceWithAdmin();
+      const invitee = await createSiweUser();
+      const wallet = await dbWalletRepo.findOneOrFail({
+        where: { user: { id: invitee.userId } },
+      });
+      for (const space of [spaceA, spaceB]) {
+        await membersRepository.inviteUsers({
+          authPayload: space.adminAuthPayload,
+          spaceId: space.spaceId,
+          users: [
+            {
+              type: InviteType.Wallet,
+              address: wallet.address,
+              role: 'MEMBER',
+              name: nameBuilder(),
+            },
+          ],
+          inviteExpiresAt: faker.date.future(),
+        });
+      }
+
+      await usersRepository.delete(invitee.authPayload);
+
+      for (const space of [spaceA, spaceB]) {
+        const rows = await dbAuditRepo.findBy({
+          spaceId: space.spaceId,
+          eventType: 'MEMBER_LEFT',
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].actorUserId).toBe(invitee.userId);
+        expect(rows[0].payload).toStrictEqual({
+          targetUserId: invitee.userId,
+          accountDeleted: true,
+        });
+      }
+      // The user and the cascading member rows are gone, the audit rows stay.
+      await expect(
+        dbUserRepo.findOneBy({ id: invitee.userId }),
+      ).resolves.toBeNull();
+      await expect(
+        dbMembersRepo.countBy({ user: { id: invitee.userId } }),
+      ).resolves.toBe(0);
+    });
+  });
+
+  describe('append-only enforcement', () => {
+    it('should reject raw UPDATE and DELETE and force created_at on INSERT', async () => {
+      const { spaceId, spaceUuid, adminUserId } = await createSpaceWithAdmin();
+      const [row] = await dbAuditRepo.findBy({ spaceId });
+
+      await expect(
+        dataSource.query(
+          `UPDATE space_audit_log SET event_type = 'SPACE_DELETED' WHERE id = $1`,
+          [row.id],
+        ),
+      ).rejects.toThrow('space_audit_log is append-only');
+
+      await expect(
+        dataSource.query(`DELETE FROM space_audit_log WHERE id = $1`, [row.id]),
+      ).rejects.toThrow('space_audit_log is append-only');
+
+      // A supplied (backdated) created_at is overwritten server-side.
+      const backdated = '2000-01-01T00:00:00Z';
+      const inserted: Array<{ created_at: Date }> = await dataSource.query(
+        `INSERT INTO space_audit_log (space_id, space_uuid, event_type, actor_user_id, payload, created_at)
+         VALUES ($1, $2, 'SPACE_CREATED', $3, '{"name":"x"}', $4)
+         RETURNING created_at`,
+        [spaceId, spaceUuid, adminUserId, backdated],
+      );
+      expect(inserted[0].created_at.getTime()).toBeGreaterThan(
+        new Date(backdated).getTime(),
+      );
+      expect(
+        Math.abs(inserted[0].created_at.getTime() - Date.now()),
+      ).toBeLessThan(60_000);
+    });
+  });
+
+  describe('findBySpaceId', () => {
+    it('should order newest-first by default, scope by space and reverse with asc', async () => {
+      const { spaceId, adminAuthPayload } = await createSpaceWithAdmin();
+      const other = await createSpaceWithAdmin();
+      const invitee = await inviteUser({ spaceId, adminAuthPayload });
+      await membersRepository.updateRole({
+        authPayload: adminAuthPayload,
+        spaceId,
+        userId: invitee.userId,
+        role: 'ADMIN',
+      });
+
+      const [desc, count] = await spaceAuditRepository.findBySpaceId({
+        spaceId,
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(count).toBe(3);
+      expect(desc.map((row) => row.eventType)).toStrictEqual([
+        'MEMBER_ROLE_UPDATED',
+        'MEMBER_INVITED',
+        'SPACE_CREATED',
+      ]);
+      // Scoped: the other space's rows are not interleaved.
+      expect(desc.every((row) => row.spaceId === spaceId)).toBe(true);
+      expect(desc.every((row) => row.spaceId !== other.spaceId)).toBe(true);
+
+      const [asc] = await spaceAuditRepository.findBySpaceId({
+        spaceId,
+        limit: 10,
+        offset: 0,
+        sortDirection: 'asc',
+      });
+      expect(asc.map((row) => row.eventType)).toStrictEqual([
+        'SPACE_CREATED',
+        'MEMBER_INVITED',
+        'MEMBER_ROLE_UPDATED',
+      ]);
+    });
+
+    it('should paginate same-timestamp rows without skips or duplicates (id tie-break)', async () => {
+      const { spaceId, adminAuthPayload } = await createSpaceWithAdmin();
+      // 5 MEMBER_INVITED rows in ONE transaction → identical created_at.
+      await membersRepository.inviteUsers({
+        authPayload: adminAuthPayload,
+        spaceId,
+        users: Array.from(
+          { length: 5 },
+          (): InviteUserInput => ({
+            type: InviteType.Email,
+            email: fakeEmailAddress(),
+            role: 'MEMBER',
+            name: nameBuilder(),
+          }),
+        ),
+        inviteExpiresAt: faker.date.future(),
+      });
+
+      const [all, count] = await spaceAuditRepository.findBySpaceId({
+        spaceId,
+        limit: 100,
+        offset: 0,
+      });
+      expect(count).toBe(6); // SPACE_CREATED + 5 invites
+
+      const paginated: Array<string> = [];
+      for (let offset = 0; offset < count; offset += 2) {
+        const [page] = await spaceAuditRepository.findBySpaceId({
+          spaceId,
+          limit: 2,
+          offset,
+        });
+        paginated.push(...page.map((row) => row.id));
+      }
+
+      expect(paginated).toStrictEqual(all.map((row) => row.id));
+      expect(new Set(paginated).size).toBe(count);
+    });
+
+    it('should filter by eventTypes, actorUserId and created-at range (AND-combined) and count the filtered set', async () => {
+      const { spaceId, adminUserId, adminAuthPayload } =
+        await createSpaceWithAdmin();
+      const invitee = await inviteUser({ spaceId, adminAuthPayload });
+      await membersRepository.updateRole({
+        authPayload: adminAuthPayload,
+        spaceId,
+        userId: invitee.userId,
+        role: 'ADMIN',
+      });
+
+      const [byType, byTypeCount] = await spaceAuditRepository.findBySpaceId({
+        spaceId,
+        limit: 10,
+        offset: 0,
+        eventTypes: ['SPACE_CREATED', 'MEMBER_INVITED'],
+      });
+      expect(byTypeCount).toBe(2);
+      expect(byType.map((row) => row.eventType).sort()).toStrictEqual([
+        'MEMBER_INVITED',
+        'SPACE_CREATED',
+      ]);
+
+      const [, byActorCount] = await spaceAuditRepository.findBySpaceId({
+        spaceId,
+        limit: 10,
+        offset: 0,
+        actorUserId: adminUserId,
+      });
+      expect(byActorCount).toBe(3);
+
+      const hourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      const hourAhead = new Date(Date.now() + 60 * 60 * 1000);
+      const [, inRangeCount] = await spaceAuditRepository.findBySpaceId({
+        spaceId,
+        limit: 10,
+        offset: 0,
+        createdAtGte: hourAgo,
+        createdAtLte: hourAhead,
+      });
+      expect(inRangeCount).toBe(3);
+
+      const [outOfRange, outOfRangeCount] =
+        await spaceAuditRepository.findBySpaceId({
+          spaceId,
+          limit: 10,
+          offset: 0,
+          createdAtLte: hourAgo,
+        });
+      expect(outOfRangeCount).toBe(0);
+      expect(outOfRange).toStrictEqual([]);
+
+      // AND-combined: matching type + actor + range.
+      const [combined, combinedCount] =
+        await spaceAuditRepository.findBySpaceId({
+          spaceId,
+          limit: 10,
+          offset: 0,
+          eventTypes: ['MEMBER_ROLE_UPDATED'],
+          actorUserId: adminUserId,
+          createdAtGte: hourAgo,
+          createdAtLte: hourAhead,
+        });
+      expect(combinedCount).toBe(1);
+      expect(combined[0].eventType).toBe('MEMBER_ROLE_UPDATED');
+    });
+  });
+
+  describe('findDistinctActorIds', () => {
+    it('should return every actor once, including removed members whose events stay filterable', async () => {
+      const { spaceId, adminUserId, adminAuthPayload } =
+        await createSpaceWithAdmin();
+      const invitee = await inviteUser({ spaceId, adminAuthPayload });
+      await membersRepository.acceptInvite({
+        authPayload: invitee.authPayload,
+        spaceId,
+        payload: { name: nameBuilder() },
+      });
+      await membersRepository.removeUser({
+        authPayload: adminAuthPayload,
+        spaceId,
+        userId: invitee.userId,
+      });
+
+      const actorIds = await spaceAuditRepository.findDistinctActorIds(spaceId);
+
+      expect(actorIds).toStrictEqual(
+        [adminUserId, invitee.userId].sort((a, b) => a - b),
+      );
+      // The ex-member is gone from the space but their events stay filterable.
+      await expect(
+        dbMembersRepo.countBy({ user: { id: invitee.userId } }),
+      ).resolves.toBe(0);
+      const [exMemberEvents, exMemberCount] =
+        await spaceAuditRepository.findBySpaceId({
+          spaceId,
+          limit: 10,
+          offset: 0,
+          actorUserId: invitee.userId,
+        });
+      expect(exMemberCount).toBe(1);
+      expect(exMemberEvents[0].eventType).toBe('MEMBER_INVITE_ACCEPTED');
+    });
+  });
+
+  describe('record (flag off)', () => {
+    it('should be a no-op when the feature flag is disabled', async () => {
+      const { spaceId, spaceUuid, adminUserId } = await createSpaceWithAdmin();
+      const disabledConfigurationService = jest.mocked({
+        getOrThrow: jest.fn().mockImplementation((key: string) => {
+          if (key === 'features.spaceAuditLog') {
+            return false;
+          }
+        }),
+      } as jest.MockedObjectDeep<IConfigurationService>);
+      const disabledRepository = new SpaceAuditRepository(
+        postgresDatabaseService,
+        disabledConfigurationService,
+      );
+
+      await postgresDatabaseService.transaction(async (entityManager) => {
+        await disabledRepository.record(entityManager, {
+          spaceId,
+          spaceUuid,
+          eventType: SpaceAuditEventType.MEMBER_ALIAS_UPDATED,
+          actorUserId: adminUserId,
+          payload: { targetUserId: adminUserId },
+        });
+      });
+
+      await expect(
+        dbAuditRepo.countBy({ spaceId, eventType: 'MEMBER_ALIAS_UPDATED' }),
+      ).resolves.toBe(0);
+    });
+  });
+});

--- a/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
@@ -335,7 +335,7 @@ describe('SpaceAuditRepository', () => {
       }
     });
 
-    it('should record MEMBER_LEFT with accountDeleted for every space on user deletion', async () => {
+    it('should record MEMBER_LEFT with accountDeleted only for ACTIVE memberships on user deletion', async () => {
       const spaceA = await createSpaceWithAdmin();
       const spaceB = await createSpaceWithAdmin();
       const invitee = await createSiweUser();
@@ -357,21 +357,32 @@ describe('SpaceAuditRepository', () => {
           inviteExpiresAt: faker.date.future(),
         });
       }
+      // The invitee joins space A but never accepts the space B invite.
+      await membersRepository.acceptInvite({
+        authPayload: invitee.authPayload,
+        spaceId: spaceA.spaceId,
+        payload: { name: nameBuilder() },
+      });
 
       await usersRepository.delete(invitee.authPayload);
 
-      for (const space of [spaceA, spaceB]) {
-        const rows = await dbAuditRepo.findBy({
-          spaceId: space.spaceId,
+      const rowsA = await dbAuditRepo.findBy({
+        spaceId: spaceA.spaceId,
+        eventType: 'MEMBER_LEFT',
+      });
+      expect(rowsA).toHaveLength(1);
+      expect(rowsA[0].actorUserId).toBe(invitee.userId);
+      expect(rowsA[0].payload).toStrictEqual({
+        targetUserId: invitee.userId,
+        accountDeleted: true,
+      });
+      // A pending invite is not a departure.
+      await expect(
+        dbAuditRepo.countBy({
+          spaceId: spaceB.spaceId,
           eventType: 'MEMBER_LEFT',
-        });
-        expect(rows).toHaveLength(1);
-        expect(rows[0].actorUserId).toBe(invitee.userId);
-        expect(rows[0].payload).toStrictEqual({
-          targetUserId: invitee.userId,
-          accountDeleted: true,
-        });
-      }
+        }),
+      ).resolves.toBe(0);
       // The user and the cascading member rows are gone, the audit rows stay.
       await expect(
         dbUserRepo.findOneBy({ id: invitee.userId }),

--- a/src/modules/spaces/domain/audit/space-audit.repository.interface.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.interface.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import type { UUID } from 'node:crypto';
+import type { EntityManager } from 'typeorm';
+import type { SpaceAuditLog } from '@/modules/spaces/datasources/entities/space-audit-log.entity.db';
+import type {
+  SpaceAuditEvent,
+  SpaceAuditEventType,
+} from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+
+export type SpaceAuditRecordArgs = {
+  spaceId: number;
+  spaceUuid: UUID;
+  actorUserId: number;
+} & SpaceAuditEvent;
+
+export type SpaceAuditFindArgs = {
+  spaceId: number;
+  limit: number;
+  offset: number;
+  eventTypes?: Array<keyof typeof SpaceAuditEventType>;
+  actorUserId?: number;
+  createdAtGte?: Date;
+  createdAtLte?: Date;
+  sortDirection?: 'asc' | 'desc';
+};
+
+export const ISpaceAuditRepository = Symbol('ISpaceAuditRepository');
+
+export interface ISpaceAuditRepository {
+  /**
+   * Appends an audit event in the caller's transaction, so the event and the
+   * mutation commit or roll back together. No-op when the feature flag is off.
+   */
+  record(
+    entityManager: EntityManager,
+    args: SpaceAuditRecordArgs,
+  ): Promise<void>;
+
+  /**
+   * Returns a page of audit events plus the filtered total count, ordered by
+   * `(created_at, id)` — the id tie-break keeps offset pagination stable for
+   * same-timestamp rows.
+   */
+  findBySpaceId(
+    args: SpaceAuditFindArgs,
+  ): Promise<[Array<SpaceAuditLog>, number]>;
+
+  /** Distinct actor user ids in a space's log, including former members. */
+  findDistinctActorIds(spaceId: number): Promise<Array<number>>;
+}

--- a/src/modules/spaces/domain/audit/space-audit.repository.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Inject, Injectable } from '@nestjs/common';
 import {
-  Between,
+  And,
   type EntityManager,
   type FindOptionsWhere,
   In,
@@ -62,20 +62,19 @@ export class SpaceAuditRepository implements ISpaceAuditRepository {
     const repository =
       await this.postgresDatabaseService.getRepository(SpaceAuditLog);
 
-    const where: FindOptionsWhere<SpaceAuditLog> = { spaceId: args.spaceId };
-    if (args.eventTypes && args.eventTypes.length > 0) {
-      where.eventType = In(args.eventTypes);
-    }
-    if (args.actorUserId !== undefined) {
-      where.actorUserId = args.actorUserId;
-    }
-    if (args.createdAtGte && args.createdAtLte) {
-      where.createdAt = Between(args.createdAtGte, args.createdAtLte);
-    } else if (args.createdAtGte) {
-      where.createdAt = MoreThanOrEqual(args.createdAtGte);
-    } else if (args.createdAtLte) {
-      where.createdAt = LessThanOrEqual(args.createdAtLte);
-    }
+    const createdAtBounds = [
+      ...(args.createdAtGte ? [MoreThanOrEqual(args.createdAtGte)] : []),
+      ...(args.createdAtLte ? [LessThanOrEqual(args.createdAtLte)] : []),
+    ];
+    const where: FindOptionsWhere<SpaceAuditLog> = {
+      spaceId: args.spaceId,
+      ...(args.eventTypes &&
+        args.eventTypes.length > 0 && { eventType: In(args.eventTypes) }),
+      ...(args.actorUserId !== undefined && {
+        actorUserId: args.actorUserId,
+      }),
+      ...(createdAtBounds.length > 0 && { createdAt: And(...createdAtBounds) }),
+    };
 
     // Same-transaction events share created_at — tie-break on id.
     const direction = args.sortDirection === 'asc' ? 'ASC' : 'DESC';

--- a/src/modules/spaces/domain/audit/space-audit.repository.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  Between,
+  type EntityManager,
+  type FindOptionsWhere,
+  In,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+} from 'typeorm';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { SpaceAuditLog } from '@/modules/spaces/datasources/entities/space-audit-log.entity.db';
+import { SpaceAuditEventSchema } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import type {
+  ISpaceAuditRepository,
+  SpaceAuditFindArgs,
+  SpaceAuditRecordArgs,
+} from '@/modules/spaces/domain/audit/space-audit.repository.interface';
+
+@Injectable()
+export class SpaceAuditRepository implements ISpaceAuditRepository {
+  private readonly isEnabled: boolean;
+
+  public constructor(
+    @Inject(PostgresDatabaseService)
+    private readonly postgresDatabaseService: PostgresDatabaseService,
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.isEnabled = this.configurationService.getOrThrow<boolean>(
+      'features.spaceAuditLog',
+    );
+  }
+
+  public async record(
+    entityManager: EntityManager,
+    args: SpaceAuditRecordArgs,
+  ): Promise<void> {
+    if (!this.isEnabled) {
+      return;
+    }
+
+    // Parsing strips unknown payload fields at the write boundary.
+    const event = SpaceAuditEventSchema.parse({
+      eventType: args.eventType,
+      payload: args.payload,
+    });
+
+    await entityManager.insert(SpaceAuditLog, {
+      spaceId: args.spaceId,
+      spaceUuid: args.spaceUuid,
+      eventType: event.eventType,
+      actorUserId: args.actorUserId,
+      payload: event.payload,
+    });
+  }
+
+  public async findBySpaceId(
+    args: SpaceAuditFindArgs,
+  ): Promise<[Array<SpaceAuditLog>, number]> {
+    const repository =
+      await this.postgresDatabaseService.getRepository(SpaceAuditLog);
+
+    const where: FindOptionsWhere<SpaceAuditLog> = { spaceId: args.spaceId };
+    if (args.eventTypes && args.eventTypes.length > 0) {
+      where.eventType = In(args.eventTypes);
+    }
+    if (args.actorUserId !== undefined) {
+      where.actorUserId = args.actorUserId;
+    }
+    if (args.createdAtGte && args.createdAtLte) {
+      where.createdAt = Between(args.createdAtGte, args.createdAtLte);
+    } else if (args.createdAtGte) {
+      where.createdAt = MoreThanOrEqual(args.createdAtGte);
+    } else if (args.createdAtLte) {
+      where.createdAt = LessThanOrEqual(args.createdAtLte);
+    }
+
+    // Same-transaction events share created_at — tie-break on id.
+    const direction = args.sortDirection === 'asc' ? 'ASC' : 'DESC';
+
+    return await repository.findAndCount({
+      where,
+      order: { createdAt: direction, id: direction },
+      take: args.limit,
+      skip: args.offset,
+    });
+  }
+
+  public async findDistinctActorIds(spaceId: number): Promise<Array<number>> {
+    const repository =
+      await this.postgresDatabaseService.getRepository(SpaceAuditLog);
+
+    const rows = await repository
+      .createQueryBuilder('sal')
+      .select('sal.actor_user_id', 'actorUserId')
+      .distinct(true)
+      .where('sal.space_id = :spaceId', { spaceId })
+      .orderBy('sal.actor_user_id', 'ASC')
+      .getRawMany<{ actorUserId: number }>();
+
+    return rows.map((row) => row.actorUserId);
+  }
+}

--- a/src/modules/spaces/domain/space-safes.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/space-safes.repository.integration.spec.ts
@@ -15,6 +15,7 @@ import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
 import { SpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
@@ -107,6 +108,7 @@ describe('SpaceSafesRepository', () => {
     spaceSafesRepo = new SpaceSafesRepository(
       postgresDatabaseService,
       mockConfigService,
+      createMockSpaceAuditRepository(),
     );
 
     dbWalletRepo = dataSource.getRepository(Wallet);
@@ -306,6 +308,7 @@ describe('SpaceSafesRepository', () => {
 
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId: userId,
         payload: [
           {
             chainId,
@@ -360,6 +363,7 @@ describe('SpaceSafesRepository', () => {
 
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId: userId,
         payload,
       });
 
@@ -399,6 +403,7 @@ describe('SpaceSafesRepository', () => {
       // Create (maxSafesPerSpace - 1) Safes
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId: userId,
         payload: faker.helpers.multiple(
           () => ({
             chainId: faker.string.numeric(),
@@ -412,6 +417,7 @@ describe('SpaceSafesRepository', () => {
       await expect(
         spaceSafesRepo.create({
           spaceId: spaceId,
+          actorUserId: userId,
           payload: faker.helpers.multiple(
             () => ({
               chainId: faker.string.numeric(),
@@ -456,6 +462,7 @@ describe('SpaceSafesRepository', () => {
 
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId: userId,
         payload: faker.helpers.multiple(
           () => ({
             chainId: faker.string.numeric(),
@@ -468,6 +475,7 @@ describe('SpaceSafesRepository', () => {
       await expect(
         spaceSafesRepo.create({
           spaceId: spaceId,
+          actorUserId: userId,
           payload: [
             {
               chainId: faker.string.numeric(),
@@ -514,10 +522,12 @@ describe('SpaceSafesRepository', () => {
         Promise.all([
           spaceSafesRepo.create({
             spaceId: spaceId,
+            actorUserId: userId,
             payload: [{ chainId, address }],
           }),
           spaceSafesRepo.create({
             spaceId: spaceId,
+            actorUserId: userId,
             payload: [
               { chainId, address },
               {
@@ -643,8 +653,10 @@ describe('SpaceSafesRepository', () => {
         name: faker.word.noun(),
       });
       const spaceId = space.identifiers[0].id as Space['id'];
+      const actorUserId = faker.number.int({ max: DB_MAX_SAFE_INTEGER });
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId,
         payload: spaceSafes,
       });
 
@@ -700,6 +712,7 @@ describe('SpaceSafesRepository', () => {
 
       await spaceSafesRepo.delete({
         spaceId: spaceId,
+        actorUserId: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
         payload: [
           {
             chainId: spaceSafeBefore[0].chainId,
@@ -729,14 +742,17 @@ describe('SpaceSafesRepository', () => {
         name: faker.word.noun(),
       });
       const spaceId = space.identifiers[0].id as Space['id'];
+      const actorUserId = faker.number.int({ max: DB_MAX_SAFE_INTEGER });
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId,
         payload: spaceSafes,
       });
       const spaceSafeBefore = await spaceSafesRepo.findBySpaceId(spaceId);
 
       await spaceSafesRepo.delete({
         spaceId: spaceId,
+        actorUserId,
         payload: spaceSafes,
       });
 
@@ -766,6 +782,7 @@ describe('SpaceSafesRepository', () => {
       await expect(
         spaceSafesRepo.delete({
           spaceId: spaceId,
+          actorUserId: faker.number.int({ max: DB_MAX_SAFE_INTEGER }),
           payload: [
             {
               chainId,
@@ -789,8 +806,10 @@ describe('SpaceSafesRepository', () => {
         name: faker.word.noun(),
       });
       const spaceId = space.identifiers[0].id as Space['id'];
+      const actorUserId = faker.number.int({ max: DB_MAX_SAFE_INTEGER });
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId,
         payload: spaceSafes,
       });
 
@@ -801,6 +820,7 @@ describe('SpaceSafesRepository', () => {
       await expect(
         spaceSafesRepo.delete({
           spaceId: spaceId,
+          actorUserId,
           payload: [
             {
               chainId: faker.string.numeric(),
@@ -824,8 +844,10 @@ describe('SpaceSafesRepository', () => {
         name: faker.word.noun(),
       });
       const spaceId = space.identifiers[0].id as Space['id'];
+      const actorUserId = faker.number.int({ max: DB_MAX_SAFE_INTEGER });
       await spaceSafesRepo.create({
         spaceId: spaceId,
+        actorUserId,
         payload: spaceSafes,
       });
 
@@ -833,6 +855,7 @@ describe('SpaceSafesRepository', () => {
       await expect(
         spaceSafesRepo.delete({
           spaceId: spaceId,
+          actorUserId,
           payload: [
             {
               chainId: spaceSafes[0].chainId,

--- a/src/modules/spaces/domain/space-safes.repository.interface.ts
+++ b/src/modules/spaces/domain/space-safes.repository.interface.ts
@@ -13,6 +13,7 @@ export const ISpaceSafesRepository = Symbol('ISpaceSafesRepository');
 export interface ISpaceSafesRepository {
   create(args: {
     spaceId: Space['id'];
+    actorUserId: number;
     payload: Array<{
       chainId: SpaceSafe['chainId'];
       address: SpaceSafe['address'];
@@ -35,6 +36,7 @@ export interface ISpaceSafesRepository {
 
   delete(args: {
     spaceId: Space['id'];
+    actorUserId: number;
     payload: Array<{
       chainId: SpaceSafe['chainId'];
       address: SpaceSafe['address'];

--- a/src/modules/spaces/domain/space-safes.repository.ts
+++ b/src/modules/spaces/domain/space-safes.repository.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
 import type {
+  EntityManager,
   FindOptionsRelations,
   FindOptionsSelect,
   FindOptionsWhere,
@@ -9,8 +10,10 @@ import { IConfigurationService } from '@/config/configuration.service.interface'
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
-import type { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import type { ISpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository.interface';
 
 export class SpaceSafesRepository implements ISpaceSafesRepository {
@@ -21,22 +24,36 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
     private readonly postgresDatabaseService: PostgresDatabaseService,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
   ) {
     this.maxSafesPerSpace = this.configurationService.getOrThrow<number>(
       'spaces.maxSafesPerSpace',
     );
   }
 
+  private async findSpaceForAuditOrFail(
+    entityManager: EntityManager,
+    spaceId: Space['id'],
+  ): Promise<Pick<Space, 'id' | 'uuid'>> {
+    const space = await entityManager.findOne(Space, {
+      where: { id: spaceId },
+      select: { id: true, uuid: true },
+    });
+    if (!space) {
+      throw new NotFoundException('Workspace not found.');
+    }
+    return space;
+  }
+
   public async create(args: {
     spaceId: Space['id'];
+    actorUserId: number;
     payload: Array<{
       chainId: SpaceSafe['chainId'];
       address: SpaceSafe['address'];
     }>;
   }): Promise<void> {
-    const spaceSafeRepository =
-      await this.postgresDatabaseService.getRepository(SpaceSafe);
-
     const safesToInsert = args.payload.map((safe) => ({
       space: { id: args.spaceId },
       chainId: safe.chainId,
@@ -53,16 +70,35 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
       );
     }
 
-    try {
-      await spaceSafeRepository.insert(safesToInsert);
-    } catch (err) {
-      if (isUniqueConstraintError(err)) {
-        throw new UniqueConstraintError(
-          `A SpaceSafe with the same chainId and address already exists: ${err.driverError.detail}`,
-        );
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      try {
+        await entityManager.insert(SpaceSafe, safesToInsert);
+      } catch (err) {
+        if (isUniqueConstraintError(err)) {
+          throw new UniqueConstraintError(
+            `A SpaceSafe with the same chainId and address already exists: ${err.driverError.detail}`,
+          );
+        }
+        throw err;
       }
-      throw err;
-    }
+
+      const space = await this.findSpaceForAuditOrFail(
+        entityManager,
+        args.spaceId,
+      );
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.SAFE_ADDED,
+        actorUserId: args.actorUserId,
+        payload: {
+          safes: args.payload.map((safe) => ({
+            chainId: safe.chainId,
+            address: safe.address,
+          })),
+        },
+      });
+    });
   }
 
   public async findBySpaceId(
@@ -102,14 +138,12 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
 
   public async delete(args: {
     spaceId: Space['id'];
+    actorUserId: number;
     payload: Array<{
       chainId: SpaceSafe['chainId'];
       address: SpaceSafe['address'];
     }>;
   }): Promise<void> {
-    const spaceSafeRepository =
-      await this.postgresDatabaseService.getRepository(SpaceSafe);
-
     const findSpaceSafesWhereClause: Array<FindOptionsWhere<SpaceSafe>> =
       args.payload.map((safe) => {
         return {
@@ -119,10 +153,32 @@ export class SpaceSafesRepository implements ISpaceSafesRepository {
         };
       });
 
-    const spaceSafes = await this.findOrFail({
-      where: findSpaceSafesWhereClause,
-    });
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const spaceSafes = await entityManager.find(SpaceSafe, {
+        where: findSpaceSafesWhereClause,
+      });
+      if (spaceSafes.length === 0) {
+        throw new NotFoundException('Workspace has no Safes.');
+      }
 
-    await spaceSafeRepository.remove(spaceSafes);
+      await entityManager.remove(spaceSafes);
+
+      const space = await this.findSpaceForAuditOrFail(
+        entityManager,
+        args.spaceId,
+      );
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.SAFE_REMOVED,
+        actorUserId: args.actorUserId,
+        payload: {
+          safes: spaceSafes.map((safe) => ({
+            chainId: safe.chainId,
+            address: safe.address,
+          })),
+        },
+      });
+    });
   }
 }

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -14,6 +14,7 @@ import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import type { ILoggingService } from '@/logging/logging.interface';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
 import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
@@ -110,6 +111,7 @@ describe('SpacesRepository', () => {
     spacesRepository = new SpacesRepository(
       postgresDatabaseService,
       mockConfigurationService,
+      createMockSpaceAuditRepository(),
     );
   });
 
@@ -267,7 +269,11 @@ describe('SpacesRepository', () => {
       config.getOrThrow.mockImplementation((key) => {
         if (key === 'spaces.maxSpaceCreationsPerUser') return 1;
       });
-      const target = new SpacesRepository(postgresDatabaseService, config);
+      const target = new SpacesRepository(
+        postgresDatabaseService,
+        config,
+        createMockSpaceAuditRepository(),
+      );
       const userStatus = faker.helpers.arrayElement(UserStatusKeys);
       const name = faker.word.noun();
       const spaceStatus = faker.helpers.arrayElement(SpaceStatusKeys);
@@ -305,7 +311,11 @@ describe('SpacesRepository', () => {
       config.getOrThrow.mockImplementation((key) => {
         if (key === 'spaces.maxSpaceCreationsPerUser') return 1;
       });
-      const target = new SpacesRepository(postgresDatabaseService, config);
+      const target = new SpacesRepository(
+        postgresDatabaseService,
+        config,
+        createMockSpaceAuditRepository(),
+      );
 
       const invitee = await dbUserRepo.insert({ status: 'ACTIVE' });
       const inviteeId = invitee.identifiers[0].id as User['id'];
@@ -838,6 +848,7 @@ describe('SpacesRepository', () => {
       await spacesRepository.update({
         id: space.id,
         updatePayload: { name: newName, status: newStatus },
+        actorUserId: userId,
       });
 
       const dbSpace = await dbSpacesRepository.findOneOrFail({
@@ -872,7 +883,7 @@ describe('SpacesRepository', () => {
         status: spaceStatus,
       });
 
-      await spacesRepository.delete(space.id);
+      await spacesRepository.delete({ id: space.id, actorUserId: userId });
 
       await expect(
         dbSpacesRepository.findOneOrFail({ where: { id: space.id } }),

--- a/src/modules/spaces/domain/spaces.repository.interface.ts
+++ b/src/modules/spaces/domain/spaces.repository.interface.ts
@@ -61,6 +61,7 @@ export interface ISpacesRepository {
   update(args: {
     id: Space['id'];
     updatePayload: Partial<Pick<Space, 'name' | 'status'>>;
+    actorUserId: number;
   }): Promise<Pick<Space, 'id' | 'uuid'>>;
 
   findIdByUuid(uuid: Space['uuid']): Promise<Space['id']>;
@@ -71,5 +72,5 @@ export interface ISpacesRepository {
   // TODO: remove after FE removes numeric Space ID fallback.
   findIdByIdOrUuid(value: string): Promise<Space['id']>;
 
-  delete(id: number): Promise<void>;
+  delete(args: { id: number; actorUserId: number }): Promise<void>;
 }

--- a/src/modules/spaces/domain/spaces.repository.ts
+++ b/src/modules/spaces/domain/spaces.repository.ts
@@ -14,13 +14,15 @@ import {
   In,
   IsNull,
 } from 'typeorm';
-import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { NUMERIC_REGEX, UUID_REGEX } from '@/domain/common/constants';
 import { getEnumKey } from '@/domain/common/utils/enum';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
-import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import {
+  SpaceAuditEventType,
+  type SpaceUpdatedPayload,
+} from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
 import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import type { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
 import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
@@ -215,7 +217,7 @@ export class SpacesRepository implements ISpacesRepository {
 
   public async update(args: {
     id: Space['id'];
-    updatePayload: QueryDeepPartialEntity<Space>;
+    updatePayload: Partial<Pick<Space, 'name' | 'status'>>;
     actorUserId: number;
   }): Promise<Pick<Space, 'id' | 'uuid'>> {
     return await this.postgresDatabaseService.transaction(
@@ -255,33 +257,24 @@ export class SpacesRepository implements ISpacesRepository {
   /** Changed `name`/`status` fields of a space update, or `null` for a no-op. */
   private diffSpaceUpdate(
     current: Pick<Space, 'name' | 'status'>,
-    updatePayload: QueryDeepPartialEntity<Space>,
-  ): {
-    old: { name?: string; status?: keyof typeof SpaceStatus };
-    new: { name?: string; status?: keyof typeof SpaceStatus };
-  } | null {
-    const oldFields: { name?: string; status?: keyof typeof SpaceStatus } = {};
-    const newFields: { name?: string; status?: keyof typeof SpaceStatus } = {};
+    updatePayload: Partial<Pick<Space, 'name' | 'status'>>,
+  ): SpaceUpdatedPayload | null {
+    const { name, status } = updatePayload;
+    const oldFields: SpaceUpdatedPayload['old'] = {};
+    const newFields: SpaceUpdatedPayload['new'] = {};
 
-    if (
-      typeof updatePayload.name === 'string' &&
-      updatePayload.name !== current.name
-    ) {
+    if (name !== undefined && name !== current.name) {
       oldFields.name = current.name;
-      newFields.name = updatePayload.name;
+      newFields.name = name;
     }
-    if (
-      typeof updatePayload.status === 'string' &&
-      updatePayload.status !== current.status
-    ) {
+    if (status !== undefined && status !== current.status) {
       oldFields.status = current.status;
-      newFields.status = updatePayload.status;
+      newFields.status = status;
     }
 
-    if (Object.keys(newFields).length === 0) {
-      return null;
-    }
-    return { old: oldFields, new: newFields };
+    return Object.keys(newFields).length > 0
+      ? { old: oldFields, new: newFields }
+      : null;
   }
 
   public async findIdByUuid(uuid: Space['uuid']): Promise<Space['id']> {

--- a/src/modules/spaces/domain/spaces.repository.ts
+++ b/src/modules/spaces/domain/spaces.repository.ts
@@ -20,6 +20,8 @@ import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.s
 import { NUMERIC_REGEX, UUID_REGEX } from '@/domain/common/constants';
 import { getEnumKey } from '@/domain/common/utils/enum';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import type { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
 import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
@@ -38,6 +40,8 @@ export class SpacesRepository implements ISpacesRepository {
     private readonly postgresDatabaseService: PostgresDatabaseService,
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
   ) {
     this.maxSpaceCreationsPerUser =
       this.configurationService.getOrThrow<number>(
@@ -50,9 +54,6 @@ export class SpacesRepository implements ISpacesRepository {
     name: string;
     status: keyof typeof SpaceStatus;
   }): Promise<Pick<Space, 'id' | 'uuid' | 'name'>> {
-    const spaceRepository =
-      await this.postgresDatabaseService.getRepository(Space);
-
     const isLimited = await this.isLimited(args.userId);
     if (isLimited) {
       throw new ForbiddenException(
@@ -77,13 +78,25 @@ export class SpacesRepository implements ISpacesRepository {
 
     space.members = [member];
 
-    const insertResult = await spaceRepository.save(space);
+    return await this.postgresDatabaseService.transaction(
+      async (entityManager) => {
+        const insertResult = await entityManager.save(space);
 
-    return {
-      id: insertResult.id,
-      uuid: insertResult.uuid,
-      name: insertResult.name,
-    };
+        await this.spaceAuditRepository.record(entityManager, {
+          spaceId: insertResult.id,
+          spaceUuid: insertResult.uuid,
+          eventType: SpaceAuditEventType.SPACE_CREATED,
+          actorUserId: args.userId,
+          payload: { name: insertResult.name },
+        });
+
+        return {
+          id: insertResult.id,
+          uuid: insertResult.uuid,
+          name: insertResult.name,
+        };
+      },
+    );
   }
 
   public async findOneOrFail(
@@ -203,24 +216,72 @@ export class SpacesRepository implements ISpacesRepository {
   public async update(args: {
     id: Space['id'];
     updatePayload: QueryDeepPartialEntity<Space>;
+    actorUserId: number;
   }): Promise<Pick<Space, 'id' | 'uuid'>> {
-    const spaceRepository =
-      await this.postgresDatabaseService.getRepository(Space);
+    return await this.postgresDatabaseService.transaction(
+      async (entityManager) => {
+        // Old values are read inside the transaction to keep the diff exact.
+        const current = await entityManager.findOne(Space, {
+          where: { id: args.id },
+          select: { id: true, uuid: true, name: true, status: true },
+        });
+        if (!current) {
+          throw new NotFoundException('Workspace not found.');
+        }
 
-    const result = await spaceRepository
-      .createQueryBuilder()
-      .update(Space)
-      .set(args.updatePayload)
-      .where({ id: args.id })
-      .returning(['id', 'uuid'])
-      .execute();
+        await entityManager
+          .createQueryBuilder()
+          .update(Space)
+          .set(args.updatePayload)
+          .where({ id: args.id })
+          .execute();
 
-    const row = result.raw[0] as Pick<Space, 'id' | 'uuid'> | undefined;
-    if (!row) {
-      throw new NotFoundException('Workspace not found.');
+        const diff = this.diffSpaceUpdate(current, args.updatePayload);
+        if (diff) {
+          await this.spaceAuditRepository.record(entityManager, {
+            spaceId: current.id,
+            spaceUuid: current.uuid,
+            eventType: SpaceAuditEventType.SPACE_UPDATED,
+            actorUserId: args.actorUserId,
+            payload: diff,
+          });
+        }
+
+        return { id: current.id, uuid: current.uuid };
+      },
+    );
+  }
+
+  /** Changed `name`/`status` fields of a space update, or `null` for a no-op. */
+  private diffSpaceUpdate(
+    current: Pick<Space, 'name' | 'status'>,
+    updatePayload: QueryDeepPartialEntity<Space>,
+  ): {
+    old: { name?: string; status?: keyof typeof SpaceStatus };
+    new: { name?: string; status?: keyof typeof SpaceStatus };
+  } | null {
+    const oldFields: { name?: string; status?: keyof typeof SpaceStatus } = {};
+    const newFields: { name?: string; status?: keyof typeof SpaceStatus } = {};
+
+    if (
+      typeof updatePayload.name === 'string' &&
+      updatePayload.name !== current.name
+    ) {
+      oldFields.name = current.name;
+      newFields.name = updatePayload.name;
+    }
+    if (
+      typeof updatePayload.status === 'string' &&
+      updatePayload.status !== current.status
+    ) {
+      oldFields.status = current.status;
+      newFields.status = updatePayload.status;
     }
 
-    return { id: row.id, uuid: row.uuid };
+    if (Object.keys(newFields).length === 0) {
+      return null;
+    }
+    return { old: oldFields, new: newFields };
   }
 
   public async findIdByUuid(uuid: Space['uuid']): Promise<Space['id']> {
@@ -259,15 +320,29 @@ export class SpacesRepository implements ISpacesRepository {
   }
 
   // @todo Add a soft delete method
-  public async delete(id: number): Promise<void> {
-    const spaceRepository =
-      await this.postgresDatabaseService.getRepository(Space);
+  public async delete(args: {
+    id: number;
+    actorUserId: number;
+  }): Promise<void> {
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const space = await entityManager.findOne(Space, {
+        where: { id: args.id },
+        select: { id: true, uuid: true, name: true },
+      });
+      if (!space) {
+        throw new NotFoundException('Workspace not found.');
+      }
 
-    const space = await this.findOneOrFail({
-      where: { id },
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.SPACE_DELETED,
+        actorUserId: args.actorUserId,
+        payload: { name: space.name },
+      });
+
+      await entityManager.delete(Space, space.id);
     });
-
-    await spaceRepository.delete(space.id);
   }
 
   /**

--- a/src/modules/spaces/routes/address-book-requests.service.ts
+++ b/src/modules/spaces/routes/address-book-requests.service.ts
@@ -7,6 +7,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import type { Address } from 'viem';
+import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
 import type { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
@@ -42,6 +43,8 @@ export class AddressBookRequestsService {
     private readonly spacesRepository: ISpacesRepository,
     @Inject(UserIdentityResolverService)
     private readonly identityResolver: UserIdentityResolverService,
+    @Inject(PostgresDatabaseService)
+    private readonly postgresDatabaseService: PostgresDatabaseService,
   ) {}
 
   public async findPending(
@@ -115,17 +118,18 @@ export class AddressBookRequestsService {
       spaceId,
     });
 
-    const claimed = await this.requestsRepository.transitionFromPending({
-      id: requestId,
-      spaceId,
-      toStatus: 'APPROVED',
-      reviewedBy: userId,
-    });
-    if (!claimed) {
-      throw new BadRequestException('Only pending requests can be approved.');
-    }
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const claimed = await this.requestsRepository.transitionFromPending({
+        id: requestId,
+        spaceId,
+        toStatus: 'APPROVED',
+        reviewedBy: userId,
+        entityManager,
+      });
+      if (!claimed) {
+        throw new BadRequestException('Only pending requests can be approved.');
+      }
 
-    try {
       await this.spaceAddressBookRepository.upsertMany({
         authPayload,
         spaceId,
@@ -137,14 +141,9 @@ export class AddressBookRequestsService {
           },
         ],
         createdByOverride: request.requestedBy.id,
+        entityManager,
       });
-    } catch (err) {
-      await this.requestsRepository.revertToPending({
-        id: requestId,
-        spaceId,
-      });
-      throw err;
-    }
+    });
   }
 
   public async reject(

--- a/src/modules/spaces/routes/entities/__tests__/space-audit-log.dto.entity.spec.ts
+++ b/src/modules/spaces/routes/entities/__tests__/space-audit-log.dto.entity.spec.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { SpaceAuditEventTypesQuerySchema } from '@/modules/spaces/routes/entities/space-audit-log.dto.entity';
+
+describe('SpaceAuditEventTypesQuerySchema', () => {
+  it('parses a comma-separated list of event types', () => {
+    expect(
+      SpaceAuditEventTypesQuerySchema.parse(
+        'ADDRESS_BOOK_UPSERTED,ADDRESS_BOOK_DELETED',
+      ),
+    ).toStrictEqual(['ADDRESS_BOOK_UPSERTED', 'ADDRESS_BOOK_DELETED']);
+  });
+
+  it('treats an empty param like an omitted one', () => {
+    expect(SpaceAuditEventTypesQuerySchema.parse('')).toStrictEqual([]);
+    expect(SpaceAuditEventTypesQuerySchema.parse(undefined)).toBeUndefined();
+  });
+
+  it('rejects unknown event types', () => {
+    const result = SpaceAuditEventTypesQuerySchema.safeParse('NOT_A_TYPE');
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/modules/spaces/routes/entities/space-audit-log.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/space-audit-log.dto.entity.ts
@@ -13,17 +13,21 @@ import { DateStringSchema } from '@/validation/entities/schemas/date-string.sche
 export const SpaceAuditEventTypesQuerySchema = z
   .string()
   .transform((str, ctx) => {
-    return str.split(',').map((item) => {
-      const result = SpaceAuditEventTypeSchema.safeParse(item);
-      if (!result.success) {
-        ctx.addIssue({
-          code: 'custom',
-          message: `Invalid event type "${item}"`,
-        });
-        return z.NEVER;
-      }
-      return result.data;
-    });
+    // An empty param behaves like an omitted one.
+    return str
+      .split(',')
+      .filter(Boolean)
+      .map((item) => {
+        const result = SpaceAuditEventTypeSchema.safeParse(item);
+        if (!result.success) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `Invalid event type "${item}"`,
+          });
+          return z.NEVER;
+        }
+        return result.data;
+      });
   })
   .optional();
 

--- a/src/modules/spaces/routes/entities/space-audit-log.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/space-audit-log.dto.entity.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import { z } from 'zod';
 import { getStringEnumKeys } from '@/domain/common/utils/enum';
 import {
@@ -64,7 +64,7 @@ export class SpaceAuditLogEntryDto {
   })
   actor!: string;
 
-  @ApiPropertyOptional({
+  @ApiProperty({
     type: String,
     nullable: true,
     description:

--- a/src/modules/spaces/routes/entities/space-audit-log.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/space-audit-log.dto.entity.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { z } from 'zod';
+import { getStringEnumKeys } from '@/domain/common/utils/enum';
+import {
+  SpaceAuditEventType,
+  SpaceAuditEventTypeSchema,
+} from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { Page } from '@/routes/common/entities/page.entity';
+import { DateStringSchema } from '@/validation/entities/schemas/date-string.schema';
+
+/** `event_type` arrives as one comma-separated query param. */
+export const SpaceAuditEventTypesQuerySchema = z
+  .string()
+  .transform((str, ctx) => {
+    return str.split(',').map((item) => {
+      const result = SpaceAuditEventTypeSchema.safeParse(item);
+      if (!result.success) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Invalid event type "${item}"`,
+        });
+        return z.NEVER;
+      }
+      return result.data;
+    });
+  })
+  .optional();
+
+export const SpaceAuditActorUserIdQuerySchema = z.coerce
+  .number()
+  .int()
+  .positive()
+  .optional();
+
+export const SpaceAuditDateQuerySchema = DateStringSchema.transform(
+  (value) => new Date(value),
+).optional();
+
+export const SpaceAuditSortDirectionQuerySchema = z
+  .enum(['asc', 'desc'])
+  .optional();
+
+export class SpaceAuditLogEntryDto {
+  @ApiProperty({
+    type: String,
+    description: 'Monotonic entry id (bigint serialized as string)',
+  })
+  id!: string;
+
+  @ApiProperty({ enum: getStringEnumKeys(SpaceAuditEventType) })
+  eventType!: keyof typeof SpaceAuditEventType;
+
+  @ApiProperty({ type: Number })
+  actorUserId!: number;
+
+  @ApiProperty({
+    type: String,
+    description: 'Resolved (and masked) display string of the acting user.',
+  })
+  actor!: string;
+
+  @ApiPropertyOptional({
+    type: String,
+    nullable: true,
+    description:
+      'Resolved (and masked) display string of the affected user, when the event has one.',
+  })
+  targetUser!: string | null;
+
+  @ApiProperty({
+    type: Object,
+    description:
+      'Event-specific payload, allowlisted per event type. Clients must treat every field as optional.',
+  })
+  payload!: Record<string, unknown>;
+
+  @ApiProperty({ type: Date })
+  createdAt!: Date;
+}
+
+export class SpaceAuditLogPage extends Page<SpaceAuditLogEntryDto> {
+  @ApiProperty({ type: SpaceAuditLogEntryDto, isArray: true })
+  results!: Array<SpaceAuditLogEntryDto>;
+}
+
+export class SpaceAuditLogActorDto {
+  @ApiProperty({ type: Number })
+  actorUserId!: number;
+
+  @ApiProperty({
+    type: String,
+    description: 'Resolved (and masked) display string of the actor.',
+  })
+  actor!: string;
+}

--- a/src/modules/spaces/routes/guards/space-audit-route.guard.ts
+++ b/src/modules/spaces/routes/guards/space-audit-route.guard.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { type CanActivate, Inject, Injectable } from '@nestjs/common';
+import { IConfigurationService } from '@/config/configuration.service.interface';
+
+@Injectable()
+export class SpaceAuditRouteGuard implements CanActivate {
+  constructor(
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {}
+
+  canActivate(): boolean {
+    return this.configurationService.getOrThrow<boolean>(
+      'features.spaceAuditLog',
+    );
+  }
+}

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -384,6 +384,10 @@ describe('MembersService', () => {
         expect(membersRepositoryMock.renewInvite).toHaveBeenCalledWith({
           memberId: targetMember.id,
           inviteExpiresAt: new Date(now.getTime() + INVITE_TTL_MS),
+          spaceId,
+          spaceUuid,
+          targetUserId: userId,
+          actorUserId: Number(authPayload.sub),
         });
       } finally {
         jest.useRealTimers();

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -93,6 +93,10 @@ export class MembersService {
     await this.membersRepository.renewInvite({
       memberId: id,
       inviteExpiresAt: new Date(Date.now() + this.inviteTtlMs),
+      spaceId: args.spaceId,
+      spaceUuid: space.uuid,
+      targetUserId: args.userId,
+      actorUserId: getAuthenticatedUserIdOrFail(args.authPayload),
     });
 
     if (user.email) {

--- a/src/modules/spaces/routes/space-audit.controller.ts
+++ b/src/modules/spaces/routes/space-audit.controller.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
+import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
+import type { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import {
+  SpaceAuditActorUserIdQuerySchema,
+  SpaceAuditDateQuerySchema,
+  SpaceAuditEventTypesQuerySchema,
+  SpaceAuditLogActorDto,
+  SpaceAuditLogPage,
+  SpaceAuditSortDirectionQuerySchema,
+} from '@/modules/spaces/routes/entities/space-audit-log.dto.entity';
+import { SpaceAuditRouteGuard } from '@/modules/spaces/routes/guards/space-audit-route.guard';
+import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceAuditService } from '@/modules/spaces/routes/space-audit.service';
+import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
+import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
+import type { PaginationData } from '@/routes/common/pagination/pagination.data';
+import { ValidationPipe } from '@/validation/pipes/validation.pipe';
+
+@ApiTags('spaces')
+@UseGuards(AuthGuard, SpaceAuditRouteGuard)
+@Controller({ path: 'spaces', version: '1' })
+export class SpaceAuditController {
+  public constructor(private readonly spaceAuditService: SpaceAuditService) {}
+
+  @ApiOperation({
+    summary: 'Get space audit log',
+    description:
+      'Retrieves the append-only audit log of a space — who did what, when. ' +
+      'Requires ACTIVE membership. Events are ordered by creation time ' +
+      '(newest first by default) with a stable id tie-break.',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'string',
+    description: 'Space identifier (UUID, or legacy numeric id)',
+  })
+  @ApiQuery({
+    name: 'event_type',
+    required: false,
+    type: String,
+    description: 'Comma-separated list of event types to filter by',
+  })
+  @ApiQuery({
+    name: 'actor_user_id',
+    required: false,
+    type: Number,
+    description: 'Filter by acting user id',
+  })
+  @ApiQuery({
+    name: 'created_at__gte',
+    required: false,
+    type: String,
+    description: 'ISO 8601 lower bound (inclusive) on event creation time',
+  })
+  @ApiQuery({
+    name: 'created_at__lte',
+    required: false,
+    type: String,
+    description: 'ISO 8601 upper bound (inclusive) on event creation time',
+  })
+  @ApiQuery({
+    name: 'sort_direction',
+    required: false,
+    enum: ['asc', 'desc'],
+    description: 'Sort direction over (created_at, id). Defaults to desc.',
+  })
+  @ApiQuery({
+    name: 'cursor',
+    required: false,
+    type: String,
+    description: 'Pagination cursor for retrieving the next set of results',
+  })
+  @ApiOkResponse({
+    type: SpaceAuditLogPage,
+    description: 'Paginated audit log entries',
+  })
+  @ApiForbiddenResponse({
+    description:
+      'User is not an ACTIVE member of the space, or the feature is disabled',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required - valid JWT token must be provided',
+  })
+  @Get(':spaceId/audit-log')
+  public async getAuditLog(
+    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Auth() authPayload: AuthPayload,
+    @RouteUrlDecorator() routeUrl: URL,
+    @PaginationDataDecorator() paginationData: PaginationData,
+    @Query('event_type', new ValidationPipe(SpaceAuditEventTypesQuerySchema))
+    eventTypes?: Array<keyof typeof SpaceAuditEventType>,
+    @Query(
+      'actor_user_id',
+      new ValidationPipe(SpaceAuditActorUserIdQuerySchema),
+    )
+    actorUserId?: number,
+    @Query('created_at__gte', new ValidationPipe(SpaceAuditDateQuerySchema))
+    createdAtGte?: Date,
+    @Query('created_at__lte', new ValidationPipe(SpaceAuditDateQuerySchema))
+    createdAtLte?: Date,
+    @Query(
+      'sort_direction',
+      new ValidationPipe(SpaceAuditSortDirectionQuerySchema),
+    )
+    sortDirection?: 'asc' | 'desc',
+  ): Promise<SpaceAuditLogPage> {
+    return await this.spaceAuditService.getAuditLog({
+      authPayload,
+      spaceId,
+      routeUrl,
+      paginationData,
+      filters: {
+        eventTypes,
+        actorUserId,
+        createdAtGte,
+        createdAtLte,
+        sortDirection,
+      },
+    });
+  }
+
+  @ApiOperation({
+    summary: 'Get space audit log actors',
+    description:
+      'Retrieves the distinct actors appearing in a space audit log — ' +
+      'including former and deleted members — as a filter dropdown source. ' +
+      'Requires ACTIVE membership.',
+  })
+  @ApiParam({
+    name: 'spaceId',
+    type: 'string',
+    description: 'Space identifier (UUID, or legacy numeric id)',
+  })
+  @ApiOkResponse({
+    type: SpaceAuditLogActorDto,
+    isArray: true,
+    description: 'Distinct audit log actors',
+  })
+  @ApiForbiddenResponse({
+    description:
+      'User is not an ACTIVE member of the space, or the feature is disabled',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required - valid JWT token must be provided',
+  })
+  @Get(':spaceId/audit-log/actors')
+  public async getAuditLogActors(
+    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Auth() authPayload: AuthPayload,
+  ): Promise<Array<SpaceAuditLogActorDto>> {
+    return await this.spaceAuditService.getAuditLogActors({
+      authPayload,
+      spaceId,
+    });
+  }
+}

--- a/src/modules/spaces/routes/space-audit.service.spec.ts
+++ b/src/modules/spaces/routes/space-audit.service.spec.ts
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+
+import { faker } from '@faker-js/faker';
+import { ForbiddenException } from '@nestjs/common';
+import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
+import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { spaceAuditLogBuilder } from '@/modules/spaces/datasources/entities/__tests__/space-audit-log.entity.db.builder';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
+import {
+  FORMER_MEMBER_LABEL,
+  SpaceAuditService,
+} from '@/modules/spaces/routes/space-audit.service';
+import { memberBuilder } from '@/modules/users/datasources/entities/__tests__/member.entity.db.builder';
+import type { User } from '@/modules/users/datasources/entities/users.entity.db';
+import type { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
+import type { UserIdentityResolverService } from '@/modules/users/domain/user-identity-resolver.service';
+import { PaginationData } from '@/routes/common/pagination/pagination.data';
+
+const spaceAuditRepository = createMockSpaceAuditRepository();
+
+const membersRepository = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+} as jest.MockedObjectDeep<IMembersRepository>;
+
+const identityResolver = {
+  resolveMany: jest.fn(),
+} as jest.MockedObjectDeep<UserIdentityResolverService>;
+
+describe('SpaceAuditService', () => {
+  let service: SpaceAuditService;
+
+  const spaceId = faker.number.int({ min: 1, max: 100_000 });
+  const viewerUserId = faker.number.int({ min: 1, max: 100_000 });
+  const authPayload = new AuthPayload(
+    siweAuthPayloadDtoBuilder().with('sub', viewerUserId.toString()).build(),
+  );
+  const routeUrl = new URL(`https://safe.test/v1/spaces/${spaceId}/audit-log`);
+
+  function mockViewer(role: 'ADMIN' | 'MEMBER' = 'MEMBER'): void {
+    membersRepository.findOne.mockResolvedValue(
+      memberBuilder()
+        .with('role', role)
+        .with('status', 'ACTIVE')
+        .with('user', { id: viewerUserId } as User)
+        .build(),
+    );
+  }
+
+  function mockActiveMemberIds(userIds: Array<number>): void {
+    membersRepository.find.mockResolvedValue(
+      userIds.map((id) =>
+        memberBuilder()
+          .with('status', 'ACTIVE')
+          .with('user', { id } as User)
+          .build(),
+      ),
+    );
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    service = new SpaceAuditService(
+      spaceAuditRepository,
+      membersRepository,
+      identityResolver,
+    );
+    identityResolver.resolveMany.mockResolvedValue(new Map());
+    membersRepository.find.mockResolvedValue([]);
+    spaceAuditRepository.findBySpaceId.mockResolvedValue([[], 0]);
+    spaceAuditRepository.findDistinctActorIds.mockResolvedValue([]);
+  });
+
+  describe('getAuditLog', () => {
+    it('should throw a ForbiddenException when the viewer has no ACTIVE membership', async () => {
+      membersRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        }),
+      ).rejects.toThrow(
+        new ForbiddenException(
+          'User is not an active member of this workspace',
+        ),
+      );
+
+      expect(membersRepository.findOne).toHaveBeenCalledWith({
+        user: { id: viewerUserId },
+        space: { id: spaceId },
+        status: 'ACTIVE',
+      });
+      expect(spaceAuditRepository.findBySpaceId).not.toHaveBeenCalled();
+    });
+
+    it('should resolve actor and target display strings with one resolveMany call', async () => {
+      mockViewer();
+      const actorUserId = faker.number.int({ min: 1, max: 100_000 });
+      const targetUserId = faker.number.int({
+        min: 100_001,
+        max: 200_000,
+      });
+      const actorAddress = faker.finance.ethereumAddress();
+      const targetAddress = faker.finance.ethereumAddress();
+      const row = spaceAuditLogBuilder()
+        .with('spaceId', spaceId)
+        .with('eventType', 'MEMBER_ROLE_UPDATED')
+        .with('actorUserId', actorUserId)
+        .with('payload', {
+          targetUserId,
+          oldRole: 'MEMBER',
+          newRole: 'ADMIN',
+        })
+        .build();
+      spaceAuditRepository.findBySpaceId.mockResolvedValue([[row], 1]);
+      identityResolver.resolveMany.mockResolvedValue(
+        new Map([
+          [actorUserId, actorAddress],
+          [targetUserId, targetAddress],
+        ]),
+      );
+
+      const page = await service.getAuditLog({
+        authPayload,
+        spaceId,
+        routeUrl,
+        paginationData: new PaginationData(20, 0),
+        filters: {},
+      });
+
+      expect(identityResolver.resolveMany).toHaveBeenCalledTimes(1);
+      expect(identityResolver.resolveMany).toHaveBeenCalledWith([
+        actorUserId,
+        targetUserId,
+      ]);
+      expect(page.results).toStrictEqual([
+        {
+          id: row.id,
+          eventType: 'MEMBER_ROLE_UPDATED',
+          actorUserId,
+          actor: actorAddress,
+          targetUser: targetAddress,
+          payload: { targetUserId, oldRole: 'MEMBER', newRole: 'ADMIN' },
+          createdAt: row.createdAt,
+        },
+      ]);
+    });
+
+    it('should fall back to the deleted-user label for unresolvable users and null target when the event has none', async () => {
+      mockViewer();
+      const row = spaceAuditLogBuilder()
+        .with('spaceId', spaceId)
+        .with('eventType', 'SPACE_CREATED')
+        .with('payload', { name: 'My space' })
+        .build();
+      spaceAuditRepository.findBySpaceId.mockResolvedValue([[row], 1]);
+      identityResolver.resolveMany.mockResolvedValue(new Map());
+
+      const page = await service.getAuditLog({
+        authPayload,
+        spaceId,
+        routeUrl,
+        paginationData: new PaginationData(20, 0),
+        filters: {},
+      });
+
+      expect(page.results[0].actor).toBe('Deleted user');
+      expect(page.results[0].targetUser).toBeNull();
+    });
+
+    describe('email masking', () => {
+      const subjectUserId = faker.number.int({ min: 1, max: 100_000 });
+      const subjectEmail = faker.internet.email();
+
+      function mockEmailSubjectRow(): void {
+        const row = spaceAuditLogBuilder()
+          .with('spaceId', spaceId)
+          .with('eventType', 'MEMBER_INVITE_ACCEPTED')
+          .with('actorUserId', subjectUserId)
+          .with('payload', { targetUserId: subjectUserId })
+          .build();
+        spaceAuditRepository.findBySpaceId.mockResolvedValue([[row], 1]);
+        identityResolver.resolveMany.mockResolvedValue(
+          new Map([[subjectUserId, subjectEmail]]),
+        );
+      }
+
+      it('should mask an email subject as a former member for a non-admin viewer when the subject is not an ACTIVE member', async () => {
+        mockViewer('MEMBER');
+        mockEmailSubjectRow();
+        mockActiveMemberIds([viewerUserId]);
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        });
+
+        expect(page.results[0].actor).toBe(FORMER_MEMBER_LABEL);
+        expect(page.results[0].targetUser).toBe(FORMER_MEMBER_LABEL);
+        expect(JSON.stringify(page)).not.toContain(subjectEmail);
+      });
+
+      it('should expose the email when the subject is an ACTIVE member', async () => {
+        mockViewer('MEMBER');
+        mockEmailSubjectRow();
+        mockActiveMemberIds([viewerUserId, subjectUserId]);
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        });
+
+        expect(page.results[0].actor).toBe(subjectEmail);
+      });
+
+      it('should expose the email to an active admin viewer even when the subject is not an ACTIVE member', async () => {
+        mockViewer('ADMIN');
+        mockEmailSubjectRow();
+        mockActiveMemberIds([viewerUserId]);
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        });
+
+        expect(page.results[0].actor).toBe(subjectEmail);
+      });
+
+      it('should never mask wallet-address display strings', async () => {
+        mockViewer('MEMBER');
+        const address = faker.finance.ethereumAddress();
+        const row = spaceAuditLogBuilder()
+          .with('spaceId', spaceId)
+          .with('eventType', 'MEMBER_LEFT')
+          .with('actorUserId', subjectUserId)
+          .with('payload', { targetUserId: subjectUserId })
+          .build();
+        spaceAuditRepository.findBySpaceId.mockResolvedValue([[row], 1]);
+        identityResolver.resolveMany.mockResolvedValue(
+          new Map([[subjectUserId, address]]),
+        );
+        mockActiveMemberIds([viewerUserId]);
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        });
+
+        expect(page.results[0].actor).toBe(address);
+      });
+    });
+
+    describe('payload allowlist', () => {
+      it('should strip fields that are not part of the event taxonomy', async () => {
+        mockViewer();
+        const targetUserId = faker.number.int({ min: 1, max: 100_000 });
+        const row = spaceAuditLogBuilder()
+          .with('spaceId', spaceId)
+          .with('eventType', 'MEMBER_INVITE_ACCEPTED')
+          .with('payload', {
+            targetUserId,
+            email: faker.internet.email(),
+          } as never)
+          .build();
+        spaceAuditRepository.findBySpaceId.mockResolvedValue([[row], 1]);
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        });
+
+        expect(page.results[0].payload).toStrictEqual({ targetUserId });
+      });
+
+      it('should degrade an unparsable payload to an empty object', async () => {
+        mockViewer();
+        const row = spaceAuditLogBuilder()
+          .with('spaceId', spaceId)
+          .with('eventType', 'SPACE_CREATED')
+          // name missing — does not parse against the SPACE_CREATED schema
+          .with('payload', {} as never)
+          .build();
+        spaceAuditRepository.findBySpaceId.mockResolvedValue([[row], 1]);
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, 0),
+          filters: {},
+        });
+
+        expect(page.results[0].payload).toStrictEqual({});
+      });
+    });
+
+    describe('pagination', () => {
+      it('should clamp the limit to 100', async () => {
+        mockViewer();
+
+        await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(500, 0),
+          filters: {},
+        });
+
+        expect(spaceAuditRepository.findBySpaceId).toHaveBeenCalledWith(
+          expect.objectContaining({ limit: 100 }),
+        );
+      });
+
+      it('should floor a negative offset at 0', async () => {
+        mockViewer();
+
+        await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl,
+          paginationData: new PaginationData(20, -5),
+          filters: {},
+        });
+
+        expect(spaceAuditRepository.findBySpaceId).toHaveBeenCalledWith(
+          expect.objectContaining({ offset: 0 }),
+        );
+      });
+
+      it('should fall back to default pagination for a malformed cursor', async () => {
+        mockViewer();
+        const malformedCursorUrl = new URL(
+          `https://safe.test/v1/spaces/${spaceId}/audit-log?cursor=not-a-cursor`,
+        );
+
+        await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl: malformedCursorUrl,
+          paginationData: PaginationData.fromCursor(malformedCursorUrl),
+          filters: {},
+        });
+
+        expect(spaceAuditRepository.findBySpaceId).toHaveBeenCalledWith(
+          expect.objectContaining({
+            limit: PaginationData.DEFAULT_LIMIT,
+            offset: PaginationData.DEFAULT_OFFSET,
+          }),
+        );
+      });
+
+      it('should build next/previous page urls from the route url', async () => {
+        mockViewer();
+        const rows = [spaceAuditLogBuilder().with('spaceId', spaceId).build()];
+        spaceAuditRepository.findBySpaceId.mockResolvedValue([rows, 50]);
+        const cursorUrl = new URL(
+          `https://safe.test/v1/spaces/${spaceId}/audit-log?cursor=limit%3D20%26offset%3D20`,
+        );
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl: cursorUrl,
+          paginationData: PaginationData.fromCursor(cursorUrl),
+          filters: {},
+        });
+
+        expect(page.count).toBe(50);
+        expect(page.next).toContain('cursor=limit%3D20%26offset%3D40');
+        expect(page.previous).toContain('cursor=limit%3D20%26offset%3D0');
+      });
+    });
+
+    it('should pass filters through to the repository', async () => {
+      mockViewer();
+      const filters = {
+        eventTypes: ['SPACE_CREATED' as const, 'MEMBER_INVITED' as const],
+        actorUserId: faker.number.int({ min: 1, max: 100_000 }),
+        createdAtGte: faker.date.past(),
+        createdAtLte: faker.date.recent(),
+        sortDirection: 'asc' as const,
+      };
+
+      await service.getAuditLog({
+        authPayload,
+        spaceId,
+        routeUrl,
+        paginationData: new PaginationData(20, 0),
+        filters,
+      });
+
+      expect(spaceAuditRepository.findBySpaceId).toHaveBeenCalledWith({
+        spaceId,
+        limit: 20,
+        offset: 0,
+        ...filters,
+      });
+    });
+  });
+
+  describe('getAuditLogActors', () => {
+    it('should throw a ForbiddenException when the viewer has no ACTIVE membership', async () => {
+      membersRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getAuditLogActors({ authPayload, spaceId }),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(spaceAuditRepository.findDistinctActorIds).not.toHaveBeenCalled();
+    });
+
+    it('should return resolved actors including non-members, applying the masking rule', async () => {
+      mockViewer('MEMBER');
+      const memberActorId = faker.number.int({ min: 1, max: 100_000 });
+      const formerActorId = faker.number.int({ min: 100_001, max: 200_000 });
+      const memberAddress = faker.finance.ethereumAddress();
+      spaceAuditRepository.findDistinctActorIds.mockResolvedValue([
+        memberActorId,
+        formerActorId,
+      ]);
+      identityResolver.resolveMany.mockResolvedValue(
+        new Map([
+          [memberActorId, memberAddress],
+          [formerActorId, faker.internet.email()],
+        ]),
+      );
+      mockActiveMemberIds([viewerUserId, memberActorId]);
+
+      const actors = await service.getAuditLogActors({ authPayload, spaceId });
+
+      expect(actors).toStrictEqual([
+        { actorUserId: memberActorId, actor: memberAddress },
+        { actorUserId: formerActorId, actor: FORMER_MEMBER_LABEL },
+      ]);
+    });
+  });
+});

--- a/src/modules/spaces/routes/space-audit.service.spec.ts
+++ b/src/modules/spaces/routes/space-audit.service.spec.ts
@@ -330,6 +330,29 @@ describe('SpaceAuditService', () => {
         );
       });
 
+      it('should build page links from the clamped values, not the raw cursor', async () => {
+        mockViewer();
+        spaceAuditRepository.findBySpaceId.mockResolvedValue([
+          [spaceAuditLogBuilder().with('spaceId', spaceId).build()],
+          150,
+        ]);
+        const oversizedCursorUrl = new URL(
+          `https://safe.test/v1/spaces/${spaceId}/audit-log?cursor=limit%3D500%26offset%3D0`,
+        );
+
+        const page = await service.getAuditLog({
+          authPayload,
+          spaceId,
+          routeUrl: oversizedCursorUrl,
+          paginationData: PaginationData.fromCursor(oversizedCursorUrl),
+          filters: {},
+        });
+
+        // 100 of 150 rows were sent — there must be a next page at offset 100.
+        expect(page.next).toContain('cursor=limit%3D100%26offset%3D100');
+        expect(page.previous).toBeNull();
+      });
+
       it('should floor a negative offset at 0', async () => {
         mockViewer();
 

--- a/src/modules/spaces/routes/space-audit.service.ts
+++ b/src/modules/spaces/routes/space-audit.service.ts
@@ -159,6 +159,7 @@ export class SpaceAuditService {
     const members = await this.membersRepository.find({
       where: { space: { id: spaceId }, status: 'ACTIVE' },
       relations: { user: true },
+      select: { id: true, user: { id: true } },
     });
     return new Set(members.map((member) => member.user.id));
   }

--- a/src/modules/spaces/routes/space-audit.service.ts
+++ b/src/modules/spaces/routes/space-audit.service.ts
@@ -57,6 +57,9 @@ export class SpaceAuditService {
 
     const limit = Math.min(args.paginationData.limit, MAX_LIMIT);
     const offset = Math.max(args.paginationData.offset, 0);
+    // Page links must be derived from the clamped values, not the raw cursor.
+    const normalizedUrl = new URL(args.routeUrl);
+    normalizedUrl.searchParams.set('cursor', `limit=${limit}&offset=${offset}`);
 
     const [rows, count] = await this.spaceAuditRepository.findBySpaceId({
       spaceId: args.spaceId,
@@ -78,8 +81,8 @@ export class SpaceAuditService {
 
     return {
       count,
-      next: buildNextPageURL(args.routeUrl, count)?.toString() ?? null,
-      previous: buildPreviousPageURL(args.routeUrl)?.toString() ?? null,
+      next: buildNextPageURL(normalizedUrl, count)?.toString() ?? null,
+      previous: buildPreviousPageURL(normalizedUrl)?.toString() ?? null,
       results: rows.map((row) => this.toEntryDto(row, display)),
     };
   }

--- a/src/modules/spaces/routes/space-audit.service.ts
+++ b/src/modules/spaces/routes/space-audit.service.ts
@@ -20,7 +20,8 @@ import { UserIdentityResolverService } from '@/modules/users/domain/user-identit
 import {
   buildNextPageURL,
   buildPreviousPageURL,
-  type PaginationData,
+  PaginationData,
+  setCursor,
 } from '@/routes/common/pagination/pagination.data';
 
 export const FORMER_MEMBER_LABEL = 'Former member';
@@ -58,8 +59,10 @@ export class SpaceAuditService {
     const limit = Math.min(args.paginationData.limit, MAX_LIMIT);
     const offset = Math.max(args.paginationData.offset, 0);
     // Page links must be derived from the clamped values, not the raw cursor.
-    const normalizedUrl = new URL(args.routeUrl);
-    normalizedUrl.searchParams.set('cursor', `limit=${limit}&offset=${offset}`);
+    const normalizedUrl = setCursor(
+      args.routeUrl,
+      new PaginationData(limit, offset),
+    );
 
     const [rows, count] = await this.spaceAuditRepository.findBySpaceId({
       spaceId: args.spaceId,

--- a/src/modules/spaces/routes/space-audit.service.ts
+++ b/src/modules/spaces/routes/space-audit.service.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { Inject, Injectable } from '@nestjs/common';
+import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import type { SpaceAuditLog } from '@/modules/spaces/datasources/entities/space-audit-log.entity.db';
+import {
+  SpaceAuditEventSchema,
+  type SpaceAuditEventType,
+} from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
+import type { Space } from '@/modules/spaces/domain/entities/space.entity';
+import type {
+  SpaceAuditLogActorDto,
+  SpaceAuditLogEntryDto,
+  SpaceAuditLogPage,
+} from '@/modules/spaces/routes/entities/space-audit-log.dto.entity';
+import { assertActiveMember } from '@/modules/spaces/routes/utils/space-assert.utils';
+import { IMembersRepository } from '@/modules/users/domain/members.repository.interface';
+import { UserIdentityResolverService } from '@/modules/users/domain/user-identity-resolver.service';
+import {
+  buildNextPageURL,
+  buildPreviousPageURL,
+  type PaginationData,
+} from '@/routes/common/pagination/pagination.data';
+
+export const FORMER_MEMBER_LABEL = 'Former member';
+
+const MAX_LIMIT = 100;
+
+export type SpaceAuditLogFilters = {
+  eventTypes?: Array<keyof typeof SpaceAuditEventType>;
+  actorUserId?: number;
+  createdAtGte?: Date;
+  createdAtLte?: Date;
+  sortDirection?: 'asc' | 'desc';
+};
+
+@Injectable()
+export class SpaceAuditService {
+  constructor(
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
+    @Inject(IMembersRepository)
+    private readonly membersRepository: IMembersRepository,
+    @Inject(UserIdentityResolverService)
+    private readonly identityResolver: UserIdentityResolverService,
+  ) {}
+
+  public async getAuditLog(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+    routeUrl: URL;
+    paginationData: PaginationData;
+    filters: SpaceAuditLogFilters;
+  }): Promise<SpaceAuditLogPage> {
+    const viewerIsActiveAdmin = await this.assertViewer(args);
+
+    const limit = Math.min(args.paginationData.limit, MAX_LIMIT);
+    const offset = Math.max(args.paginationData.offset, 0);
+
+    const [rows, count] = await this.spaceAuditRepository.findBySpaceId({
+      spaceId: args.spaceId,
+      limit,
+      offset,
+      ...args.filters,
+    });
+
+    const display = await this.buildDisplayResolver({
+      spaceId: args.spaceId,
+      viewerIsActiveAdmin,
+      subjectIds: rows.flatMap((row) => {
+        const targetUserId = getTargetUserId(row.payload);
+        return targetUserId === null
+          ? [row.actorUserId]
+          : [row.actorUserId, targetUserId];
+      }),
+    });
+
+    return {
+      count,
+      next: buildNextPageURL(args.routeUrl, count)?.toString() ?? null,
+      previous: buildPreviousPageURL(args.routeUrl)?.toString() ?? null,
+      results: rows.map((row) => this.toEntryDto(row, display)),
+    };
+  }
+
+  public async getAuditLogActors(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<Array<SpaceAuditLogActorDto>> {
+    const viewerIsActiveAdmin = await this.assertViewer(args);
+
+    const actorIds = await this.spaceAuditRepository.findDistinctActorIds(
+      args.spaceId,
+    );
+
+    const display = await this.buildDisplayResolver({
+      spaceId: args.spaceId,
+      viewerIsActiveAdmin,
+      subjectIds: actorIds,
+    });
+
+    return actorIds.map((actorUserId) => ({
+      actorUserId,
+      actor: display(actorUserId),
+    }));
+  }
+
+  private async assertViewer(args: {
+    authPayload: AuthPayload;
+    spaceId: Space['id'];
+  }): Promise<boolean> {
+    const userId = getAuthenticatedUserIdOrFail(args.authPayload);
+    const viewer = await assertActiveMember(
+      this.membersRepository,
+      args.spaceId,
+      userId,
+    );
+    return viewer.role === 'ADMIN';
+  }
+
+  /**
+   * Email display strings are only exposed when the subject is an ACTIVE
+   * member or the viewer is an active admin (mirrors the members endpoint);
+   * otherwise {@link FORMER_MEMBER_LABEL} is substituted.
+   */
+  private async buildDisplayResolver(args: {
+    spaceId: Space['id'];
+    viewerIsActiveAdmin: boolean;
+    subjectIds: Array<number>;
+  }): Promise<(userId: number) => string> {
+    const [identityMap, activeMemberUserIds] = await Promise.all([
+      this.identityResolver.resolveMany(args.subjectIds),
+      this.findActiveMemberUserIds(args.spaceId),
+    ]);
+
+    return (userId: number): string => {
+      const resolved =
+        identityMap.get(userId) ??
+        UserIdentityResolverService.DELETED_USER_LABEL;
+      const isEmail = resolved.includes('@');
+      if (
+        isEmail &&
+        !activeMemberUserIds.has(userId) &&
+        !args.viewerIsActiveAdmin
+      ) {
+        return FORMER_MEMBER_LABEL;
+      }
+      return resolved;
+    };
+  }
+
+  private async findActiveMemberUserIds(
+    spaceId: Space['id'],
+  ): Promise<Set<number>> {
+    const members = await this.membersRepository.find({
+      where: { space: { id: spaceId }, status: 'ACTIVE' },
+      relations: { user: true },
+    });
+    return new Set(members.map((member) => member.user.id));
+  }
+
+  private toEntryDto(
+    row: SpaceAuditLog,
+    display: (userId: number) => string,
+  ): SpaceAuditLogEntryDto {
+    const targetUserId = getTargetUserId(row.payload);
+    return {
+      id: row.id,
+      eventType: row.eventType,
+      actorUserId: row.actorUserId,
+      actor: display(row.actorUserId),
+      targetUser: targetUserId === null ? null : display(targetUserId),
+      payload: allowlistPayload(row),
+      createdAt: row.createdAt,
+    };
+  }
+}
+
+function getTargetUserId(payload: SpaceAuditLog['payload']): number | null {
+  return 'targetUserId' in payload && typeof payload.targetUserId === 'number'
+    ? payload.targetUserId
+    : null;
+}
+
+// Payloads are re-parsed against the taxonomy at read time; rows that no
+// longer parse degrade to an empty payload.
+function allowlistPayload(row: SpaceAuditLog): Record<string, unknown> {
+  const result = SpaceAuditEventSchema.safeParse({
+    eventType: row.eventType,
+    payload: row.payload,
+  });
+  return result.success ? result.data.payload : {};
+}

--- a/src/modules/spaces/routes/space-safes.service.spec.ts
+++ b/src/modules/spaces/routes/space-safes.service.spec.ts
@@ -61,6 +61,7 @@ describe('SpaceSafesService', () => {
       expect(spacesRepositoryMock.findOne).toHaveBeenCalled();
       expect(spaceSafesRepositoryMock.create).toHaveBeenCalledWith({
         spaceId,
+        actorUserId: Number(authPayload.sub),
         payload,
       });
     });
@@ -165,6 +166,7 @@ describe('SpaceSafesService', () => {
       expect(spacesRepositoryMock.findOne).toHaveBeenCalled();
       expect(spaceSafesRepositoryMock.delete).toHaveBeenCalledWith({
         spaceId,
+        actorUserId: Number(authPayload.sub),
         payload,
       });
     });

--- a/src/modules/spaces/routes/space-safes.service.ts
+++ b/src/modules/spaces/routes/space-safes.service.ts
@@ -38,6 +38,7 @@ export class SpaceSafesService {
 
     return await this.spaceSafesRepository.create({
       spaceId: args.spaceId,
+      actorUserId: userId,
       payload: args.payload,
     });
   }
@@ -66,6 +67,7 @@ export class SpaceSafesService {
 
     await this.spaceSafesRepository.delete({
       spaceId: args.spaceId,
+      actorUserId: userId,
       payload: args.payload,
     });
   }

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -790,7 +790,10 @@ describe('SpacesService', () => {
 
       await service.delete({ id: spaceId, authPayload });
 
-      expect(spacesRepositoryMock.delete).toHaveBeenCalledWith(spaceId);
+      expect(spacesRepositoryMock.delete).toHaveBeenCalledWith({
+        id: spaceId,
+        actorUserId: Number(authPayload.sub),
+      });
     });
 
     it.each([

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -129,7 +129,11 @@ export class SpacesService {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
     await assertAdmin(this.spacesRepository, args.id, userId);
 
-    return await this.spacesRepository.update(args);
+    return await this.spacesRepository.update({
+      id: args.id,
+      updatePayload: args.updatePayload,
+      actorUserId: userId,
+    });
   }
 
   /**
@@ -194,6 +198,9 @@ export class SpacesService {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
     await assertAdmin(this.spacesRepository, args.id, userId);
 
-    return await this.spacesRepository.delete(args.id);
+    return await this.spacesRepository.delete({
+      id: args.id,
+      actorUserId: userId,
+    });
   }
 }

--- a/src/modules/spaces/routes/utils/space-assert.utils.ts
+++ b/src/modules/spaces/routes/utils/space-assert.utils.ts
@@ -53,3 +53,29 @@ export async function assertMember(
     throw new ForbiddenException('User is not a member of this workspace');
   }
 }
+
+/**
+ * Unlike {@link assertMember}, INVITED members are rejected.
+ *
+ * @returns the membership row, so callers can derive permissions without a
+ * second query.
+ */
+export async function assertActiveMember(
+  membersRepository: IMembersRepository,
+  spaceId: Space['id'],
+  userId: number,
+): Promise<Member> {
+  const member = await membersRepository.findOne({
+    user: { id: userId },
+    space: { id: spaceId },
+    status: 'ACTIVE',
+  });
+
+  if (!member) {
+    throw new ForbiddenException(
+      'User is not an active member of this workspace',
+    );
+  }
+
+  return member;
+}

--- a/src/modules/spaces/spaces.module.ts
+++ b/src/modules/spaces/spaces.module.ts
@@ -17,6 +17,7 @@ import { AddressBookRequestsRepository } from '@/modules/spaces/domain/address-b
 import { IAddressBookRequestsRepository } from '@/modules/spaces/domain/address-books/address-book-requests.repository.interface';
 import { UserAddressBookItemsRepository } from '@/modules/spaces/domain/address-books/user-address-book-items.repository';
 import { IUserAddressBookItemsRepository } from '@/modules/spaces/domain/address-books/user-address-book-items.repository.interface';
+import { SpaceAuditModule } from '@/modules/spaces/domain/audit/space-audit.module';
 import { SpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository';
 import { ISpaceSafesRepository } from '@/modules/spaces/domain/space-safes.repository.interface';
 import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
@@ -31,6 +32,8 @@ import {
   LegacySpaceIdPipe,
   SpaceIdPipe,
 } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceAuditController } from '@/modules/spaces/routes/space-audit.controller';
+import { SpaceAuditService } from '@/modules/spaces/routes/space-audit.service';
 import { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
 import { SpaceSafesController } from '@/modules/spaces/routes/space-safes.controller';
 import { SpaceSafesService } from '@/modules/spaces/routes/space-safes.service';
@@ -59,6 +62,7 @@ const isSesEmailFeatureEnabled = configuration().features.sesEmail;
     forwardRef(() => AuthModule),
     forwardRef(() => UsersModule),
     ...(isSesEmailFeatureEnabled ? [SesEmailModule] : []),
+    SpaceAuditModule,
     UserIdentityResolverModule,
     WalletsModule,
   ],
@@ -67,6 +71,7 @@ const isSesEmailFeatureEnabled = configuration().features.sesEmail;
     UserAddressBookController,
     AddressBookRequestsController,
     SpacesController,
+    SpaceAuditController,
     SpaceSafesController,
     MembersController,
   ],
@@ -75,6 +80,7 @@ const isSesEmailFeatureEnabled = configuration().features.sesEmail;
     UserAddressBookService,
     AddressBookRequestsService,
     SpacesService,
+    SpaceAuditService,
     SpaceSafesService,
     MembersService,
     SpaceInviteEmailService,

--- a/src/modules/users/domain/members.repository.integration.spec.ts
+++ b/src/modules/users/domain/members.repository.integration.spec.ts
@@ -21,6 +21,7 @@ import {
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { SpaceStatus } from '@/modules/spaces/domain/entities/space.entity';
 import { SpacesRepository } from '@/modules/spaces/domain/spaces.repository';
 import {
@@ -131,8 +132,17 @@ describe('MembersRepository', () => {
     const walletsRepo = new WalletsRepository(postgresDatabaseService);
     membersRepository = new MembersRepository(
       postgresDatabaseService,
-      new UsersRepository(postgresDatabaseService, walletsRepo),
-      new SpacesRepository(postgresDatabaseService, mockConfigurationService),
+      new UsersRepository(
+        postgresDatabaseService,
+        walletsRepo,
+        createMockSpaceAuditRepository(),
+      ),
+      new SpacesRepository(
+        postgresDatabaseService,
+        mockConfigurationService,
+        createMockSpaceAuditRepository(),
+      ),
+      createMockSpaceAuditRepository(),
     );
   });
 
@@ -1151,11 +1161,18 @@ describe('MembersRepository', () => {
         inviteExpiresAt: expiredAt,
       });
       const memberId = memberInsert.identifiers[0].id as Member['id'];
+      const inviteeId = invitee.identifiers[0].id as User['id'];
+      const spaceId = space.generatedMaps[0].id as Space['id'];
+      const spaceUuid = space.generatedMaps[0].uuid as Space['uuid'];
 
       await expect(
         membersRepository.renewInvite({
           memberId,
           inviteExpiresAt: renewedInviteExpiresAt,
+          spaceId,
+          spaceUuid,
+          targetUserId: inviteeId,
+          actorUserId: invitedBy,
         }),
       ).resolves.toBeUndefined();
 

--- a/src/modules/users/domain/members.repository.interface.ts
+++ b/src/modules/users/domain/members.repository.interface.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
+import type { UUID } from 'node:crypto';
 import type {
   FindManyOptions,
   FindOptionsRelations,
@@ -58,6 +59,10 @@ export interface IMembersRepository {
   renewInvite(args: {
     memberId: Member['id'];
     inviteExpiresAt: Date;
+    spaceId: Space['id'];
+    spaceUuid: UUID;
+    targetUserId: User['id'];
+    actorUserId: User['id'];
   }): Promise<void>;
 
   /**

--- a/src/modules/users/domain/members.repository.spec.ts
+++ b/src/modules/users/domain/members.repository.spec.ts
@@ -8,6 +8,7 @@ import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-er
 import { nameBuilder } from '@/domain/common/entities/name.builder';
 import { siweAuthPayloadDtoBuilder } from '@/modules/auth/domain/entities/__tests__/auth-payload-dto.entity.builder';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { spaceBuilder } from '@/modules/spaces/domain/entities/__tests__/space.entity.db.builder';
 import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import { InviteType } from '@/modules/spaces/routes/entities/invite-users.dto.entity';
@@ -59,6 +60,7 @@ describe('MembersRepository', () => {
       postgresDatabaseService,
       usersRepository,
       spacesRepository,
+      createMockSpaceAuditRepository(),
     );
   });
 
@@ -258,21 +260,20 @@ describe('MembersRepository', () => {
   });
 
   describe('renewInvite', () => {
-    let dbMembersRepository: { update: jest.Mock };
-
-    beforeEach(() => {
-      dbMembersRepository = { update: jest.fn() };
-      postgresDatabaseService.getRepository = jest
-        .fn()
-        .mockResolvedValue(dbMembersRepository);
-    });
-
     it("should update the member's inviteExpiresAt by id", async () => {
       const memberId = faker.number.int();
+      const targetUserId = faker.number.int();
 
-      await target.renewInvite({ memberId, inviteExpiresAt });
+      await target.renewInvite({
+        memberId,
+        inviteExpiresAt,
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        targetUserId,
+        actorUserId: authenticatedUserId,
+      });
 
-      expect(dbMembersRepository.update).toHaveBeenCalledWith(memberId, {
+      expect(entityManager.update).toHaveBeenCalledWith(DbMember, memberId, {
         inviteExpiresAt,
       });
     });

--- a/src/modules/users/domain/members.repository.ts
+++ b/src/modules/users/domain/members.repository.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
+import type { UUID } from 'node:crypto';
 import {
   ConflictException,
   ForbiddenException,
@@ -20,6 +21,9 @@ import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-
 import { UniqueConstraintError } from '@/datasources/errors/unique-constraint-error';
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import { Space as DbSpace } from '@/modules/spaces/datasources/entities/space.entity.db';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import {
@@ -43,7 +47,23 @@ export class MembersRepository implements IMembersRepository {
     private readonly usersRepository: IUsersRepository,
     @Inject(ISpacesRepository)
     private readonly spacesRepository: ISpacesRepository,
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
   ) {}
+
+  private async findSpaceForAuditOrFail(
+    entityManager: EntityManager,
+    spaceId: Space['id'],
+  ): Promise<Pick<DbSpace, 'id' | 'uuid'>> {
+    const space = await entityManager.findOne(DbSpace, {
+      where: { id: spaceId },
+      select: { id: true, uuid: true },
+    });
+    if (!space) {
+      throw new NotFoundException('Workspace not found.');
+    }
+    return space;
+  }
 
   public async findOneOrFail(
     where: Array<FindOptionsWhere<Member>> | FindOptionsWhere<Member>,
@@ -163,13 +183,25 @@ export class MembersRepository implements IMembersRepository {
           }
         }
 
-        await this.insertOrUpdateInvite({
+        const { reinvite } = await this.insertOrUpdateInvite({
           entityManager,
           space,
           userId: userIdToInvite,
           userToInvite,
           invitedBy: userId,
           inviteExpiresAt: args.inviteExpiresAt,
+        });
+
+        await this.spaceAuditRepository.record(entityManager, {
+          spaceId: space.id,
+          spaceUuid: space.uuid,
+          eventType: SpaceAuditEventType.MEMBER_INVITED,
+          actorUserId: userId,
+          payload: {
+            targetUserId: userIdToInvite,
+            role: userToInvite.role,
+            ...(reinvite && { reinvite }),
+          },
         });
 
         invitations.push({
@@ -187,6 +219,7 @@ export class MembersRepository implements IMembersRepository {
     return invitations;
   }
 
+  /** @returns `reinvite: true` when an existing `INVITED` member was updated. */
   private async insertOrUpdateInvite(args: {
     entityManager: EntityManager;
     space: Space;
@@ -194,7 +227,7 @@ export class MembersRepository implements IMembersRepository {
     userToInvite: InviteUserInput;
     invitedBy: number | null;
     inviteExpiresAt: Date;
-  }): Promise<void> {
+  }): Promise<{ reinvite: boolean }> {
     const {
       entityManager,
       space,
@@ -236,7 +269,7 @@ export class MembersRepository implements IMembersRepository {
         }
         throw err;
       }
-      return;
+      return { reinvite: false };
     }
 
     if (existingMember.status === 'INVITED') {
@@ -246,7 +279,7 @@ export class MembersRepository implements IMembersRepository {
         invitedBy,
         inviteExpiresAt,
       });
-      return;
+      return { reinvite: true };
     }
 
     throw duplicateInviteError();
@@ -255,11 +288,23 @@ export class MembersRepository implements IMembersRepository {
   public async renewInvite(args: {
     memberId: Member['id'];
     inviteExpiresAt: Date;
+    spaceId: Space['id'];
+    spaceUuid: UUID;
+    targetUserId: User['id'];
+    actorUserId: User['id'];
   }): Promise<void> {
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    await membersRepository.update(args.memberId, {
-      inviteExpiresAt: args.inviteExpiresAt,
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      await entityManager.update(DbMember, args.memberId, {
+        inviteExpiresAt: args.inviteExpiresAt,
+      });
+
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: args.spaceId,
+        spaceUuid: args.spaceUuid,
+        eventType: SpaceAuditEventType.MEMBER_INVITE_RENEWED,
+        actorUserId: args.actorUserId,
+        payload: { targetUserId: args.targetUserId },
+      });
     });
   }
 
@@ -292,6 +337,14 @@ export class MembersRepository implements IMembersRepository {
         status: 'ACTIVE',
         entityManager,
       });
+
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.MEMBER_INVITE_ACCEPTED,
+        actorUserId: userId,
+        payload: { targetUserId: userId },
+      });
     });
   }
 
@@ -315,6 +368,14 @@ export class MembersRepository implements IMembersRepository {
       await entityManager.update(DbMember, member.id, {
         status: 'DECLINED',
         inviteExpiresAt: null,
+      });
+
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.MEMBER_INVITE_DECLINED,
+        actorUserId: userId,
+        payload: { targetUserId: userId },
       });
     });
   }
@@ -378,16 +439,32 @@ export class MembersRepository implements IMembersRepository {
       });
     }
 
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    const updateResult = await membersRepository.update(
-      { user: { id: args.userId }, space: { id: args.spaceId } },
-      { role: args.role },
-    );
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const member = await entityManager.findOne(DbMember, {
+        where: { user: { id: args.userId }, space: { id: args.spaceId } },
+      });
+      if (!member) {
+        throw new NotFoundException('Member not found.');
+      }
 
-    if (updateResult.affected === 0) {
-      throw new NotFoundException('Member not found.');
-    }
+      await entityManager.update(DbMember, member.id, { role: args.role });
+
+      const space = await this.findSpaceForAuditOrFail(
+        entityManager,
+        args.spaceId,
+      );
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.MEMBER_ROLE_UPDATED,
+        actorUserId: actingUserId,
+        payload: {
+          targetUserId: args.userId,
+          oldRole: member.role,
+          newRole: args.role,
+        },
+      });
+    });
   }
 
   public async updateAlias(args: {
@@ -397,16 +474,28 @@ export class MembersRepository implements IMembersRepository {
   }): Promise<void> {
     const userId = getAuthenticatedUserIdOrFail(args.authPayload);
 
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    const updateResult = await membersRepository.update(
-      { user: { id: userId }, space: { id: args.spaceId } },
-      { alias: args.alias },
-    );
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const member = await entityManager.findOne(DbMember, {
+        where: { user: { id: userId }, space: { id: args.spaceId } },
+      });
+      if (!member) {
+        throw new NotFoundException('Member not found.');
+      }
 
-    if (updateResult.affected === 0) {
-      throw new NotFoundException('Member not found.');
-    }
+      await entityManager.update(DbMember, member.id, { alias: args.alias });
+
+      const space = await this.findSpaceForAuditOrFail(
+        entityManager,
+        args.spaceId,
+      );
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.MEMBER_ALIAS_UPDATED,
+        actorUserId: userId,
+        payload: { targetUserId: userId },
+      });
+    });
   }
 
   public async removeUser(args: {
@@ -427,16 +516,28 @@ export class MembersRepository implements IMembersRepository {
       });
     }
 
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
-    const deleteResult = await membersRepository.delete({
-      user: { id: args.userId },
-      space: { id: args.spaceId },
-    });
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const member = await entityManager.findOne(DbMember, {
+        where: { user: { id: args.userId }, space: { id: args.spaceId } },
+      });
+      if (!member) {
+        throw new NotFoundException('Member not found.');
+      }
 
-    if (deleteResult.affected === 0) {
-      throw new NotFoundException('Member not found.');
-    }
+      await entityManager.delete(DbMember, member.id);
+
+      const space = await this.findSpaceForAuditOrFail(
+        entityManager,
+        args.spaceId,
+      );
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.MEMBER_REMOVED,
+        actorUserId: actingUserId,
+        payload: { targetUserId: args.userId },
+      });
+    });
   }
 
   public async removeSelf(args: {
@@ -449,17 +550,28 @@ export class MembersRepository implements IMembersRepository {
 
     this.assertIsNotLastAdmin({ members: activeAdmins, userId });
 
-    const membersRepository =
-      await this.postgresDatabaseService.getRepository(DbMember);
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const member = await entityManager.findOne(DbMember, {
+        where: { user: { id: userId }, space: { id: args.spaceId } },
+      });
+      if (!member) {
+        throw new NotFoundException('Member not found.');
+      }
 
-    const deleteResult = await membersRepository.delete({
-      user: { id: userId },
-      space: { id: args.spaceId },
+      await entityManager.delete(DbMember, member.id);
+
+      const space = await this.findSpaceForAuditOrFail(
+        entityManager,
+        args.spaceId,
+      );
+      await this.spaceAuditRepository.record(entityManager, {
+        spaceId: space.id,
+        spaceUuid: space.uuid,
+        eventType: SpaceAuditEventType.MEMBER_LEFT,
+        actorUserId: userId,
+        payload: { targetUserId: userId },
+      });
     });
-
-    if (deleteResult.affected === 0) {
-      throw new NotFoundException('Member not found.');
-    }
   }
 
   private assertIsActiveAdmin(args: {

--- a/src/modules/users/domain/users.repository.integration.spec.ts
+++ b/src/modules/users/domain/users.repository.integration.spec.ts
@@ -18,6 +18,7 @@ import {
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import { SpaceSafe } from '@/modules/spaces/datasources/entities/space-safes.entity.db';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
 import { UserStatus } from '@/modules/users/domain/entities/user.entity';
@@ -103,6 +104,7 @@ describe('UsersRepository', () => {
     usersRepository = new UsersRepository(
       postgresDatabaseService,
       new WalletsRepository(postgresDatabaseService),
+      createMockSpaceAuditRepository(),
     );
   });
 

--- a/src/modules/users/domain/users.repository.spec.ts
+++ b/src/modules/users/domain/users.repository.spec.ts
@@ -4,6 +4,7 @@ import { UnauthorizedException } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
 import { getAddress } from 'viem';
 import type { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
+import { createMockSpaceAuditRepository } from '@/modules/spaces/domain/audit/__tests__/space-audit.repository.mock';
 import { User as DbUser } from '@/modules/users/datasources/entities/users.entity.db';
 import { UserEmailAlreadyInUseError } from '@/modules/users/domain/errors/user-email-already-in-use.error';
 import { UsersRepository } from '@/modules/users/domain/users.repository';
@@ -58,7 +59,11 @@ describe('UsersRepository', () => {
       transaction: jest.fn(),
     } as jest.MockedObjectDeep<PostgresDatabaseService>;
 
-    target = new UsersRepository(postgresDatabaseService, walletsRepository);
+    target = new UsersRepository(
+      postgresDatabaseService,
+      walletsRepository,
+      createMockSpaceAuditRepository(),
+    );
   });
 
   describe('findOrCreateByWalletAddress', () => {

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -162,7 +162,8 @@ export class UsersRepository implements IUsersRepository {
       });
 
       for (const membership of memberships) {
-        if (membership.status === 'DECLINED') {
+        // Only ACTIVE members "leave" — pending/declined invites just expire.
+        if (membership.status !== 'ACTIVE') {
           continue;
         }
         await this.spaceAuditRepository.record(entityManager, {

--- a/src/modules/users/domain/users.repository.ts
+++ b/src/modules/users/domain/users.repository.ts
@@ -13,6 +13,9 @@ import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.s
 import { isUniqueConstraintError } from '@/datasources/errors/helpers/is-unique-constraint-error.helper';
 import { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { getAuthenticatedUserIdOrFail } from '@/modules/auth/utils/assert-authenticated.utils';
+import { SpaceAuditEventType } from '@/modules/spaces/domain/audit/entities/space-audit-event.entity';
+import { ISpaceAuditRepository } from '@/modules/spaces/domain/audit/space-audit.repository.interface';
+import { Member as DbMember } from '@/modules/users/datasources/entities/member.entity.db';
 import { User as DbUser } from '@/modules/users/datasources/entities/users.entity.db';
 import type { User } from '@/modules/users/domain/entities/user.entity';
 import { UserStatus } from '@/modules/users/domain/entities/user.entity';
@@ -28,6 +31,8 @@ export class UsersRepository implements IUsersRepository {
     private readonly postgresDatabaseService: PostgresDatabaseService,
     @Inject(IWalletsRepository)
     private readonly walletsRepository: IWalletsRepository,
+    @Inject(ISpaceAuditRepository)
+    private readonly spaceAuditRepository: ISpaceAuditRepository,
   ) {}
 
   public async findOneOrFail(
@@ -150,10 +155,27 @@ export class UsersRepository implements IUsersRepository {
   public async delete(authPayload: AuthPayload): Promise<void> {
     const userId = getAuthenticatedUserIdOrFail(authPayload);
 
-    const userRepository =
-      await this.postgresDatabaseService.getRepository(DbUser);
+    await this.postgresDatabaseService.transaction(async (entityManager) => {
+      const memberships = await entityManager.find(DbMember, {
+        where: { user: { id: userId } },
+        relations: { space: true },
+      });
 
-    await userRepository.delete({ id: userId });
+      for (const membership of memberships) {
+        if (membership.status === 'DECLINED') {
+          continue;
+        }
+        await this.spaceAuditRepository.record(entityManager, {
+          spaceId: membership.space.id,
+          spaceUuid: membership.space.uuid,
+          eventType: SpaceAuditEventType.MEMBER_LEFT,
+          actorUserId: userId,
+          payload: { targetUserId: userId, accountDeleted: true },
+        });
+      }
+
+      await entityManager.delete(DbUser, { id: userId });
+    });
   }
 
   public async deleteWalletFromUser(args: {

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostgresDatabaseModuleV2 } from '@/datasources/db/v2/postgres-database.module';
 import { AuthModule } from '@/modules/auth/auth.module';
 import { SiweModule } from '@/modules/siwe/siwe.module';
+import { SpaceAuditModule } from '@/modules/spaces/domain/audit/space-audit.module';
 import { SpacesModule } from '@/modules/spaces/spaces.module';
 import { Member } from '@/modules/users/datasources/entities/member.entity.db';
 import { User } from '@/modules/users/datasources/entities/users.entity.db';
@@ -24,6 +25,7 @@ import { WalletsModule } from '@/modules/wallets/wallets.module';
     forwardRef(() => AuthModule),
     SiweModule,
     forwardRef(() => SpacesModule),
+    SpaceAuditModule,
   ],
   providers: [
     {

--- a/src/routes/common/pagination/pagination.data.ts
+++ b/src/routes/common/pagination/pagination.data.ts
@@ -136,7 +136,7 @@ export function cursorUrlFromLimitAndOffset(
  * @param url
  * @param paginationData
  */
-function setCursor(
+export function setCursor(
   url: Readonly<URL | string>,
   paginationData: PaginationData,
 ): URL {


### PR DESCRIPTION
## Summary

Adds an append-only audit log for Spaces: every space mutation (space create/update/delete, member lifecycle, Safe add/remove, address book changes, account-deletion departures) is recorded in the same database transaction as the mutation, and ACTIVE space members can read it through a new paginated endpoint. Powers the Activity log in the web app (separate PR).

Related to: https://linear.app/safe-global/issue/WA-2550

## Changes

- New `space_audit_log` table; DB triggers reject `UPDATE`/`DELETE`/`TRUNCATE` and `created_at` is always set server-side
- `SpaceAuditRepository.record()` joins the caller's transaction, so the event and the mutation commit or roll back together; writes are gated by `FF_SPACE_AUDIT_LOG` (default off)
- All space mutation paths instrumented (15 event types), including member departures caused by user-account deletion
- Address book request approval now runs the state transition and the upsert in one shared transaction (replaces the manual revert-to-pending)
- New endpoints: `GET /v1/spaces/:spaceId/audit-log` (event-type/actor/date filters, sort direction, pagination) and `GET /v1/spaces/:spaceId/audit-log/actors`; ACTIVE members only, display names resolved server-side with the same email-visibility rules as the members endpoint
- Unit + integration coverage: transactional atomicity, trigger enforcement, stable pagination ordering, filters, display-name masking

## How to test

1. Run migrations and start the service with `FF_SPACE_AUDIT_LOG=true`
2. Exercise space mutations (create a space, invite/accept a member, add a Safe, upsert/delete an address book contact)
3. As an ACTIVE member, `GET /v1/spaces/:spaceId/audit-log` returns the events newest-first; query params narrow the feed; `/audit-log/actors` lists distinct actors
4. `yarn test:unit --testPathPatterns space-audit` and `yarn test:integration --testPathPatterns space-audit`