### PR TITLE
fix: tolerate client/server clock skew when validating SiWe message t…

### DIFF
--- a/.env.sample.json
+++ b/.env.sample.json
@@ -102,6 +102,12 @@
     "required": false
   },
   {
+    "name": "AUTH_CLOCK_SKEW_SECONDS",
+    "description": "Tolerated clock skew in seconds when validating SiWe message time bounds (issuedAt, expirationTime, notBefore)",
+    "defaultValue": 30,
+    "required": false
+  },
+  {
     "name": "AUTH_POST_LOGIN_REDIRECT_URI",
     "description": "Application URL to redirect to after the auth callback succeeds (can be dummy for dev)",
     "defaultValue": "http://localhost:3001/welcome/",

--- a/src/config/entities/__tests__/configuration.ts
+++ b/src/config/entities/__tests__/configuration.ts
@@ -27,6 +27,7 @@ export default (): ReturnType<typeof configuration> => ({
     token: faker.string.hexadecimal({ length: 32 }),
     nonceTtlSeconds: faker.number.int(),
     maxValidityPeriodSeconds: faker.number.int({ min: 1, max: 60 * 1_000 }),
+    clockSkewSeconds: faker.number.int({ min: 1, max: 30 }),
     stateTtlMs: faker.number.int({ min: 60_000, max: 600_000 }),
     postLoginRedirectUri: faker.internet.url(),
     allowedRedirectDomain: undefined,

--- a/src/config/entities/configuration.ts
+++ b/src/config/entities/configuration.ts
@@ -49,6 +49,10 @@ export default () => ({
       process.env.AUTH_VALIDITY_PERIOD_SECONDS ?? `${24 * 60 * 60}`,
       10, // 24 hours
     ),
+    clockSkewSeconds: Number.parseInt(
+      process.env.AUTH_CLOCK_SKEW_SECONDS ?? `${30}`,
+      10, // 30 seconds
+    ),
     stateTtlMs: Number.parseInt(
       process.env.AUTH_STATE_TTL_MILLISECONDS ?? `${5 * 60 * 1_000}`,
       10, // 5 minutes

--- a/src/modules/auth/AUTH.md
+++ b/src/modules/auth/AUTH.md
@@ -232,6 +232,7 @@ Use `assertAuthenticated(payload)` from `utils/assert-authenticated.utils.ts` to
 - Default max lifetime: **24 hours** (`AUTH_VALIDITY_PERIOD_SECONDS`, default `86400`)
 - SiWe messages may include `expirationTime`; gateway enforces whichever is shorter
 - SiWe messages may include `notBefore`; if present, the JWT `nbf` claim is set and the token is not valid before that time
+- SiWe message time bounds (`issuedAt`, `expirationTime`, `notBefore`) are validated with a tolerated clock skew between client and server (`AUTH_CLOCK_SKEW_SECONDS`, default `30`) to avoid rejecting valid messages when clocks are slightly out of sync
 - Auth0 tokens inherit their `exp` from Auth0; the cookie `maxAge` is derived from the JWT `exp` claim
 - Logout redirect checks `auth_method` from the current token (without re-verifying it) to decide whether to route through Auth0's logout endpoint
 
@@ -253,6 +254,7 @@ Post-login redirects are validated against `AUTH_POST_LOGIN_REDIRECT_URI`:
 | -------------------------------- | -------- | -------------------------------------------------- |
 | `AUTH_NONCE_TTL_SECONDS`         | `300`    | How long a SiWe nonce is valid                     |
 | `AUTH_VALIDITY_PERIOD_SECONDS`   | `86400`  | Max token lifetime                                 |
+| `AUTH_CLOCK_SKEW_SECONDS`        | `30`     | Tolerated client/server clock skew for SiWe time bounds |
 | `AUTH_STATE_TTL_MILLISECONDS`    | `300000` | OIDC state cookie TTL                              |
 | `AUTH_POST_LOGIN_REDIRECT_URI`   | —        | Required. Default redirect after login             |
 | `AUTH_ALLOWED_REDIRECT_DOMAIN`   | —        | Optional. Extra allowed redirect domain (non-prod) |

--- a/src/modules/auth/AUTH.md
+++ b/src/modules/auth/AUTH.md
@@ -250,16 +250,16 @@ Post-login redirects are validated against `AUTH_POST_LOGIN_REDIRECT_URI`:
 
 ## Other Auth Config
 
-| Env var                          | Default  | Description                                        |
-| -------------------------------- | -------- | -------------------------------------------------- |
-| `AUTH_NONCE_TTL_SECONDS`         | `300`    | How long a SiWe nonce is valid                     |
-| `AUTH_VALIDITY_PERIOD_SECONDS`   | `86400`  | Max token lifetime                                 |
+| Env var                          | Default  | Description                                             |
+| -------------------------------- | -------- | ------------------------------------------------------- |
+| `AUTH_NONCE_TTL_SECONDS`         | `300`    | How long a SiWe nonce is valid                          |
+| `AUTH_VALIDITY_PERIOD_SECONDS`   | `86400`  | Max token lifetime                                      |
 | `AUTH_CLOCK_SKEW_SECONDS`        | `30`     | Tolerated client/server clock skew for SiWe time bounds |
-| `AUTH_STATE_TTL_MILLISECONDS`    | `300000` | OIDC state cookie TTL                              |
-| `AUTH_POST_LOGIN_REDIRECT_URI`   | —        | Required. Default redirect after login             |
-| `AUTH_ALLOWED_REDIRECT_DOMAIN`   | —        | Optional. Extra allowed redirect domain (non-prod) |
-| `AUTH_RATE_LIMIT_MAX`            | `5`      | OIDC requests per window                           |
-| `AUTH_RATE_LIMIT_WINDOW_SECONDS` | `60`     | Rate limit window                                  |
+| `AUTH_STATE_TTL_MILLISECONDS`    | `300000` | OIDC state cookie TTL                                   |
+| `AUTH_POST_LOGIN_REDIRECT_URI`   | —        | Required. Default redirect after login                  |
+| `AUTH_ALLOWED_REDIRECT_DOMAIN`   | —        | Optional. Extra allowed redirect domain (non-prod)      |
+| `AUTH_RATE_LIMIT_MAX`            | `5`      | OIDC requests per window                                |
+| `AUTH_RATE_LIMIT_WINDOW_SECONDS` | `60`     | Rate limit window                                       |
 
 ---
 

--- a/src/modules/auth/routes/auth.controller.integration.spec.ts
+++ b/src/modules/auth/routes/auth.controller.integration.spec.ts
@@ -404,7 +404,8 @@ describe('AuthController', () => {
       );
       const nonce: string = nonceResponse.body.nonce;
       const cacheDir = new CacheDir(`auth_nonce_${nonce}`, '');
-      const expirationTime = new Date();
+      // Expired beyond the allowed clock-skew tolerance
+      const expirationTime = new Date(Date.now() - 60_000);
       const message = createSiweMessage(
         siweMessageBuilder()
           .with('address', signer.address)

--- a/src/modules/siwe/domain/entities/__tests__/siwe-message.entity.spec.ts
+++ b/src/modules/siwe/domain/entities/__tests__/siwe-message.entity.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: FSL-1.1-MIT
+import { siweMessageBuilder } from '@/modules/siwe/domain/entities/__tests__/siwe-message.builder';
+import { buildSiweMessageSchema } from '@/modules/siwe/domain/entities/siwe-message.entity';
+
+describe('buildSiweMessageSchema', () => {
+  const SKEW_SECONDS = 30;
+  const schema = buildSiweMessageSchema(SKEW_SECONDS);
+
+  function issues(s: typeof schema, message: unknown): Array<string> {
+    const result = s.safeParse(message);
+    return result.success ? [] : result.error.issues.map((i) => i.message);
+  }
+
+  it('validates a well-formed message', () => {
+    const message = siweMessageBuilder().build();
+
+    expect(schema.safeParse(message).success).toBe(true);
+  });
+
+  // The schema tolerates the configured clock skew between the client that
+  // signed the message and this server, so legitimate messages are not rejected
+  // when the two wall clocks are slightly out of sync.
+  describe('clock-skew tolerance on time bounds', () => {
+    it('accepts an issuedAt within the tolerated skew in the future', () => {
+      const message = siweMessageBuilder()
+        .with('issuedAt', new Date(Date.now() + (SKEW_SECONDS - 5) * 1_000))
+        .build();
+
+      expect(issues(schema, message)).not.toContain('Message yet issued');
+    });
+
+    it('rejects an issuedAt beyond the tolerated skew in the future', () => {
+      const message = siweMessageBuilder()
+        .with('issuedAt', new Date(Date.now() + (SKEW_SECONDS + 30) * 1_000))
+        .build();
+
+      expect(issues(schema, message)).toContain('Message yet issued');
+    });
+
+    it('accepts an expirationTime that lapsed within the tolerated skew', () => {
+      const message = siweMessageBuilder()
+        .with(
+          'expirationTime',
+          new Date(Date.now() - (SKEW_SECONDS - 5) * 1_000),
+        )
+        .build();
+
+      expect(issues(schema, message)).not.toContain('Message has expired');
+    });
+
+    it('rejects an expirationTime beyond the tolerated skew in the past', () => {
+      const message = siweMessageBuilder()
+        .with(
+          'expirationTime',
+          new Date(Date.now() - (SKEW_SECONDS + 30) * 1_000),
+        )
+        .build();
+
+      expect(issues(schema, message)).toContain('Message has expired');
+    });
+
+    it('accepts a notBefore within the tolerated skew in the future', () => {
+      const message = siweMessageBuilder()
+        .with('notBefore', new Date(Date.now() + (SKEW_SECONDS - 5) * 1_000))
+        .build();
+
+      expect(issues(schema, message)).not.toContain('Message yet valid');
+    });
+
+    it('rejects a notBefore beyond the tolerated skew in the future', () => {
+      const message = siweMessageBuilder()
+        .with('notBefore', new Date(Date.now() + (SKEW_SECONDS + 30) * 1_000))
+        .build();
+
+      expect(issues(schema, message)).toContain('Message yet valid');
+    });
+
+    it('honors the configured skew value', () => {
+      // 20s in the future: accepted under a 30s skew, rejected under a 5s skew.
+      const message = siweMessageBuilder()
+        .with('issuedAt', new Date(Date.now() + 20_000))
+        .build();
+
+      expect(issues(buildSiweMessageSchema(30), message)).not.toContain(
+        'Message yet issued',
+      );
+      expect(issues(buildSiweMessageSchema(5), message)).toContain(
+        'Message yet issued',
+      );
+    });
+  });
+});

--- a/src/modules/siwe/domain/entities/__tests__/siwe-message.entity.spec.ts
+++ b/src/modules/siwe/domain/entities/__tests__/siwe-message.entity.spec.ts
@@ -26,7 +26,7 @@ describe('buildSiweMessageSchema', () => {
         .with('issuedAt', new Date(Date.now() + (SKEW_SECONDS - 5) * 1_000))
         .build();
 
-      expect(issues(schema, message)).not.toContain('Message yet issued');
+      expect(issues(schema, message)).not.toContain('Message not yet issued');
     });
 
     it('rejects an issuedAt beyond the tolerated skew in the future', () => {
@@ -34,7 +34,7 @@ describe('buildSiweMessageSchema', () => {
         .with('issuedAt', new Date(Date.now() + (SKEW_SECONDS + 30) * 1_000))
         .build();
 
-      expect(issues(schema, message)).toContain('Message yet issued');
+      expect(issues(schema, message)).toContain('Message not yet issued');
     });
 
     it('accepts an expirationTime that lapsed within the tolerated skew', () => {
@@ -64,7 +64,7 @@ describe('buildSiweMessageSchema', () => {
         .with('notBefore', new Date(Date.now() + (SKEW_SECONDS - 5) * 1_000))
         .build();
 
-      expect(issues(schema, message)).not.toContain('Message yet valid');
+      expect(issues(schema, message)).not.toContain('Message not yet valid');
     });
 
     it('rejects a notBefore beyond the tolerated skew in the future', () => {
@@ -72,7 +72,7 @@ describe('buildSiweMessageSchema', () => {
         .with('notBefore', new Date(Date.now() + (SKEW_SECONDS + 30) * 1_000))
         .build();
 
-      expect(issues(schema, message)).toContain('Message yet valid');
+      expect(issues(schema, message)).toContain('Message not yet valid');
     });
 
     it('honors the configured skew value', () => {
@@ -82,10 +82,10 @@ describe('buildSiweMessageSchema', () => {
         .build();
 
       expect(issues(buildSiweMessageSchema(30), message)).not.toContain(
-        'Message yet issued',
+        'Message not yet issued',
       );
       expect(issues(buildSiweMessageSchema(5), message)).toContain(
-        'Message yet issued',
+        'Message not yet issued',
       );
     });
   });

--- a/src/modules/siwe/domain/entities/siwe-message.entity.ts
+++ b/src/modules/siwe/domain/entities/siwe-message.entity.ts
@@ -16,56 +16,72 @@ import { AddressSchema } from '@/validation/entities/schemas/address.schema';
  * messages and strict types.
  *
  * @see https://eips.ethereum.org/EIPS/eip-4361
+ *
+ * @param clockSkewSeconds - Tolerated clock skew, in seconds, between the client
+ * that produced the message and this server when validating its time bounds
+ * (`issuedAt`, `expirationTime`, `notBefore`). Client and server wall clocks are
+ * never perfectly aligned, so without a small allowance a freshly-signed message
+ * whose `issuedAt` is a few seconds ahead of the server clock would be wrongly
+ * rejected as "Message yet issued". This mirrors the leeway used by JWT/OIDC
+ * validators. Replay protection and freshness are independently enforced by the
+ * single-use, TTL-bound nonce, so this tolerance does not weaken those
+ * guarantees.
  */
-export const SiweMessageSchema = z
-  .preprocess(
-    (value) => (typeof value === 'string' ? parseSiweMessage(value) : value),
-    // We only validate primitives as parseSiweMessage ensures compliance,
-    // e.g. scheme, domain and uri should be RFC 3986 compliant.
-    z.object({
-      scheme: z.string().optional(),
-      domain: z.string(),
-      address: AddressSchema,
-      statement: z.string().optional(),
-      uri: z.string(),
-      version: z.literal('1'),
-      chainId: z.coerce.number(),
-      nonce: z.string(),
-      issuedAt: z.coerce.date(),
-      expirationTime: z.coerce.date().optional(),
-      notBefore: z.coerce.date().optional(),
-      requestId: z.string().optional(),
-      resources: z.array(z.string()).optional(),
-    }),
-  )
-  .superRefine((message, ctx) => {
-    /**
-     * According to the spec., we should also compare the scheme, domain and uri
-     * of the message against the request but as our API is often used either
-     * locally or across environments, those checks would fail.
-     */
-    const now = new Date();
+export function buildSiweMessageSchema(clockSkewSeconds?: number) {
+  return z
+    .preprocess(
+      (value) => (typeof value === 'string' ? parseSiweMessage(value) : value),
+      // We only validate primitives as parseSiweMessage ensures compliance,
+      // e.g. scheme, domain and uri should be RFC 3986 compliant.
+      z.object({
+        scheme: z.string().optional(),
+        domain: z.string(),
+        address: AddressSchema,
+        statement: z.string().optional(),
+        uri: z.string(),
+        version: z.literal('1'),
+        chainId: z.coerce.number(),
+        nonce: z.string(),
+        issuedAt: z.coerce.date(),
+        expirationTime: z.coerce.date().optional(),
+        notBefore: z.coerce.date().optional(),
+        requestId: z.string().optional(),
+        resources: z.array(z.string()).optional(),
+      }),
+    )
+    .superRefine((message, ctx) => {
+      /**
+       * According to the spec., we should also compare the scheme, domain and uri
+       * of the message against the request but as our API is often used either
+       * locally or across environments, those checks would fail.
+       */
+      const now = Date.now();
+      const skewMs = clockSkewSeconds ? clockSkewSeconds * 1_000 : 0;
 
-    if (!message.issuedAt || message.issuedAt > now) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Message yet issued',
-      });
-    }
+      if (!message.issuedAt || message.issuedAt.getTime() > now + skewMs) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Message yet issued',
+        });
+      }
 
-    if (message.expirationTime && message.expirationTime <= now) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Message has expired',
-      });
-    }
+      if (
+        message.expirationTime &&
+        message.expirationTime.getTime() <= now - skewMs
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Message has expired',
+        });
+      }
 
-    if (message.notBefore && message.notBefore > now) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'Message yet valid',
-      });
-    }
+      if (message.notBefore && message.notBefore.getTime() > now + skewMs) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Message yet valid',
+        });
+      }
 
-    return z.NEVER;
-  });
+      return z.NEVER;
+    });
+}

