### PR TITLE
feat: remove client-facing legacy numeric spaceId; keep UUID only

### DIFF
--- a/src/modules/counterfactual-safes/routes/__tests__/space-counterfactual-safes.controller.e2e-spec.ts
+++ b/src/modules/counterfactual-safes/routes/__tests__/space-counterfactual-safes.controller.e2e-spec.ts
@@ -114,7 +114,7 @@ describe('SpaceCounterfactualSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: nameBuilder() });
-      const spaceId = spaceRes.body.id as number;
+      const spaceId = spaceRes.body.uuid as string;
 
       // Create counterfactual safe
       await request(app.getHttpServer())
@@ -162,7 +162,7 @@ describe('SpaceCounterfactualSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: nameBuilder() });
-      const spaceId = spaceRes.body.id as number;
+      const spaceId = spaceRes.body.uuid as string;
 
       const getResponse = await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}/counterfactual-safes`)
@@ -187,7 +187,7 @@ describe('SpaceCounterfactualSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken1}`])
         .send({ name: nameBuilder() });
-      const spaceId = spaceRes.body.id as number;
+      const spaceId = spaceRes.body.uuid as string;
 
       // User 2 tries to access
       await request(app.getHttpServer())
@@ -221,7 +221,7 @@ describe('SpaceCounterfactualSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: nameBuilder() });
-      const spaceId = spaceRes.body.id as number;
+      const spaceId = spaceRes.body.uuid as string;
 
       // Create counterfactual safe
       await request(app.getHttpServer())

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.controller.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.controller.ts
@@ -14,7 +14,7 @@ import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
 import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
 import { GetCounterfactualSafesResponse } from '@/modules/counterfactual-safes/routes/entities/get-counterfactual-safe.dto.entity';
 import { SpaceCounterfactualSafesService } from '@/modules/counterfactual-safes/routes/space-counterfactual-safes.service';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 
 @ApiTags('spaces')
 @Controller({
@@ -53,7 +53,7 @@ export class SpaceCounterfactualSafesController {
   })
   @Get()
   public async get(
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<GetCounterfactualSafesResponse> {
     return await this.spaceCounterfactualSafesService.get(spaceId, authPayload);

--- a/src/modules/counterfactual-safes/routes/space-counterfactual-safes.controller.ts
+++ b/src/modules/counterfactual-safes/routes/space-counterfactual-safes.controller.ts
@@ -2,6 +2,7 @@
 
 import { Controller, Get, Inject, Param, UseGuards } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -36,14 +37,14 @@ export class SpaceCounterfactualSafesController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
     description: 'Counterfactual Safes retrieved successfully',
     type: GetCounterfactualSafesResponse,
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @ApiUnauthorizedResponse({
     description:
       'Authentication required or user is not a member of this space',

--- a/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/audit/space-audit.repository.integration.spec.ts
@@ -188,8 +188,9 @@ describe('SpaceAuditRepository', () => {
       name: nameBuilder(),
       status: 'ACTIVE',
     });
+    const spaceId = await spacesRepository.findIdByUuid(space.uuid);
     return {
-      spaceId: space.id,
+      spaceId,
       spaceUuid: space.uuid,
       adminUserId: userId,
       adminAuthPayload: authPayload,

--- a/src/modules/spaces/domain/spaces.repository.integration.spec.ts
+++ b/src/modules/spaces/domain/spaces.repository.integration.spec.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { faker } from '@faker-js/faker';
-import { BadRequestException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
 import { DataSource, EntityNotFoundError, In } from 'typeorm';
 import type { IConfigurationService } from '@/config/configuration.service.interface';
@@ -220,7 +219,6 @@ describe('SpacesRepository', () => {
       });
 
       expect(space).toEqual({
-        id: expect.any(Number),
         uuid: expect.any(String),
         name,
       });
@@ -289,7 +287,6 @@ describe('SpacesRepository', () => {
           status: spaceStatus,
         }),
       ).resolves.toEqual({
-        id: expect.any(Number),
         uuid: expect.any(String),
         name,
       });
@@ -346,7 +343,6 @@ describe('SpacesRepository', () => {
           status: 'ACTIVE',
         }),
       ).resolves.toEqual({
-        id: expect.any(Number),
         uuid: expect.any(String),
         name: expect.any(String),
       });
@@ -368,7 +364,6 @@ describe('SpacesRepository', () => {
       });
 
       expect(space).toEqual({
-        id: expect.any(Number),
         uuid: expect.any(String),
         name: spaceName,
       });
@@ -463,11 +458,12 @@ describe('SpacesRepository', () => {
         name: name,
         status: spaceStatus,
       });
+      const spaceId = await spacesRepository.findIdByUuid(space.uuid);
 
       await expect(
-        spacesRepository.findOneOrFail({ where: { id: space.id } }),
+        spacesRepository.findOneOrFail({ where: { id: spaceId } }),
       ).resolves.toEqual({
-        id: space.id,
+        id: spaceId,
         uuid: space.uuid,
         name,
         status: spaceStatus,
@@ -500,76 +496,14 @@ describe('SpacesRepository', () => {
         status: faker.helpers.arrayElement(SpaceStatusKeys),
       });
 
-      await expect(spacesRepository.findIdByUuid(space.uuid)).resolves.toBe(
-        space.id,
+      await expect(spacesRepository.findIdByUuid(space.uuid)).resolves.toEqual(
+        expect.any(Number),
       );
     });
 
     it('should throw if no space has the UUID', async () => {
       await expect(spacesRepository.findIdByUuid(fakeUuid())).rejects.toThrow(
         'Workspace not found.',
-      );
-    });
-  });
-
-  describe('findIdByIdOrUuid', () => {
-    it('should resolve a UUID to its numeric id', async () => {
-      const user = await dbUserRepo.insert({
-        status: faker.helpers.arrayElement(UserStatusKeys),
-      });
-      const userId = user.identifiers[0].id as User['id'];
-      const space = await spacesRepository.create({
-        userId,
-        name: faker.word.noun(),
-        status: faker.helpers.arrayElement(SpaceStatusKeys),
-      });
-
-      await expect(spacesRepository.findIdByIdOrUuid(space.uuid)).resolves.toBe(
-        space.id,
-      );
-    });
-
-    it('should resolve a legacy numeric id to itself', async () => {
-      const user = await dbUserRepo.insert({
-        status: faker.helpers.arrayElement(UserStatusKeys),
-      });
-      const userId = user.identifiers[0].id as User['id'];
-      const space = await spacesRepository.create({
-        userId,
-        name: faker.word.noun(),
-        status: faker.helpers.arrayElement(SpaceStatusKeys),
-      });
-
-      await expect(
-        spacesRepository.findIdByIdOrUuid(String(space.id)),
-      ).resolves.toBe(space.id);
-    });
-
-    it('should throw if no space has the UUID', async () => {
-      await expect(
-        spacesRepository.findIdByIdOrUuid(faker.string.uuid()),
-      ).rejects.toThrow('Workspace not found.');
-    });
-
-    it('should throw if no space has the numeric id', async () => {
-      const spaceId = faker.number.int({
-        min: 69420,
-        max: DB_MAX_SAFE_INTEGER,
-      });
-
-      await expect(
-        spacesRepository.findIdByIdOrUuid(String(spaceId)),
-      ).rejects.toThrow('Workspace not found.');
-    });
-
-    it.each([
-      ['empty string', ''],
-      ['non-UUID text', faker.lorem.word()],
-      ['UUID missing a segment', faker.string.uuid().slice(0, -13)],
-      ['UUID with a non-hex character', `${faker.string.uuid().slice(0, -1)}g`],
-    ])('should throw BadRequestException for a malformed identifier (%s)', async (_label, value) => {
-      await expect(spacesRepository.findIdByIdOrUuid(value)).rejects.toThrow(
-        new BadRequestException('Invalid space identifier'),
       );
     });
   });
@@ -588,11 +522,12 @@ describe('SpacesRepository', () => {
         name: name,
         status: spaceStatus,
       });
+      const spaceId = await spacesRepository.findIdByUuid(space.uuid);
 
       await expect(
-        spacesRepository.findOne({ where: { id: space.id } }),
+        spacesRepository.findOne({ where: { id: spaceId } }),
       ).resolves.toEqual({
-        id: space.id,
+        id: spaceId,
         uuid: space.uuid,
         name,
         status: spaceStatus,
@@ -636,14 +571,16 @@ describe('SpacesRepository', () => {
         name: spaceName2,
         status: spaceStatus2,
       });
+      const space1Id = await spacesRepository.findIdByUuid(space1.uuid);
+      const space2Id = await spacesRepository.findIdByUuid(space2.uuid);
 
       await expect(
         spacesRepository.findOrFail({
-          where: { id: In([space1.id, space2.id]) },
+          where: { id: In([space1Id, space2Id]) },
         }),
       ).resolves.toEqual([
         {
-          id: space1.id,
+          id: space1Id,
           uuid: space1.uuid,
           name: spaceName1,
           status: spaceStatus1,
@@ -653,7 +590,7 @@ describe('SpacesRepository', () => {
           safes: undefined,
         },
         {
-          id: space2.id,
+          id: space2Id,
           uuid: space2.uuid,
           name: spaceName2,
           status: spaceStatus2,
@@ -698,16 +635,18 @@ describe('SpacesRepository', () => {
         name: spaceName2,
         status: spaceStatus2,
       });
+      const space1Id = await spacesRepository.findIdByUuid(space1.uuid);
+      const space2Id = await spacesRepository.findIdByUuid(space2.uuid);
 
       await expect(
         spacesRepository.find({
           where: {
-            id: In([space1.id, space2.id]),
+            id: In([space1Id, space2Id]),
           },
         }),
       ).resolves.toEqual([
         {
-          id: space1.id,
+          id: space1Id,
           uuid: space1.uuid,
           name: spaceName1,
           status: spaceStatus1,
@@ -717,7 +656,7 @@ describe('SpacesRepository', () => {
           safes: undefined,
         },
         {
-          id: space2.id,
+          id: space2Id,
           uuid: space2.uuid,
           name: spaceName2,
           status: spaceStatus2,
@@ -756,12 +695,14 @@ describe('SpacesRepository', () => {
         status: spaceStatus,
       });
 
+      const spaceId = await spacesRepository.findIdByUuid(space.uuid);
+
       await expect(
         spacesRepository.findOneByUserIdOrFail({
           userId,
         }),
       ).resolves.toEqual({
-        id: space.id,
+        id: spaceId,
         uuid: space.uuid,
         name: spaceName,
         status: spaceStatus,
@@ -799,12 +740,14 @@ describe('SpacesRepository', () => {
         status: spaceStatus,
       });
 
+      const spaceId = await spacesRepository.findIdByUuid(space.uuid);
+
       await expect(
         spacesRepository.findOneByUserId({
           userId,
         }),
       ).resolves.toEqual({
-        id: space.id,
+        id: spaceId,
         uuid: space.uuid,
         name: spaceName,
         status: spaceStatus,
@@ -842,21 +785,23 @@ describe('SpacesRepository', () => {
         status: spaceStatus,
       });
 
+      const spaceId = await spacesRepository.findIdByUuid(space.uuid);
+
       const newName = faker.word.noun();
       const newStatus = faker.helpers.arrayElement(SpaceStatusKeys);
 
       await spacesRepository.update({
-        id: space.id,
+        id: spaceId,
         updatePayload: { name: newName, status: newStatus },
         actorUserId: userId,
       });
 
       const dbSpace = await dbSpacesRepository.findOneOrFail({
-        where: { id: space.id },
+        where: { id: spaceId },
       });
 
       expect(dbSpace).toEqual({
-        id: space.id,
+        id: spaceId,
         uuid: space.uuid,
         name: newName,
         status: newStatus,
@@ -883,10 +828,12 @@ describe('SpacesRepository', () => {
         status: spaceStatus,
       });
 
-      await spacesRepository.delete({ id: space.id, actorUserId: userId });
+      const spaceId = await spacesRepository.findIdByUuid(space.uuid);
+
+      await spacesRepository.delete({ id: spaceId, actorUserId: userId });
 
       await expect(
-        dbSpacesRepository.findOneOrFail({ where: { id: space.id } }),
+        dbSpacesRepository.findOneOrFail({ where: { id: spaceId } }),
       ).rejects.toBeInstanceOf(EntityNotFoundError);
     });
   });

--- a/src/modules/spaces/domain/spaces.repository.interface.ts
+++ b/src/modules/spaces/domain/spaces.repository.interface.ts
@@ -16,7 +16,7 @@ export interface ISpacesRepository {
     userId: User['id'];
     name: string;
     status: keyof typeof SpaceStatus;
-  }): Promise<Pick<Space, 'id' | 'uuid' | 'name'>>;
+  }): Promise<Pick<Space, 'uuid' | 'name'>>;
 
   findOneOrFail(
     args: Parameters<SpacesRepository['findOne']>[0],
@@ -62,15 +62,12 @@ export interface ISpacesRepository {
     id: Space['id'];
     updatePayload: Partial<Pick<Space, 'name' | 'status'>>;
     actorUserId: number;
-  }): Promise<Pick<Space, 'id' | 'uuid'>>;
+  }): Promise<Pick<Space, 'uuid'>>;
 
   findIdByUuid(uuid: Space['uuid']): Promise<Space['id']>;
 
-  // TODO: remove after FE removes numeric Space ID fallback.
+  // Resolves the internal numeric id to the client-facing UUID for response mapping.
   findUuidById(id: Space['id']): Promise<Space['uuid']>;
-
-  // TODO: remove after FE removes numeric Space ID fallback.
-  findIdByIdOrUuid(value: string): Promise<Space['id']>;
 
   delete(args: { id: number; actorUserId: number }): Promise<void>;
 }

--- a/src/modules/spaces/domain/spaces.repository.ts
+++ b/src/modules/spaces/domain/spaces.repository.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 
 import {
-  BadRequestException,
   ForbiddenException,
   Inject,
   Injectable,
@@ -16,7 +15,6 @@ import {
 } from 'typeorm';
 import { IConfigurationService } from '@/config/configuration.service.interface';
 import { PostgresDatabaseService } from '@/datasources/db/v2/postgres-database.service';
-import { NUMERIC_REGEX, UUID_REGEX } from '@/domain/common/constants';
 import { getEnumKey } from '@/domain/common/utils/enum';
 import { Space } from '@/modules/spaces/datasources/entities/space.entity.db';
 import {
@@ -55,7 +53,7 @@ export class SpacesRepository implements ISpacesRepository {
     userId: number;
     name: string;
     status: keyof typeof SpaceStatus;
-  }): Promise<Pick<Space, 'id' | 'uuid' | 'name'>> {
+  }): Promise<Pick<Space, 'uuid' | 'name'>> {
     const isLimited = await this.isLimited(args.userId);
     if (isLimited) {
       throw new ForbiddenException(
@@ -93,7 +91,6 @@ export class SpacesRepository implements ISpacesRepository {
         });
 
         return {
-          id: insertResult.id,
           uuid: insertResult.uuid,
           name: insertResult.name,
         };
@@ -219,7 +216,7 @@ export class SpacesRepository implements ISpacesRepository {
     id: Space['id'];
     updatePayload: Partial<Pick<Space, 'name' | 'status'>>;
     actorUserId: number;
-  }): Promise<Pick<Space, 'id' | 'uuid'>> {
+  }): Promise<Pick<Space, 'uuid'>> {
     return await this.postgresDatabaseService.transaction(
       async (entityManager) => {
         // Old values are read inside the transaction to keep the diff exact.
@@ -249,7 +246,7 @@ export class SpacesRepository implements ISpacesRepository {
           });
         }
 
-        return { id: current.id, uuid: current.uuid };
+        return { uuid: current.uuid };
       },
     );
   }
@@ -285,31 +282,14 @@ export class SpacesRepository implements ISpacesRepository {
     return space.id;
   }
 
-  // TODO: remove after FE removes numeric Space ID fallback. Used to echo the
-  // Space UUID alongside the deprecated numeric id in responses.
+  // Resolves the internal numeric id to the client-facing UUID. Mappers hold a
+  // numeric spaceId internally and use this to emit the UUID in responses.
   public async findUuidById(id: Space['id']): Promise<Space['uuid']> {
     const space = await this.findOneOrFail({
       where: { id },
       select: { uuid: true },
     });
     return space.uuid;
-  }
-
-  // TODO: remove after FE removes numeric Space ID fallback.
-  // UUID is re-validated here (defence in depth) so a malformed string can't
-  // reach Postgres as a UUID and surface as a raw 500 instead of a 400.
-  public async findIdByIdOrUuid(value: string): Promise<Space['id']> {
-    if (NUMERIC_REGEX.test(value)) {
-      const space = await this.findOneOrFail({
-        where: { id: Number(value) },
-        select: { id: true },
-      });
-      return space.id;
-    }
-    if (!UUID_REGEX.test(value)) {
-      throw new BadRequestException('Invalid space identifier');
-    }
-    return await this.findIdByUuid(value as Space['uuid']);
   }
 
   // @todo Add a soft delete method

--- a/src/modules/spaces/routes/address-book-requests.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/address-book-requests.controller.e2e-spec.ts
@@ -464,9 +464,7 @@ describe('AddressBookRequestsController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect(({ body }) =>
-          expect(body).toEqual(
-            expect.objectContaining({ spaceId: spaceId.toString(), data: [] }),
-          ),
+          expect(body).toEqual(expect.objectContaining({ data: [] })),
         );
     });
 
@@ -523,9 +521,7 @@ describe('AddressBookRequestsController', () => {
         .set('Cookie', [`access_token=${memberAccessToken}`])
         .expect(200)
         .expect(({ body }) =>
-          expect(body).toEqual(
-            expect.objectContaining({ spaceId: spaceId.toString(), data: [] }),
-          ),
+          expect(body).toEqual(expect.objectContaining({ data: [] })),
         );
     });
   });
@@ -561,7 +557,7 @@ describe('AddressBookRequestsController', () => {
       .set('Cookie', [`access_token=${accessToken}`])
       .send({ name: spaceName })
       .expect(201);
-    const spaceId = createSpaceResponse.body.id;
+    const spaceId = createSpaceResponse.body.uuid;
     return { spaceId, accessToken };
   };
 
@@ -586,7 +582,7 @@ describe('AddressBookRequestsController', () => {
       .send({ name: nameBuilder() })
       .expect(201);
     return {
-      spaceId: createSpaceResponse.body.id,
+      spaceId: createSpaceResponse.body.uuid,
       accessToken,
       userId,
       email,

--- a/src/modules/spaces/routes/address-book-requests.controller.ts
+++ b/src/modules/spaces/routes/address-book-requests.controller.ts
@@ -37,7 +37,7 @@ import {
   CreateAddressBookRequestSchema,
 } from '@/modules/spaces/routes/entities/address-book-request.dto.entity';
 import { SpacesAddressBookRequestsRateLimitGuard } from '@/modules/spaces/routes/guards/spaces-address-book-requests-rate-limit.guard';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
 @ApiTags('spaces')
@@ -72,7 +72,7 @@ export class AddressBookRequestsController {
   @UseGuards(AuthGuard)
   public async getPendingRequests(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
   ): Promise<AddressBookRequestsDto> {
     return await this.service.findPending(authPayload, spaceId);
   }
@@ -110,7 +110,7 @@ export class AddressBookRequestsController {
   @UseGuards(AuthGuard, SpacesAddressBookRequestsRateLimitGuard)
   public async createRequest(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Body(new ValidationPipe(CreateAddressBookRequestSchema))
     dto: CreateAddressBookRequestDto,
   ): Promise<AddressBookRequestItemDto> {
@@ -145,7 +145,7 @@ export class AddressBookRequestsController {
   @UseGuards(AuthGuard)
   public async approveRequest(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('requestId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     requestId: number,
   ): Promise<void> {
@@ -180,7 +180,7 @@ export class AddressBookRequestsController {
   @UseGuards(AuthGuard)
   public async rejectRequest(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('requestId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     requestId: number,
   ): Promise<void> {

--- a/src/modules/spaces/routes/address-book-requests.controller.ts
+++ b/src/modules/spaces/routes/address-book-requests.controller.ts
@@ -56,14 +56,14 @@ export class AddressBookRequestsController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
     description: 'Pending requests retrieved successfully',
     type: AddressBookRequestsDto,
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @ApiUnauthorizedResponse({ description: 'Authentication required' })
   @ApiForbiddenResponse({
     description: 'User is not a member of this space',

--- a/src/modules/spaces/routes/address-book-requests.service.ts
+++ b/src/modules/spaces/routes/address-book-requests.service.ts
@@ -175,7 +175,6 @@ export class AddressBookRequestsService {
     ]);
 
     return {
-      spaceId: spaceId.toString(),
       spaceUuid,
       data: requests.map((request) => this.toDto(request, identityMap)),
     };

--- a/src/modules/spaces/routes/address-books.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/address-books.controller.e2e-spec.ts
@@ -90,7 +90,7 @@ describe('AddressBooksController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .expect(200)
         .expect({
-          spaceId: spaceId.toString(),
+          spaceUuid: spaceId,
           data: [],
         });
     });
@@ -107,7 +107,7 @@ describe('AddressBooksController', () => {
         .set('Cookie', [`access_token=${memberAccessToken}`])
         .expect(200)
         .expect({
-          spaceId: spaceId.toString(),
+          spaceUuid: spaceId,
           data: [],
         });
     });
@@ -127,7 +127,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: [
               {
                 chainIds: mockChainIds,
@@ -163,7 +163,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: [
               {
                 chainIds: mockChainIds,
@@ -294,7 +294,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: [
               {
                 chainIds: mockChainIds,
@@ -326,7 +326,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: [
               {
                 chainIds: mockChainIds,
@@ -363,7 +363,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: [
               {
                 chainIds: mockChainIds,
@@ -420,7 +420,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: expect.arrayContaining([
               {
                 ...updatedFirstItem,
@@ -634,7 +634,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId.toString(),
+            spaceUuid: spaceId,
             data: [],
           }),
         );
@@ -667,7 +667,7 @@ describe('AddressBooksController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            spaceId: spaceId2.toString(),
+            spaceUuid: spaceId2,
             data: [
               {
                 address: mockAddress,
@@ -787,7 +787,7 @@ describe('AddressBooksController', () => {
       .set('Cookie', [`access_token=${accessToken}`])
       .send({ name: spaceName })
       .expect(201);
-    const spaceId = createSpaceResponse.body.id;
+    const spaceId = createSpaceResponse.body.uuid;
     return {
       spaceId,
       accessToken,

--- a/src/modules/spaces/routes/address-books.controller.ts
+++ b/src/modules/spaces/routes/address-books.controller.ts
@@ -32,7 +32,7 @@ import {
   UpsertAddressBookItemsSchema,
 } from '@/modules/spaces/routes/entities/upsert-address-book-items.dto.entity';
 import { SpacesAddressBookRateLimitGuard } from '@/modules/spaces/routes/guards/spaces-address-book-rate-limit.guard';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { AddressSchema } from '@/validation/entities/schemas/address.schema';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
@@ -73,7 +73,7 @@ export class AddressBooksController {
   @UseGuards(AuthGuard)
   public async getAddressBookItems(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
   ): Promise<SpaceAddressBookDto> {
     return await this.service.findAllBySpaceId(authPayload, spaceId);
   }
@@ -116,7 +116,7 @@ export class AddressBooksController {
   @UseGuards(AuthGuard)
   public async upsertAddressBookItems(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Body(new ValidationPipe(UpsertAddressBookItemsSchema))
     addressBookItems: UpsertAddressBookItemsDto,
   ): Promise<SpaceAddressBookDto> {
@@ -158,7 +158,7 @@ export class AddressBooksController {
   @UseGuards(AuthGuard)
   public async deleteByAddress(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('address', new ValidationPipe(AddressSchema))
     address: Address,
   ): Promise<void> {

--- a/src/modules/spaces/routes/address-books.controller.ts
+++ b/src/modules/spaces/routes/address-books.controller.ts
@@ -52,14 +52,14 @@ export class AddressBooksController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID to get address book for (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID to get address book for',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
     description: 'Address book items retrieved successfully',
     type: SpaceAddressBookDto,
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @ApiNotFoundResponse({
     description: 'User, member, or space not found',
   })
@@ -147,6 +147,7 @@ export class AddressBooksController {
   @ApiNoContentResponse({
     description: 'Address book entry deleted successfully',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @ApiNotFoundResponse({
     description: 'User, member, space, or address book entry not found',
   })

--- a/src/modules/spaces/routes/address-books.service.spec.ts
+++ b/src/modules/spaces/routes/address-books.service.spec.ts
@@ -75,7 +75,7 @@ describe('AddressBooksService', () => {
 
       const result = await service.findAllBySpaceId(authPayload, spaceId);
 
-      expect(result.spaceId).toBe(spaceId.toString());
+      expect(result.spaceUuid).toEqual(expect.any(String));
       expect(result.data).toHaveLength(1);
       expect(repositoryMock.findAllBySpaceId).toHaveBeenCalledWith({
         authPayload,
@@ -117,7 +117,7 @@ describe('AddressBooksService', () => {
         })),
       });
 
-      expect(result.spaceId).toBe(spaceId.toString());
+      expect(result.spaceUuid).toEqual(expect.any(String));
       expect(result.data).toHaveLength(items.length);
       expect(repositoryMock.upsertMany).toHaveBeenCalled();
     });

--- a/src/modules/spaces/routes/address-books.service.ts
+++ b/src/modules/spaces/routes/address-books.service.ts
@@ -76,7 +76,6 @@ export class AddressBooksService {
   ): Promise<SpaceAddressBookDto> {
     const spaceUuid = await this.spacesRepository.findUuidById(spaceId);
     return {
-      spaceId: spaceId.toString(),
       spaceUuid,
       data: items.map((item) => ({
         name: item.name,

--- a/src/modules/spaces/routes/address-books.service.ts
+++ b/src/modules/spaces/routes/address-books.service.ts
@@ -39,10 +39,7 @@ export class AddressBooksService {
       authPayload,
       spaceId,
     });
-    const identityMap = await this.identityResolver.resolveMany(
-      items.flatMap((item) => [item.createdBy, item.lastUpdatedBy]),
-    );
-    return this.mapAddressBookItems(spaceId, items, identityMap);
+    return this.mapAddressBookItems(spaceId, items);
   }
 
   public async upsertMany(
@@ -55,10 +52,7 @@ export class AddressBooksService {
       spaceId,
       addressBookItems: addressBookItems.items,
     });
-    const identityMap = await this.identityResolver.resolveMany(
-      updated.flatMap((item) => [item.createdBy, item.lastUpdatedBy]),
-    );
-    return this.mapAddressBookItems(spaceId, updated, identityMap);
+    return this.mapAddressBookItems(spaceId, updated);
   }
 
   public async deleteByAddress(args: {
@@ -72,9 +66,13 @@ export class AddressBooksService {
   private async mapAddressBookItems(
     spaceId: Space['id'],
     items: Array<AddressBookDbItem>,
-    identityMap: Map<number, string>,
   ): Promise<SpaceAddressBookDto> {
-    const spaceUuid = await this.spacesRepository.findUuidById(spaceId);
+    const [identityMap, spaceUuid] = await Promise.all([
+      this.identityResolver.resolveMany(
+        items.flatMap((item) => [item.createdBy, item.lastUpdatedBy]),
+      ),
+      this.spacesRepository.findUuidById(spaceId),
+    ]);
     return {
       spaceUuid,
       data: items.map((item) => ({

--- a/src/modules/spaces/routes/entities/address-book-request.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/address-book-request.dto.entity.ts
@@ -59,14 +59,6 @@ export class AddressBookRequestItemDto {
 }
 
 export class AddressBookRequestsDto {
-  @ApiProperty({
-    type: String,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use spaceUuid). Kept for FE fallback',
-  })
-  public spaceId!: string;
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   public spaceUuid!: string;
 

--- a/src/modules/spaces/routes/entities/create-space.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/create-space.dto.entity.ts
@@ -17,14 +17,6 @@ export class CreateSpaceResponse {
   @ApiProperty({ type: String })
   public readonly name!: Space['name'];
 
-  @ApiProperty({
-    type: Number,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use uuid). Kept for FE fallback',
-  })
-  public readonly id!: Space['id'];
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   public readonly uuid!: Space['uuid'];
 }

--- a/src/modules/spaces/routes/entities/get-space.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/get-space.dto.entity.ts
@@ -42,14 +42,6 @@ class SpaceMemberDto {
 }
 
 export class GetSpaceResponse {
-  @ApiProperty({
-    type: Number,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use uuid). Kept for FE fallback',
-  })
-  public id!: Space['id'];
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   public uuid!: Space['uuid'];
 

--- a/src/modules/spaces/routes/entities/invitation.entity.ts
+++ b/src/modules/spaces/routes/entities/invitation.entity.ts
@@ -16,14 +16,6 @@ export class Invitation {
   @ApiProperty({ type: String })
   name!: Member['name'];
 
-  @ApiProperty({
-    type: Number,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use spaceUuid). Kept for FE fallback',
-  })
-  spaceId!: Space['id'];
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   spaceUuid!: Space['uuid'];
 

--- a/src/modules/spaces/routes/entities/space-address-book.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/space-address-book.dto.entity.ts
@@ -47,14 +47,6 @@ export class SpaceAddressBookItemDto {
 }
 
 export class SpaceAddressBookDto {
-  @ApiProperty({
-    type: String,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use spaceUuid). Kept for FE fallback',
-  })
-  public spaceId!: string;
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   public spaceUuid!: string;
 

--- a/src/modules/spaces/routes/entities/update-space.dto.entity.ts
+++ b/src/modules/spaces/routes/entities/update-space.dto.entity.ts
@@ -24,14 +24,6 @@ export class UpdateSpaceDto implements z.infer<typeof UpdateSpaceSchema> {
 }
 
 export class UpdateSpaceResponse {
-  @ApiProperty({
-    type: Number,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use uuid). Kept for FE fallback',
-  })
-  public readonly id!: Space['id'];
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   public readonly uuid!: Space['uuid'];
 }

--- a/src/modules/spaces/routes/members.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/members.controller.e2e-spec.ts
@@ -90,7 +90,7 @@ describe('MembersController', () => {
     spaceName: string,
   ): Promise<{
     accessToken: string;
-    spaceId: number;
+    spaceId: string;
     spaceUuid: string;
     userId: number;
   }> => {
@@ -109,7 +109,7 @@ describe('MembersController', () => {
       .expect(201);
     return {
       accessToken,
-      spaceId: createSpaceResponse.body.id,
+      spaceId: createSpaceResponse.body.uuid,
       spaceUuid: createSpaceResponse.body.uuid,
       userId,
     };
@@ -158,7 +158,6 @@ describe('MembersController', () => {
           expect(body).toEqual([
             {
               userId: expect.any(Number),
-              spaceId,
               spaceUuid,
               name: user1Name,
               role: 'ADMIN',
@@ -167,7 +166,6 @@ describe('MembersController', () => {
             },
             {
               userId: expect.any(Number),
-              spaceId,
               spaceUuid,
               name: user2Name,
               role: 'MEMBER',
@@ -355,7 +353,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${targetSpaceOwnerAccessToken}`])
         .send({ name: nameBuilder() })
         .expect(201);
-      const targetSpaceId = targetSpaceResponse.body.id;
+      const targetSpaceId = targetSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${targetSpaceId}/members/invite`)
@@ -548,7 +546,6 @@ describe('MembersController', () => {
         .expect(({ body }) =>
           expect(body).toEqual({
             userId: inviteeUserId,
-            spaceId,
             spaceUuid,
             name: inviteeName,
             role: 'MEMBER',
@@ -1175,7 +1172,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName })
         .expect(201);
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}/members`)
@@ -1948,7 +1945,7 @@ describe('MembersController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName })
         .expect(201);
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .patch(`/v1/spaces/${spaceId}/members/alias`)

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -49,7 +49,7 @@ import {
   UpdateRoleDtoSchema,
 } from '@/modules/spaces/routes/entities/update-role.dto.entity';
 import { MembersService } from '@/modules/spaces/routes/members.service';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
 @ApiTags('spaces')
@@ -94,7 +94,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async inviteUser(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Body(new ValidationPipe(InviteUsersDtoSchema))
     inviteUsersDto: InviteUsersDto,
   ): Promise<Array<Invitation>> {
@@ -139,7 +139,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async acceptInvite(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Body(new ValidationPipe(AcceptInviteDtoSchema))
     acceptInviteDto: AcceptInviteDto,
   ): Promise<void> {
@@ -178,7 +178,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async declineInvite(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
   ): Promise<void> {
     return await this.membersService.declineInvite({
       authPayload,
@@ -223,7 +223,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async renewInvite(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     userId: number,
   ): Promise<Invitation> {
@@ -262,7 +262,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async getUsers(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
   ): Promise<MembersDto> {
     return await this.membersService.get({
       authPayload,
@@ -296,7 +296,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async getMembership(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
   ): Promise<MemberDto> {
     return await this.membersService.getSelfMembership({
       authPayload,
@@ -345,7 +345,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async updateRole(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     userId: number,
     @Body(new ValidationPipe(UpdateRoleDtoSchema))
@@ -380,7 +380,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async updateAlias(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Body(new ValidationPipe(UpdateMemberAliasDtoSchema))
     updateMemberAliasDto: UpdateMemberAliasDto,
   ): Promise<void> {
@@ -427,7 +427,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async removeUser(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('userId', ParseIntPipe, new ValidationPipe(RowSchema.shape.id))
     userId: number,
   ): Promise<void> {
@@ -461,7 +461,7 @@ export class MembersController {
   @UseGuards(AuthGuard)
   public async selfRemove(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
   ): Promise<void> {
     return await this.membersService.selfRemove({
       authPayload,

--- a/src/modules/spaces/routes/members.controller.ts
+++ b/src/modules/spaces/routes/members.controller.ts
@@ -13,6 +13,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBody,
   ApiConflictResponse,
   ApiForbiddenResponse,
@@ -90,6 +91,7 @@ export class MembersController {
     description:
       'Authentication required or user not admin or member not active',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Post('/:spaceId/members/invite')
   @UseGuards(AuthGuard)
   public async inviteUser(
@@ -135,6 +137,7 @@ export class MembersController {
   @ApiConflictResponse({
     description: 'User invitation is not in pending state or already processed',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Post('/:spaceId/members/accept')
   @UseGuards(AuthGuard)
   public async acceptInvite(
@@ -174,6 +177,7 @@ export class MembersController {
   @ApiConflictResponse({
     description: 'User invitation is not in pending state or already processed',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Post('/:spaceId/members/decline')
   @UseGuards(AuthGuard)
   public async declineInvite(
@@ -196,8 +200,7 @@ export class MembersController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID containing the invitation (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID containing the invitation',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiParam({
@@ -219,6 +222,7 @@ export class MembersController {
   @ApiConflictResponse({
     description: 'Invitation is not in a pending state',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Post('/:spaceId/members/:userId/invite/renew')
   @UseGuards(AuthGuard)
   public async renewInvite(
@@ -243,8 +247,7 @@ export class MembersController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID to get members for (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID to get members for',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
@@ -258,6 +261,7 @@ export class MembersController {
   @ApiNotFoundResponse({
     description: 'User or space not found',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Get('/:spaceId/members')
   @UseGuards(AuthGuard)
   public async getUsers(
@@ -279,8 +283,7 @@ export class MembersController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      "Space UUID to fetch the caller's membership for (numeric ID accepted for legacy clients, deprecated)",
+    description: "Space UUID to fetch the caller's membership for",
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
@@ -292,6 +295,7 @@ export class MembersController {
       'Access forbidden - user not authenticated, or has no ACTIVE/INVITED membership in this space',
   })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Get('/:spaceId/membership')
   @UseGuards(AuthGuard)
   public async getMembership(
@@ -341,6 +345,7 @@ export class MembersController {
   @ApiConflictResponse({
     description: 'Cannot remove the last admin from the space',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Patch('/:spaceId/members/:userId/role')
   @UseGuards(AuthGuard)
   public async updateRole(
@@ -376,6 +381,7 @@ export class MembersController {
     description: 'Space UUID to update own member alias in',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Patch('/:spaceId/members/alias')
   @UseGuards(AuthGuard)
   public async updateAlias(
@@ -423,6 +429,7 @@ export class MembersController {
   @ApiConflictResponse({
     description: 'Cannot remove the last admin from the space',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Delete('/:spaceId/members/:userId')
   @UseGuards(AuthGuard)
   public async removeUser(
@@ -457,6 +464,7 @@ export class MembersController {
     description: 'Space UUID to remove own membership from',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Delete('/:spaceId/members')
   @UseGuards(AuthGuard)
   public async selfRemove(

--- a/src/modules/spaces/routes/members.service.spec.ts
+++ b/src/modules/spaces/routes/members.service.spec.ts
@@ -374,7 +374,6 @@ describe('MembersService', () => {
           service.renewInvite({ authPayload, spaceId, userId }),
         ).resolves.toEqual({
           userId,
-          spaceId,
           spaceUuid,
           name: targetMember.name,
           role: targetMember.role,

--- a/src/modules/spaces/routes/members.service.ts
+++ b/src/modules/spaces/routes/members.service.ts
@@ -109,7 +109,6 @@ export class MembersService {
 
     return {
       userId: args.userId,
-      spaceId: args.spaceId,
       spaceUuid: space.uuid,
       name,
       role,

--- a/src/modules/spaces/routes/pipes/space-id.pipe.spec.ts
+++ b/src/modules/spaces/routes/pipes/space-id.pipe.spec.ts
@@ -2,17 +2,14 @@
 
 import { faker } from '@faker-js/faker';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { DB_MAX_SAFE_INTEGER } from '@/domain/common/constants';
 import type { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 import {
   INVALID_SPACE_IDENTIFIER_MESSAGE,
-  LegacySpaceIdPipe,
   SpaceIdPipe,
 } from '@/modules/spaces/routes/pipes/space-id.pipe';
 
 const spacesRepositoryMock = {
   findIdByUuid: jest.fn(),
-  findIdByIdOrUuid: jest.fn(),
 } as jest.MockedObjectDeep<ISpacesRepository>;
 
 describe('SpaceIdPipe', () => {
@@ -71,100 +68,5 @@ describe('SpaceIdPipe', () => {
     await expect(pipe.transform(uuid)).rejects.toThrow(
       new NotFoundException('Workspace not found.'),
     );
-  });
-});
-
-describe('LegacySpaceIdPipe', () => {
-  let pipe: LegacySpaceIdPipe;
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-    pipe = new LegacySpaceIdPipe(spacesRepositoryMock);
-  });
-
-  it('should resolve a UUID to its numeric id', async () => {
-    const uuid = faker.string.uuid();
-    const id = faker.number.int({ min: 1 });
-    spacesRepositoryMock.findIdByIdOrUuid.mockResolvedValue(id);
-
-    await expect(pipe.transform(uuid)).resolves.toBe(id);
-    expect(spacesRepositoryMock.findIdByIdOrUuid).toHaveBeenCalledWith(uuid);
-  });
-
-  it('should resolve an uppercase UUID (case-insensitive)', async () => {
-    const uuid = faker.string.uuid().toUpperCase();
-    const id = faker.number.int({ min: 1 });
-    spacesRepositoryMock.findIdByIdOrUuid.mockResolvedValue(id);
-
-    await expect(pipe.transform(uuid)).resolves.toBe(id);
-    expect(spacesRepositoryMock.findIdByIdOrUuid).toHaveBeenCalledWith(uuid);
-  });
-
-  it('should resolve a numeric id', async () => {
-    const id = faker.number.int({ min: 1, max: 2 ** 31 - 2 });
-    spacesRepositoryMock.findIdByIdOrUuid.mockResolvedValue(id);
-
-    await expect(pipe.transform(String(id))).resolves.toBe(id);
-    expect(spacesRepositoryMock.findIdByIdOrUuid).toHaveBeenCalledWith(
-      String(id),
-    );
-  });
-
-  it('should resolve a numeric id equal to DB_MAX_SAFE_INTEGER (inclusive boundary)', async () => {
-    const id = DB_MAX_SAFE_INTEGER;
-    spacesRepositoryMock.findIdByIdOrUuid.mockResolvedValue(id);
-
-    await expect(pipe.transform(String(id))).resolves.toBe(id);
-    expect(spacesRepositoryMock.findIdByIdOrUuid).toHaveBeenCalledWith(
-      String(id),
-    );
-  });
-
-  it('should reject a non-numeric, non-UUID value with the shared message', async () => {
-    await expect(pipe.transform(faker.string.alpha())).rejects.toThrow(
-      new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE),
-    );
-    expect(spacesRepositoryMock.findIdByIdOrUuid).not.toHaveBeenCalled();
-  });
-
-  it('should reject an empty string with the shared message', async () => {
-    await expect(pipe.transform('')).rejects.toThrow(
-      new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE),
-    );
-    expect(spacesRepositoryMock.findIdByIdOrUuid).not.toHaveBeenCalled();
-  });
-
-  it('should reject a numeric id beyond the DB max with the shared message', async () => {
-    await expect(
-      pipe.transform(String(DB_MAX_SAFE_INTEGER + 1)),
-    ).rejects.toThrow(
-      new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE),
-    );
-    expect(spacesRepositoryMock.findIdByIdOrUuid).not.toHaveBeenCalled();
-  });
-
-  it('should propagate NotFoundException for a valid UUID with no row', async () => {
-    const uuid = faker.string.uuid();
-    spacesRepositoryMock.findIdByIdOrUuid.mockRejectedValue(
-      new NotFoundException('Workspace not found.'),
-    );
-
-    await expect(pipe.transform(uuid)).rejects.toThrow(
-      new NotFoundException('Workspace not found.'),
-    );
-  });
-
-  it('should propagate NotFoundException for a valid numeric id with no row', async () => {
-    spacesRepositoryMock.findIdByIdOrUuid.mockRejectedValue(
-      new NotFoundException('Workspace not found.'),
-    );
-
-    await expect(
-      pipe.transform(String(faker.number.int({ min: 1, max: 2 ** 31 - 2 }))),
-    ).rejects.toThrow(new NotFoundException('Workspace not found.'));
-  });
-
-  it('should use the same rejection message as SpaceIdPipe', () => {
-    expect(INVALID_SPACE_IDENTIFIER_MESSAGE).toBe('Invalid space identifier');
   });
 });

--- a/src/modules/spaces/routes/pipes/space-id.pipe.spec.ts
+++ b/src/modules/spaces/routes/pipes/space-id.pipe.spec.ts
@@ -69,4 +69,28 @@ describe('SpaceIdPipe', () => {
       new NotFoundException('Workspace not found.'),
     );
   });
+
+  it.each([
+    ['missing a hyphen', '123e4567e89b-12d3-a456-426614174000'],
+    ['too short', '123e4567-e89b-12d3-a456-42661417400'],
+    ['too long', '123e4567-e89b-12d3-a456-4266141740000'],
+    ['a non-hex character', '123e4567-e89b-12d3-a456-42661417400g'],
+    ['surrounding whitespace', ' 123e4567-e89b-12d3-a456-426614174000 '],
+  ])('should reject a malformed UUID (%s)', async (_label, value) => {
+    await expect(pipe.transform(value)).rejects.toThrow(
+      new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE),
+    );
+    expect(spacesRepositoryMock.findIdByUuid).not.toHaveBeenCalled();
+  });
+
+  it('should treat the nil UUID as structurally valid and delegate to the repository', async () => {
+    // UUID_REGEX validates shape only, so the nil UUID passes the pipe and the
+    // repository decides whether such a row exists.
+    const nilUuid = '00000000-0000-0000-0000-000000000000';
+    const id = faker.number.int({ min: 1 });
+    spacesRepositoryMock.findIdByUuid.mockResolvedValue(id);
+
+    await expect(pipe.transform(nilUuid)).resolves.toBe(id);
+    expect(spacesRepositoryMock.findIdByUuid).toHaveBeenCalledWith(nilUuid);
+  });
 });

--- a/src/modules/spaces/routes/pipes/space-id.pipe.ts
+++ b/src/modules/spaces/routes/pipes/space-id.pipe.ts
@@ -6,17 +6,14 @@ import {
   Injectable,
   type PipeTransform,
 } from '@nestjs/common';
-import { DB_MAX_SAFE_INTEGER, UUID_REGEX } from '@/domain/common/constants';
+import { UUID_REGEX } from '@/domain/common/constants';
 import type { Space } from '@/modules/spaces/domain/entities/space.entity';
 import { ISpacesRepository } from '@/modules/spaces/domain/spaces.repository.interface';
 
 /**
- * Shared 400 message for malformed Space identifiers. Both pipes use it so
- * clients see a single, stable error body regardless of which one validates.
+ * Shared 400 message for malformed Space identifiers.
  */
 export const INVALID_SPACE_IDENTIFIER_MESSAGE = 'Invalid space identifier';
-
-const NUMERIC_REGEX = /^\d+$/;
 
 /**
  * Resolves a route param holding a Space UUID into the numeric primary key.
@@ -36,34 +33,5 @@ export class SpaceIdPipe
       throw new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE);
     }
     return await this.spacesRepository.findIdByUuid(value as UUID);
-  }
-}
-
-/**
- * Like SpaceIdPipe but also accepts a legacy numeric Space id for the FE
- * fallback window. Rejects malformed input with the same
- * {@link INVALID_SPACE_IDENTIFIER_MESSAGE} as SpaceIdPipe. Remove together with
- * the legacy numeric Space ID fallback.
- */
-@Injectable()
-export class LegacySpaceIdPipe
-  implements PipeTransform<string, Promise<Space['id']>>
-{
-  constructor(
-    @Inject(ISpacesRepository)
-    private readonly spacesRepository: ISpacesRepository,
-  ) {}
-
-  async transform(value: string): Promise<Space['id']> {
-    if (NUMERIC_REGEX.test(value)) {
-      // DB_MAX_SAFE_INTEGER is below Number.MAX_SAFE_INTEGER, so this bound also
-      // rejects any value that would lose integer precision.
-      if (Number(value) > DB_MAX_SAFE_INTEGER) {
-        throw new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE);
-      }
-    } else if (!UUID_REGEX.test(value)) {
-      throw new BadRequestException(INVALID_SPACE_IDENTIFIER_MESSAGE);
-    }
-    return await this.spacesRepository.findIdByIdOrUuid(value);
   }
 }

--- a/src/modules/spaces/routes/space-audit.controller.ts
+++ b/src/modules/spaces/routes/space-audit.controller.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiForbiddenResponse,
   ApiOkResponse,
   ApiOperation,
@@ -45,7 +46,7 @@ export class SpaceAuditController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description: 'Space identifier (UUID, or legacy numeric id)',
+    description: 'Space UUID',
   })
   @ApiQuery({
     name: 'event_type',
@@ -94,6 +95,7 @@ export class SpaceAuditController {
   @ApiUnauthorizedResponse({
     description: 'Authentication required - valid JWT token must be provided',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Get(':spaceId/audit-log')
   public async getAuditLog(
     @Param('spaceId', SpaceIdPipe) spaceId: number,
@@ -142,7 +144,7 @@ export class SpaceAuditController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description: 'Space identifier (UUID, or legacy numeric id)',
+    description: 'Space UUID',
   })
   @ApiOkResponse({
     type: SpaceAuditLogActorDto,
@@ -156,6 +158,7 @@ export class SpaceAuditController {
   @ApiUnauthorizedResponse({
     description: 'Authentication required - valid JWT token must be provided',
   })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @Get(':spaceId/audit-log/actors')
   public async getAuditLogActors(
     @Param('spaceId', SpaceIdPipe) spaceId: number,

--- a/src/modules/spaces/routes/space-audit.controller.ts
+++ b/src/modules/spaces/routes/space-audit.controller.ts
@@ -47,6 +47,7 @@ export class SpaceAuditController {
     name: 'spaceId',
     type: 'string',
     description: 'Space UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiQuery({
     name: 'event_type',
@@ -145,6 +146,7 @@ export class SpaceAuditController {
     name: 'spaceId',
     type: 'string',
     description: 'Space UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
     type: SpaceAuditLogActorDto,

--- a/src/modules/spaces/routes/space-audit.controller.ts
+++ b/src/modules/spaces/routes/space-audit.controller.ts
@@ -22,7 +22,7 @@ import {
   SpaceAuditSortDirectionQuerySchema,
 } from '@/modules/spaces/routes/entities/space-audit-log.dto.entity';
 import { SpaceAuditRouteGuard } from '@/modules/spaces/routes/guards/space-audit-route.guard';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { SpaceAuditService } from '@/modules/spaces/routes/space-audit.service';
 import { PaginationDataDecorator } from '@/routes/common/decorators/pagination.data.decorator';
 import { RouteUrlDecorator } from '@/routes/common/decorators/route.url.decorator';
@@ -96,7 +96,7 @@ export class SpaceAuditController {
   })
   @Get(':spaceId/audit-log')
   public async getAuditLog(
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Auth() authPayload: AuthPayload,
     @RouteUrlDecorator() routeUrl: URL,
     @PaginationDataDecorator() paginationData: PaginationData,
@@ -158,7 +158,7 @@ export class SpaceAuditController {
   })
   @Get(':spaceId/audit-log/actors')
   public async getAuditLogActors(
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<Array<SpaceAuditLogActorDto>> {
     return await this.spaceAuditService.getAuditLogActors({

--- a/src/modules/spaces/routes/space-safes.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/space-safes.controller.e2e-spec.ts
@@ -90,7 +90,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/safes`)
@@ -122,7 +122,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/safes`)
@@ -161,7 +161,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
       const spaceSafe1 = {
         chainId: chain1.chainId,
         address: getAddress(faker.finance.ethereumAddress()),
@@ -216,8 +216,8 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: space2Name });
-      const spaceId = createSpaceResponse.body.id;
-      const space2Id = createSpace2Response.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
+      const space2Id = createSpace2Response.body.uuid;
       const spaceSafe1 = {
         chainId: chain1.chainId,
         address: getAddress(faker.finance.ethereumAddress()),
@@ -267,7 +267,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/safes`)
@@ -306,7 +306,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${activeAdminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -357,7 +357,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -640,7 +640,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/safes`)
@@ -701,7 +701,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       // Create the member user and the wallet
       await request(app.getHttpServer())
@@ -777,7 +777,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}/safes`)
@@ -809,7 +809,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}/safes`)
@@ -908,7 +908,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/safes`)
@@ -954,7 +954,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/safes`)
@@ -1006,7 +1006,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .delete(`/v1/spaces/${spaceId}/safes`)
@@ -1049,7 +1049,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       // Invite the member user
       await request(app.getHttpServer())
@@ -1117,7 +1117,7 @@ describe('SpaceSafesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${activeAdminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)

--- a/src/modules/spaces/routes/space-safes.controller.ts
+++ b/src/modules/spaces/routes/space-safes.controller.ts
@@ -29,7 +29,7 @@ import { CreateSpaceSafesDto } from '@/modules/spaces/routes/entities/create-spa
 import { DeleteSpaceSafesDto } from '@/modules/spaces/routes/entities/delete-space-safe.dto.entity';
 import { GetSpaceSafeResponse } from '@/modules/spaces/routes/entities/get-space-safe.dto.entity';
 import { SpaceSafesSchema } from '@/modules/spaces/routes/entities/space-safe.dto.entity';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { SpaceSafesService } from '@/modules/spaces/routes/space-safes.service';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
@@ -79,7 +79,7 @@ export class SpaceSafesController {
   public async create(
     @Body(new ValidationPipe(SpaceSafesSchema))
     body: CreateSpaceSafesDto,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<void> {
     return await this.spaceSafesService.create({
@@ -117,7 +117,7 @@ export class SpaceSafesController {
   })
   @Get()
   public async get(
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<GetSpaceSafeResponse> {
     return await this.spaceSafesService.get(spaceId, authPayload);
@@ -159,7 +159,7 @@ export class SpaceSafesController {
   public async delete(
     @Body(new ValidationPipe(SpaceSafesSchema))
     body: DeleteSpaceSafesDto,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<void> {
     return await this.spaceSafesService.delete({

--- a/src/modules/spaces/routes/space-safes.controller.ts
+++ b/src/modules/spaces/routes/space-safes.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBody,
   ApiCreatedResponse,
   ApiForbiddenResponse,
@@ -64,6 +65,9 @@ export class SpaceSafesController {
   @ApiCreatedResponse({
     description: 'Safes added to space successfully',
   })
+  @ApiBadRequestResponse({
+    description: 'Invalid space identifier',
+  })
   @ApiUnauthorizedResponse({
     description:
       'Authentication required or user unauthorized to modify this space',
@@ -97,13 +101,15 @@ export class SpaceSafesController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID to get Safes for (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID to get Safes for',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
     description: 'Space Safes retrieved successfully',
     type: GetSpaceSafeResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid space identifier',
   })
   @ApiUnauthorizedResponse({
     description:
@@ -141,6 +147,9 @@ export class SpaceSafesController {
   })
   @ApiNoContentResponse({
     description: 'Safes removed from space successfully',
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid space identifier',
   })
   @ApiUnauthorizedResponse({
     description:

--- a/src/modules/spaces/routes/spaces.controller.e2e-spec.ts
+++ b/src/modules/spaces/routes/spaces.controller.e2e-spec.ts
@@ -108,7 +108,6 @@ describe('SpacesController', () => {
         .expect(201)
         .expect(({ body }) =>
           expect(body).toEqual({
-            id: expect.any(Number),
             uuid: expect.any(String),
             name: spaceName,
           }),
@@ -181,7 +180,6 @@ describe('SpacesController', () => {
         .expect(201)
         .expect(({ body }) =>
           expect(body).toEqual({
-            id: expect.any(Number),
             uuid: expect.any(String),
             name: expect.any(String),
           }),
@@ -266,7 +264,6 @@ describe('SpacesController', () => {
         .expect(({ body }) => {
           expect(body).toEqual([
             {
-              id: expect.any(Number),
               uuid: expect.any(String),
               name: firstSpaceName,
               status: getEnumKey(SpaceStatus, SpaceStatus.ACTIVE),
@@ -293,7 +290,6 @@ describe('SpacesController', () => {
               ],
             },
             {
-              id: expect.any(Number),
               uuid: expect.any(String),
               name: secondSpaceName,
               status: getEnumKey(SpaceStatus, SpaceStatus.ACTIVE),
@@ -381,7 +377,7 @@ describe('SpacesController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName })
         .expect(201);
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}`)
@@ -389,8 +385,7 @@ describe('SpacesController', () => {
         .expect(200)
         .expect(({ body }) => {
           expect(body).toEqual({
-            id: spaceId,
-            uuid: expect.any(String),
+            uuid: spaceId,
             name: spaceName,
             status: getEnumKey(SpaceStatus, SpaceStatus.ACTIVE),
             createdAt: expect.any(String),
@@ -436,7 +431,7 @@ describe('SpacesController', () => {
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName })
         .expect(201);
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -459,7 +454,7 @@ describe('SpacesController', () => {
         .expect(({ body }) => {
           expect(body).toEqual(
             expect.objectContaining({
-              id: spaceId,
+              uuid: spaceId,
               name: spaceName,
               status: getEnumKey(SpaceStatus, SpaceStatus.ACTIVE),
               members: expect.arrayContaining([
@@ -504,7 +499,7 @@ describe('SpacesController', () => {
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName })
         .expect(201);
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -616,7 +611,7 @@ describe('SpacesController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: previousSpaceName });
 
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .patch(`/v1/spaces/${spaceId}`)
@@ -628,7 +623,7 @@ describe('SpacesController', () => {
         .expect(200)
         .expect(({ body }) =>
           expect(body).toEqual({
-            id: spaceId,
+            uuid: spaceId,
           }),
         );
     });
@@ -748,7 +743,7 @@ describe('SpacesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: previousSpaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -799,7 +794,7 @@ describe('SpacesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${activeAdminAccessToken}`])
         .send({ name: previousSpaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -851,7 +846,7 @@ describe('SpacesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: previousSpaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .patch(`/v1/spaces/${spaceId}`)
@@ -886,7 +881,7 @@ describe('SpacesController', () => {
         .set('Cookie', [`access_token=${accessToken}`])
         .send({ name: spaceName });
 
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .delete(`/v1/spaces/${spaceId}`)
@@ -939,7 +934,7 @@ describe('SpacesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -986,7 +981,7 @@ describe('SpacesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${activeAdminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceId}/members/invite`)
@@ -1033,7 +1028,7 @@ describe('SpacesController', () => {
         .post('/v1/spaces')
         .set('Cookie', [`access_token=${adminAccessToken}`])
         .send({ name: spaceName });
-      const spaceId = createSpaceResponse.body.id;
+      const spaceId = createSpaceResponse.body.uuid;
 
       await request(app.getHttpServer())
         .delete(`/v1/spaces/${spaceId}`)

--- a/src/modules/spaces/routes/spaces.controller.ts
+++ b/src/modules/spaces/routes/spaces.controller.ts
@@ -13,6 +13,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBadRequestResponse,
   ApiBody,
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -114,13 +115,15 @@ export class SpacesController {
   @ApiParam({
     name: 'id',
     type: 'string',
-    description:
-      'Space UUID (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiOkResponse({
     description: 'Space information retrieved successfully',
     type: GetSpaceResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid space identifier',
   })
   @ApiNotFoundResponse({
     description: 'Space not found',
@@ -157,6 +160,9 @@ export class SpacesController {
   @ApiOkResponse({
     description: 'Space updated successfully',
     type: UpdateSpaceResponse,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid space identifier',
   })
   @ApiForbiddenResponse({
     description: 'Forbidden resource - user is not an admin of this space',
@@ -197,6 +203,9 @@ export class SpacesController {
   @ApiResponse({
     description: 'Space deleted successfully',
     status: HttpStatus.NO_CONTENT,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid space identifier',
   })
   @ApiForbiddenResponse({
     description: 'Forbidden resource - user is not an admin of this space',

--- a/src/modules/spaces/routes/spaces.controller.ts
+++ b/src/modules/spaces/routes/spaces.controller.ts
@@ -40,7 +40,7 @@ import {
   UpdateSpaceSchema,
 } from '@/modules/spaces/routes/entities/update-space.dto.entity';
 import { SpacesCreationRateLimitGuard } from '@/modules/spaces/routes/guards/spaces-creation-rate-limit.guard';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { SpacesService } from '@/modules/spaces/routes/spaces.service';
 import { ValidationPipe } from '@/validation/pipes/validation.pipe';
 
@@ -133,7 +133,7 @@ export class SpacesController {
   })
   @Get('/:id')
   public async getOne(
-    @Param('id', LegacySpaceIdPipe) id: number,
+    @Param('id', SpaceIdPipe) id: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<GetSpaceResponse> {
     return await this.spacesService.getActiveOrInvitedSpace(id, authPayload);
@@ -173,7 +173,7 @@ export class SpacesController {
   public async update(
     @Body(new ValidationPipe(UpdateSpaceSchema))
     payload: UpdateSpaceDto,
-    @Param('id', LegacySpaceIdPipe) id: number,
+    @Param('id', SpaceIdPipe) id: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<UpdateSpaceResponse> {
     return await this.spacesService.update({
@@ -211,7 +211,7 @@ export class SpacesController {
   @Delete('/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   public async delete(
-    @Param('id', LegacySpaceIdPipe) id: number,
+    @Param('id', SpaceIdPipe) id: number,
     @Auth() authPayload: AuthPayload,
   ): Promise<void> {
     return await this.spacesService.delete({ id, authPayload });

--- a/src/modules/spaces/routes/spaces.controller.ts
+++ b/src/modules/spaces/routes/spaces.controller.ts
@@ -108,7 +108,7 @@ export class SpacesController {
   }
 
   @ApiOperation({
-    summary: 'Get space by ID',
+    summary: 'Get space by UUID',
     description:
       'Retrieves detailed information about a specific space. The user must be a member of or invited to the space.',
   })

--- a/src/modules/spaces/routes/spaces.service.spec.ts
+++ b/src/modules/spaces/routes/spaces.service.spec.ts
@@ -95,7 +95,6 @@ describe('SpacesService', () => {
 
       expect(result).toEqual([
         {
-          id: mockSpace.id,
           uuid: mockSpace.uuid,
           name: space.name,
           members: [member],
@@ -492,7 +491,7 @@ describe('SpacesService', () => {
       const result = await service.getActiveOrInvitedSpaces(authPayload);
 
       // Space A: inviter present → invitedByName populated
-      const spaceAResult = result.find((s) => s.id === spaceA.id)!;
+      const spaceAResult = result.find((s) => s.uuid === spaceA.uuid)!;
       const invitedInA = spaceAResult.members.find(
         (m) => m.status === 'INVITED',
       );
@@ -501,7 +500,7 @@ describe('SpacesService', () => {
       );
 
       // Space B: inviter absent → invitedByName must NOT leak from Space A
-      const spaceBResult = result.find((s) => s.id === spaceB.id)!;
+      const spaceBResult = result.find((s) => s.uuid === spaceB.uuid)!;
       const invitedInB = spaceBResult.members.find(
         (m) => m.status === 'INVITED',
       );
@@ -586,7 +585,6 @@ describe('SpacesService', () => {
         authPayload,
       );
 
-      expect(result.id).toBe(space.id);
       expect(result.uuid).toBe(space.uuid);
     });
 
@@ -682,7 +680,6 @@ describe('SpacesService', () => {
       const userId = Number(authPayload.sub);
       const name = faker.word.noun();
       const repositoryResponse = {
-        id: faker.number.int(),
         uuid: fakeUuid(),
         name,
       };
@@ -696,7 +693,6 @@ describe('SpacesService', () => {
       });
 
       expect(result).toEqual({
-        id: repositoryResponse.id,
         uuid: repositoryResponse.uuid,
         name,
       });
@@ -715,7 +711,6 @@ describe('SpacesService', () => {
       const authPayload = new AuthPayload(builder().build());
       const userId = Number(authPayload.sub);
       const expectedResponse = {
-        id: faker.number.int(),
         uuid: fakeUuid(),
         name: faker.word.noun(),
       };
@@ -780,7 +775,6 @@ describe('SpacesService', () => {
         spaceBuilder().with('id', spaceId).with('uuid', spaceUuid).build(),
       );
       spacesRepositoryMock.update.mockResolvedValue({
-        id: spaceId,
         uuid: spaceUuid,
       });
 
@@ -790,7 +784,7 @@ describe('SpacesService', () => {
         authPayload,
       });
 
-      expect(result).toEqual({ id: spaceId, uuid: spaceUuid });
+      expect(result).toEqual({ uuid: spaceUuid });
     });
 
     it.each([

--- a/src/modules/spaces/routes/spaces.service.ts
+++ b/src/modules/spaces/routes/spaces.service.ts
@@ -113,7 +113,6 @@ export class SpacesService {
         : space.members.filter((member) => member.user.id === userId);
 
       return {
-        id: space.id,
         uuid: space.uuid,
         name: space.name,
         members: visibleMembers.map((member) => ({

--- a/src/modules/spaces/spaces.module.ts
+++ b/src/modules/spaces/spaces.module.ts
@@ -25,10 +25,7 @@ import { AddressBooksController } from '@/modules/spaces/routes/address-books.co
 import { AddressBooksService } from '@/modules/spaces/routes/address-books.service';
 import { MembersController } from '@/modules/spaces/routes/members.controller';
 import { MembersService } from '@/modules/spaces/routes/members.service';
-import {
-  LegacySpaceIdPipe,
-  SpaceIdPipe,
-} from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { SpaceAuditController } from '@/modules/spaces/routes/space-audit.controller';
 import { SpaceAuditService } from '@/modules/spaces/routes/space-audit.service';
 import { SpaceInviteEmailService } from '@/modules/spaces/routes/space-invite-email.service';
@@ -92,10 +89,7 @@ const isSesEmailFeatureEnabled = configuration().features.sesEmail;
       provide: IAddressBookRequestsRepository,
       useClass: AddressBookRequestsRepository,
     },
-    // SpaceIdPipe (UUID-only) is wired but unused for now; controllers switch
-    // to it once the FE drops the numeric Space id. Do not delete as unused.
     SpaceIdPipe,
-    LegacySpaceIdPipe,
   ],
   exports: [
     ISpacesRepository,
@@ -103,7 +97,6 @@ const isSesEmailFeatureEnabled = configuration().features.sesEmail;
     IAddressBookItemsRepository,
     IAddressBookRequestsRepository,
     SpaceIdPipe,
-    LegacySpaceIdPipe,
   ],
 })
 export class SpacesModule {}

--- a/src/modules/surveys/routes/entities/submit-survey-response.dto.entity.ts
+++ b/src/modules/surveys/routes/entities/submit-survey-response.dto.entity.ts
@@ -27,14 +27,6 @@ export class SurveyResponseResultDto {
   @ApiProperty({ type: Number })
   id!: number;
 
-  @ApiProperty({
-    type: Number,
-    deprecated: true,
-    description:
-      'Numeric Space id (deprecated, use spaceUuid). Kept for FE fallback',
-  })
-  spaceId!: Space['id'];
-
   @ApiProperty({ type: String, description: 'Space UUID' })
   spaceUuid!: Space['uuid'];
 

--- a/src/modules/surveys/routes/surveys.controller.integration.spec.ts
+++ b/src/modules/surveys/routes/surveys.controller.integration.spec.ts
@@ -247,19 +247,19 @@ describe('SurveysController', () => {
         .expect(404);
     });
 
-    it('accepts the legacy numeric space id (FE fallback)', async () => {
+    it('rejects a numeric space id with 400', async () => {
       const { accessToken, spaceId } = await seedAdminWithSpace();
 
       await request(app.getHttpServer())
         .get(`/v1/spaces/${spaceId}/surveys/${ONBOARDING_SLUG}/state`)
         .set('Cookie', [`access_token=${accessToken}`])
-        .expect(200);
+        .expect(400);
     });
   });
 
   describe('POST /v1/spaces/:spaceId/surveys/:slug/responses', () => {
     it('admin submits then re-submits, upserting selections and bumping updated_at', async () => {
-      const { accessToken, spaceId, spaceUuid } = await seedAdminWithSpace();
+      const { accessToken, spaceUuid } = await seedAdminWithSpace();
 
       const first = await request(app.getHttpServer())
         .post(`/v1/spaces/${spaceUuid}/surveys/${ONBOARDING_SLUG}/responses`)
@@ -269,7 +269,7 @@ describe('SurveysController', () => {
 
       expect(first.body).toEqual(
         expect.objectContaining({
-          spaceId,
+          spaceUuid,
           surveySlug: ONBOARDING_SLUG,
           surveyVersion: 1,
           selections: { [USE_CASES_PAGE]: ['hold_assets'] },

--- a/src/modules/surveys/routes/surveys.controller.ts
+++ b/src/modules/surveys/routes/surveys.controller.ts
@@ -50,12 +50,12 @@ export class SurveysController {
   @ApiParam({
     name: 'spaceId',
     type: 'string',
-    description:
-      'Space UUID to get survey state for (numeric ID accepted for legacy clients, deprecated)',
+    description: 'Space UUID to get survey state for',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiParam({ name: 'slug', type: 'string', example: 'onboarding' })
   @ApiOkResponse({ type: SurveyStateDto })
+  @ApiBadRequestResponse({ description: 'Invalid space identifier' })
   @ApiUnauthorizedResponse({ description: 'Not authenticated' })
   @ApiForbiddenResponse({
     description: 'User is not an active admin of this space',

--- a/src/modules/surveys/routes/surveys.controller.ts
+++ b/src/modules/surveys/routes/surveys.controller.ts
@@ -23,7 +23,7 @@ import {
 import type { AuthPayload } from '@/modules/auth/domain/entities/auth-payload.entity';
 import { Auth } from '@/modules/auth/routes/decorators/auth.decorator';
 import { AuthGuard } from '@/modules/auth/routes/guards/auth.guard';
-import { LegacySpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
+import { SpaceIdPipe } from '@/modules/spaces/routes/pipes/space-id.pipe';
 import { SurveySlugSchema } from '@/modules/surveys/domain/entities/survey.entity';
 import {
   SubmitSurveyResponseDto,
@@ -65,7 +65,7 @@ export class SurveysController {
   @UseGuards(AuthGuard)
   public async getState(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('slug', new ValidationPipe(SurveySlugSchema)) slug: string,
   ): Promise<SurveyStateDto> {
     return await this.surveysService.getState({
@@ -101,7 +101,7 @@ export class SurveysController {
   @UseGuards(AuthGuard)
   public async submitResponse(
     @Auth() authPayload: AuthPayload,
-    @Param('spaceId', LegacySpaceIdPipe) spaceId: number,
+    @Param('spaceId', SpaceIdPipe) spaceId: number,
     @Param('slug', new ValidationPipe(SurveySlugSchema)) slug: string,
     @Body(new ValidationPipe(SubmitSurveyResponseDtoSchema))
     body: SubmitSurveyResponseDto,

--- a/src/modules/surveys/routes/surveys.service.ts
+++ b/src/modules/surveys/routes/surveys.service.ts
@@ -96,7 +96,6 @@ export class SurveysService {
 
     return {
       id: upserted.id,
-      spaceId: args.spaceId,
       spaceUuid,
       surveySlug: survey.slug,
       surveyVersion: survey.version,


### PR DESCRIPTION
## Summary

Resolves: [WA-2570](https://linear.app/safe-global/issue/WA-2570/cleanup-remove-client-facing-legacy-numeric-spaceid-from-cgw)

Removes the client-facing legacy numeric Space identifier so the Space `uuid` is the **only** identifier exposed over the API. The numeric `id` is retained internally as the DB primary key but no longer appears in any response or is accepted in any request path param.

**Why:** A sequential numeric id in responses/params allows sequential scraping / enumeration of spaces (IDOR-style reconnaissance). A random UUID does not. This is a security hardening. The frontend already uses the UUID `spaceId` everywhere, so this is a clean cut with no deprecation window (existing rows already have UUIDs via the `gen_random_uuid()` default).

## Changes

**Responses — numeric id removed (UUID retained):**
- `GetSpaceResponse`, `CreateSpaceResponse`, `UpdateSpaceResponse` — dropped `id`
- `Invitation`, `SpaceAddressBookDto`, `AddressBookRequestsDto`, `SurveyResponseResultDto` — dropped numeric `spaceId`

**Mappers/services — stopped emitting the numeric id:**
- `SpacesService.findSpaces`, `AddressBooksService`, `AddressBookRequestsService`, `SurveysService`, `MembersService`

**Requests — UUID-only path params:**
- Swapped `LegacySpaceIdPipe` → UUID-only `SpaceIdPipe` across all 8 controllers (Spaces, Members, AddressBooks, AddressBookRequests, SpaceAudit, SpaceSafes, Surveys, SpaceCounterfactualSafes)
- A numeric `:spaceId` now returns `400 Invalid space identifier`

**Cleanup:**
- Deleted `LegacySpaceIdPipe` and its module registration
- Removed `SpacesRepository.findIdByIdOrUuid` (interface + impl)
- Dropped `id` from `create`/`update` repository return shapes
- Kept `findUuidById` (now load-bearing: derives the UUID from the internal numeric id for response mapping)

**Tests:**
- Updated unit, integration, and e2e specs to assert UUID-only responses and pass UUIDs as path params
- Replaced the legacy "accepts numeric space id (FE fallback)" test with one asserting a numeric id is rejected with `400`

## ⚠️ 

`spaces.*` API no longer returns the numeric Space `id` nor accepts it in URLs. Clients must use the Space `uuid`. ⚠️ Legacy bookmarked URLs containing a numeric `spaceId` will now 400 — some changes on the FE are following to enable graceful redirect.

Depending: [PR in the frontend](https://github.com/safe-global/safe-wallet-monorepo/pull/8132) that should be release after this one.
