### PR TITLE
chore: document IRSA injection of AWS_WEB_IDENTITY_TOKEN_FILE

### DIFF
--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -272,6 +272,10 @@ export default () => ({
         accessKeyId: process.env.SES_AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.SES_AWS_SECRET_ACCESS_KEY,
         // EKS service-account token path. SES uses this for IRSA in deployed environments.
+        // Never set manually: the EKS Pod Identity Webhook injects this env var (and
+        // AWS_ROLE_ARN) into pods whose ServiceAccount is annotated with
+        // eks.amazonaws.com/role-arn — the annotation is the only thing set in ArgoCD.
+        // See https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html
         webIdentityTokenFile: process.env.AWS_WEB_IDENTITY_TOKEN_FILE,
       },
       // BullMQ queue configuration for email sending.


### PR DESCRIPTION
## Summary

- Documents at the config read site that `AWS_WEB_IDENTITY_TOKEN_FILE` is never set manually: the EKS Pod Identity Webhook injects it (together with `AWS_ROLE_ARN`) into pods whose ServiceAccount carries the `eks.amazonaws.com/role-arn` annotation — the annotation is the only thing configured in ArgoCD.
- Links the relevant AWS docs: https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)