--- a/src/modules/siwe/domain/entities/siwe-message.entity.ts
+++ b/src/modules/siwe/domain/entities/siwe-message.entity.ts
@@ -61,7 +61,7 @@ export function buildSiweMessageSchema(clockSkewSeconds?: number) {
       if (!message.issuedAt || message.issuedAt.getTime() > now + skewMs) {
         ctx.addIssue({
           code: 'custom',
-          message: 'Message yet issued',
+          message: 'Message not yet issued',
         });
       }
 
@@ -78,7 +78,7 @@ export function buildSiweMessageSchema(clockSkewSeconds?: number) {
       if (message.notBefore && message.notBefore.getTime() > now + skewMs) {
         ctx.addIssue({
           code: 'custom',
-          message: 'Message yet valid',
+          message: 'Message not yet valid',
         });
       }
 

--- a/src/modules/siwe/domain/siwe.repository.ts
+++ b/src/modules/siwe/domain/siwe.repository.ts
@@ -3,16 +3,25 @@ import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import type { Hex } from 'viem';
 import { verifyMessage } from 'viem';
 import { generateSiweNonce, type SiweMessage } from 'viem/siwe';
+import { IConfigurationService } from '@/config/configuration.service.interface';
 import { ISiweApi } from '@/domain/interfaces/siwe-api.interface';
-import { SiweMessageSchema } from '@/modules/siwe/domain/entities/siwe-message.entity';
+import { buildSiweMessageSchema } from '@/modules/siwe/domain/entities/siwe-message.entity';
 import type { ISiweRepository } from '@/modules/siwe/domain/siwe.repository.interface';
 
 @Injectable()
 export class SiweRepository implements ISiweRepository {
+  private readonly clockSkewSeconds: number;
+
   constructor(
     @Inject(ISiweApi)
     private readonly siweApi: ISiweApi,
-  ) {}
+    @Inject(IConfigurationService)
+    private readonly configurationService: IConfigurationService,
+  ) {
+    this.clockSkewSeconds = this.configurationService.getOrThrow<number>(
+      'auth.clockSkewSeconds',
+    );
+  }
 
   /**
    * Generates a unique nonce and stores it in cache for later verification.
@@ -33,7 +42,8 @@ export class SiweRepository implements ISiweRepository {
     message: string;
     signature: Hex;
   }): Promise<SiweMessage> {
-    const result = SiweMessageSchema.safeParse(args.message);
+    const siweMessageSchema = buildSiweMessageSchema(this.clockSkewSeconds);
+    const result = siweMessageSchema.safeParse(args.message);
     if (!result.success) {
       throw new UnauthorizedException('Invalid message');
     }

--- a/src/modules/siwe/domain/siwe.repository.ts
+++ b/src/modules/siwe/domain/siwe.repository.ts
@@ -10,7 +10,7 @@ import type { ISiweRepository } from '@/modules/siwe/domain/siwe.repository.inte
 
 @Injectable()
 export class SiweRepository implements ISiweRepository {
-  private readonly clockSkewSeconds: number;
+  private readonly siweMessageSchema: ReturnType<typeof buildSiweMessageSchema>;
 
   constructor(
     @Inject(ISiweApi)
@@ -18,9 +18,10 @@ export class SiweRepository implements ISiweRepository {
     @Inject(IConfigurationService)
     private readonly configurationService: IConfigurationService,
   ) {
-    this.clockSkewSeconds = this.configurationService.getOrThrow<number>(
+    const clockSkewSeconds = this.configurationService.getOrThrow<number>(
       'auth.clockSkewSeconds',
     );
+    this.siweMessageSchema = buildSiweMessageSchema(clockSkewSeconds);
   }
 
   /**
@@ -42,8 +43,7 @@ export class SiweRepository implements ISiweRepository {
     message: string;
     signature: Hex;
   }): Promise<SiweMessage> {
-    const siweMessageSchema = buildSiweMessageSchema(this.clockSkewSeconds);
-    const result = siweMessageSchema.safeParse(args.message);
+    const result = this.siweMessageSchema.safeParse(args.message);
     if (!result.success) {
       throw new UnauthorizedException('Invalid message');
     }


### PR DESCRIPTION
## Summary

  SiWe login intermittently failed with `401 "Invalid message"` immediately after signing, then succeeded after waiting ~1 minute. Root cause: the SiWe message time bounds (`issuedAt`, `expirationTime`, `notBefore`) were compared against the server clock with **zero tolerance**. When
  the client clock runs ahead of the server clock (clock skew), a freshly-signed message's `issuedAt` is in the future relative to the server and is rejected as "Message yet issued" until the server clock catches up.

  This adds a configurable clock-skew allowance, applied symmetrically to the three time bounds, mirroring the leeway used by JWT/OIDC validators. Replay protection and freshness remain enforced independently by the single-use, TTL-bound nonce, so the tolerance does not weaken those
  guarantees.

  ## Changes

  - Convert `SiweMessageSchema` into a factory `buildSiweMessageSchema(clockSkewSeconds?)` that applies the skew to the `issuedAt` / `expirationTime` / `notBefore` checks (follows the existing `page.schema.factory.ts` schema-factory pattern).
  - `SiweRepository` reads `auth.clockSkewSeconds` via `IConfigurationService` and passes it into the schema.
  - Add `auth.clockSkewSeconds` config, sourced from `AUTH_CLOCK_SKEW_SECONDS` (default **30s**).
  - Document `AUTH_CLOCK_SKEW_SECONDS` in `.env.sample.json` and `src/modules/auth/AUTH.md`.
  - Add a `buildSiweMessageSchema` unit spec (the schema had none) covering within/beyond-tolerance boundaries for all three bounds and asserting the configured skew is honored.
  - Update the message-expiry integration test to expire beyond the tolerance window.